### PR TITLE
Store and write namespaces

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -105,7 +105,7 @@ impl Channel {
                                     }
 
                                     let key = try!(str::from_utf8(name)).to_string();
-                                    let value = try!(String::from_utf8(attr.1.into_owned()));
+                                    let value = try!(str::from_utf8(attr.1)).to_string();
                                     namespaces.insert(key, value);
                                 }
                             }

--- a/src/extension/dublincore.rs
+++ b/src/extension/dublincore.rs
@@ -10,6 +10,9 @@ use extension::remove_extension_values;
 
 use toxml::{ToXml, XmlWriterExt};
 
+/// The Dublin Core XML namespace.
+pub static NAMESPACE: &'static str = "http://purl.org/dc/elements/1.1/";
+
 /// A Dublin Core element extension.
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct DublinCoreExtension {

--- a/src/extension/itunes.rs
+++ b/src/extension/itunes.rs
@@ -10,6 +10,9 @@ use extension::remove_extension_value;
 
 use toxml::{ToXml, XmlWriterExt};
 
+/// The iTunes XML namespace.
+pub static NAMESPACE: &'static str = "http://www.itunes.com/dtds/podcast-1.0.dtd";
+
 /// An iTunes channel element extension.
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct ITunesChannelExtension {

--- a/tests/data/extension.xml
+++ b/tests/data/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0">
+<rss version="2.0" xmlns:ext="http://example.com/" xmlns:dc="http://purl.org/dc/elements/1.1/">
 	<channel>
 		<item>
 			<ext:creator><![CDATA[Creator Name]]></ext:creator>

--- a/tests/data/verify_write_format.xml
+++ b/tests/data/verify_write_format.xml
@@ -1,4 +1,4 @@
-<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:dc="http://purl.org/dc/elements/1.1/">
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ext="http://example.com/">
 	<channel>
 		<title>Title</title>
 		<link>http://example.com/</link>

--- a/tests/data/verify_write_format.xml
+++ b/tests/data/verify_write_format.xml
@@ -1,4 +1,4 @@
-<rss version="2.0">
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:dc="http://purl.org/dc/elements/1.1/">
 	<channel>
 		<title>Title</title>
 		<link>http://example.com/</link>

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -172,6 +172,10 @@ fn read_textinput() {
 fn read_extension() {
     let input = include_str!("data/extension.xml");
     let channel = input.parse::<Channel>().expect("failed to parse xml");
+    
+    let ns = channel.namespaces.get("ext").expect("failed to find namespace");
+    assert_eq!(ns, "http://example.com/");
+    assert_eq!(channel.namespaces.len(), 1);
 
     let ext = channel.items[0].extensions.get("ext").expect("failed to find extension");
     assert_eq!(get_extension_values(&ext, "creator"),

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -1,6 +1,6 @@
 extern crate rss;
 
-use rss::{Channel, Item};
+use rss::{Channel, Item, extension};
 
 macro_rules! test_write {
     ($channel:ident) => ({
@@ -114,7 +114,12 @@ fn verify_write_format() {
     channel.title = "Title".to_string();
     channel.link = "http://example.com/".to_string();
     channel.description = "Description".to_string();
-    channel.items.push(Item::default());
+    channel.items.push({
+        let mut item = Item::default();
+        item.itunes_ext = Some(extension::itunes::ITunesItemExtension::default());
+        item.dublin_core_ext = Some(extension::dublincore::DublinCoreExtension::default());
+        item
+    });
     
     let output = include_str!("data/verify_write_format.xml").replace("\n", "").replace("\t", "");
 

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -120,6 +120,7 @@ fn verify_write_format() {
         item.dublin_core_ext = Some(extension::dublincore::DublinCoreExtension::default());
         item
     });
+    channel.namespaces.insert("ext".to_string(), "http://example.com/".to_string());
     
     let output = include_str!("data/verify_write_format.xml").replace("\n", "").replace("\t", "");
 


### PR DESCRIPTION
Namespaces are stored in `channel.namespaces` so that custom namespaces can be resolved and written.