### PR TITLE
Upgrade to quick-xml 0.7.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ include = ["src/*", "Cargo.toml", "LICENSE-MIT", "LICENSE-APACHE", "README.md"]
 from_url = ["reqwest"]
 
 [dependencies]
-quick-xml = "0.4"
+quick-xml = "0.6.0"
 chrono = "0.3"
 url = "1.4"
 mime = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rss"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["James Hurst <jh.jameshurst@gmail.com>", "Corey Farwell <coreyf@rwell.org>", "Chris Palmer <pennstate5013@gmail.com>"]
 description = "Library for serializing the RSS web content syndication format"
 repository = "https://github.com/rust-syndication/rss"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ include = ["src/*", "Cargo.toml", "LICENSE-MIT", "LICENSE-APACHE", "README.md"]
 from_url = ["reqwest"]
 
 [dependencies]
-quick-xml = "0.6.0"
+quick-xml = "0.7.3"
 chrono = "0.3"
 url = "1.4"
 mime = "0.2"

--- a/src/category.rs
+++ b/src/category.rs
@@ -88,7 +88,7 @@ impl FromXml for Category {
         for attr in atts.with_checks(false) {
             if let Ok(attr) = attr {
                 if attr.key == b"domain" {
-                    domain = Some(try!(attr.unescape_and_decode_value(&reader)));
+                    domain = Some(attr.unescape_and_decode_value(&reader)?);
                     break;
                 }
             }

--- a/src/category.rs
+++ b/src/category.rs
@@ -109,12 +109,14 @@ impl ToXml for Category {
         let name = b"category";
 
         try!(writer.write_event(Event::Start({
-            let mut element = BytesStart::borrowed(name, name.len());
-            if let Some(ref domain) = self.domain {
-                element.push_attribute((b"domain".as_ref(), domain.as_bytes()));
-            }
-            element
-        })));
+                                                 let mut element = BytesStart::borrowed(name,
+                                                                                        name.len());
+                                                 if let Some(ref domain) = self.domain {
+                                                     element.push_attribute((b"domain".as_ref(),
+                                                                             domain.as_bytes()));
+                                                 }
+                                                 element
+                                             })));
 
         try!(writer.write_event(Event::Text(BytesText::borrowed(self.name.as_bytes()))));
 

--- a/src/category.rs
+++ b/src/category.rs
@@ -7,7 +7,7 @@
 
 
 use error::Error;
-use fromxml::FromXml;
+use fromxml::{FromXml, element_text};
 use quick_xml::errors::Error as XmlError;
 use quick_xml::events::{Event, BytesStart, BytesEnd, BytesText};
 use quick_xml::events::attributes::Attributes;
@@ -80,9 +80,9 @@ impl Category {
 }
 
 impl FromXml for Category {
-    fn from_xml<R: ::std::io::BufRead>(mut reader: Reader<R>,
+    fn from_xml<R: ::std::io::BufRead>(reader: &mut Reader<R>,
                                        mut atts: Attributes)
-                                       -> Result<(Self, Reader<R>), Error> {
+                                       -> Result<Self, Error> {
         let mut domain = None;
 
         for attr in atts.with_checks(false) {
@@ -94,13 +94,12 @@ impl FromXml for Category {
             }
         }
 
-        let content = element_text!(reader).unwrap_or_default();
+        let content = element_text(reader)?.unwrap_or_default();
 
-        Ok((Category {
-                name: content,
-                domain: domain,
-            },
-            reader))
+        Ok(Category {
+               name: content,
+               domain: domain,
+           })
     }
 }
 

--- a/src/category.rs
+++ b/src/category.rs
@@ -107,20 +107,14 @@ impl FromXml for Category {
 impl ToXml for Category {
     fn to_xml<W: ::std::io::Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"category";
-
-        try!(writer.write_event(Event::Start({
-                                                 let mut element = BytesStart::borrowed(name,
-                                                                                        name.len());
-                                                 if let Some(ref domain) = self.domain {
-                                                     element.push_attribute((b"domain".as_ref(),
-                                                                             domain.as_bytes()));
-                                                 }
-                                                 element
-                                             })));
-
-        try!(writer.write_event(Event::Text(BytesText::borrowed(self.name.as_bytes()))));
-
-        try!(writer.write_event(Event::End(BytesEnd::borrowed(name))));
+        let mut element = BytesStart::borrowed(name, name.len());
+        if let Some(ref domain) = self.domain {
+            element.push_attribute(("domain", &**domain));
+        }
+        writer.write_event(Event::Start(element))?;
+        writer
+            .write_event(Event::Text(BytesText::borrowed(self.name.as_bytes())))?;
+        writer.write_event(Event::End(BytesEnd::borrowed(name)))?;
         Ok(())
     }
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -946,7 +946,7 @@ impl Channel {
                             channel.namespaces = namespaces;
                             return Ok(channel);
                         }
-                        name => try!(reader.read_to_end(name, &mut skip_buf)),
+                        name => reader.read_to_end(name, &mut skip_buf)?,
                     }
                 }
                 Ok(Event::End(_)) => in_rss = false,
@@ -1363,8 +1363,7 @@ impl FromXml for Channel {
                                                 channel.skip_hours.push(content);
                                             }
                                         } else {
-                                            try!(reader.read_to_end(element.name(),
-                                                                    &mut Vec::new()));
+                                            reader.read_to_end(element.name(), &mut Vec::new())?;
                                         }
                                     }
                                     Ok(Event::End(_)) => {
@@ -1386,8 +1385,7 @@ impl FromXml for Channel {
                                                 channel.skip_days.push(content);
                                             }
                                         } else {
-                                            try!(reader.read_to_end(element.name(),
-                                                                    &mut Vec::new()));
+                                            reader.read_to_end(element.name(), &mut Vec::new())?;
                                         }
                                     }
                                     Ok(Event::End(_)) => {
@@ -1403,7 +1401,7 @@ impl FromXml for Channel {
                             if let Some((ns, name)) = fromxml::extension_name(element.name()) {
                                 parse_extension!(reader, element, ns, name, channel.extensions);
                             } else {
-                                try!(reader.read_to_end(n, &mut skip_buf));
+                                reader.read_to_end(n, &mut skip_buf)?;
                             }
                         }
                     }
@@ -1534,7 +1532,7 @@ impl ToXml for Channel {
             ext.to_xml(writer)?;
         }
 
-        try!(writer.write_event(Event::End(BytesEnd::borrowed(name))));
+        writer.write_event(Event::End(BytesEnd::borrowed(name)))?;
         Ok(())
     }
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1407,7 +1407,7 @@ impl FromXml for Channel {
                             }
                         }
                         _ => {
-                            if let Some((ns, name)) = fromxml::extension_name(&element) {
+                            if let Some((ns, name)) = fromxml::extension_name(element.name()) {
                                 parse_extension!(reader, element, ns, name, channel.extensions);
                             } else {
                                 skip_element!(reader);

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -8,7 +8,7 @@
 use error::Error;
 use fromxml::FromXml;
 use quick_xml::errors::Error as XmlError;
-use quick_xml::events::{Event, BytesStart, BytesEnd};
+use quick_xml::events::{Event, BytesStart};
 use quick_xml::events::attributes::Attributes;
 use quick_xml::reader::Reader;
 use quick_xml::writer::Writer;
@@ -209,24 +209,16 @@ impl FromXml for Cloud {
 impl ToXml for Cloud {
     fn to_xml<W: ::std::io::Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"cloud";
+        let mut element = BytesStart::borrowed(name, name.len());
 
-        writer
-            .write_event(Event::Start({
-                                          let mut element = BytesStart::borrowed(name, name.len());
+        let attrs = &[(b"domain" as &[u8], self.domain.as_bytes()),
+                      (b"port", self.port.as_bytes()),
+                      (b"path", self.path.as_bytes()),
+                      (b"registerProcedure", self.register_procedure.as_bytes()),
+                      (b"protocol", self.protocol.as_bytes())];
+        element.extend_attributes(attrs.into_iter().map(|v| *v));
 
-                                          let attrs = &[(b"domain" as &[u8],
-                                                         self.domain.as_bytes()),
-                                                        (b"port", self.port.as_bytes()),
-                                                        (b"path", self.path.as_bytes()),
-                                                        (b"registerProcedure",
-                                                         self.register_procedure.as_bytes()),
-                                                        (b"protocol", self.protocol.as_bytes())];
-                                          element.extend_attributes(attrs.into_iter().map(|v| *v));
-
-                                          element
-                                      }))?;
-
-        writer.write_event(Event::End(BytesEnd::borrowed(name)))?;
+        writer.write_event(Event::Empty(element))?;
         Ok(())
     }
 }

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -7,8 +7,11 @@
 
 use error::Error;
 use fromxml::FromXml;
-use quick_xml::{Element, Event, XmlReader, XmlWriter};
-use quick_xml::error::Error as XmlError;
+use quick_xml::errors::Error as XmlError;
+use quick_xml::events::{Event, BytesStart, BytesEnd};
+use quick_xml::events::attributes::Attributes;
+use quick_xml::reader::Reader;
+use quick_xml::writer::Writer;
 use std::str::FromStr;
 use toxml::ToXml;
 use url::Url;
@@ -141,32 +144,32 @@ impl Cloud {
 }
 
 impl FromXml for Cloud {
-    fn from_xml<R: ::std::io::BufRead>(mut reader: XmlReader<R>,
-                                       element: Element)
-                                       -> Result<(Self, XmlReader<R>), Error> {
+    fn from_xml<R: ::std::io::BufRead>(mut reader: Reader<R>, 
+                                       mut atts: Attributes)
+                                       -> Result<(Self, Reader<R>), Error> {
         let mut domain = None;
         let mut port = None;
         let mut path = None;
         let mut register_procedure = None;
         let mut protocol = None;
 
-        for attr in element.attributes().with_checks(false).unescaped() {
-            if let Ok(attr) = attr {
-                match attr.0 {
+        for attr in atts.with_checks(false) {
+            if let Ok(att) = attr {
+                match att.key {
                     b"domain" if domain.is_none() => {
-                        domain = Some(String::from_utf8(attr.1.into_owned())?);
+                        domain = Some(att.unescape_and_decode_value(&reader)?);
                     }
                     b"port" if port.is_none() => {
-                        port = Some(String::from_utf8(attr.1.into_owned())?);
+                        port  = Some(att.unescape_and_decode_value(&reader)?);
                     }
                     b"path" if path.is_none() => {
-                        path = Some(String::from_utf8(attr.1.into_owned())?);
+                        path  = Some(att.unescape_and_decode_value(&reader)?);
                     }
                     b"registerProcedure" if register_procedure.is_none() => {
-                        register_procedure = Some(String::from_utf8(attr.1.into_owned())?);
+                        register_procedure  = Some(att.unescape_and_decode_value(&reader)?);
                     }
                     b"protocol" if protocol.is_none() => {
-                        protocol = Some(String::from_utf8(attr.1.into_owned())?);
+                        protocol  = Some(att.unescape_and_decode_value(&reader)?);
                     }
                     _ => {}
                 }
@@ -194,24 +197,24 @@ impl FromXml for Cloud {
 }
 
 impl ToXml for Cloud {
-    fn to_xml<W: ::std::io::Write>(&self, writer: &mut XmlWriter<W>) -> Result<(), XmlError> {
-        let element = Element::new(b"cloud");
+    fn to_xml<W: ::std::io::Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
+        let name = b"cloud";
 
-        writer
-            .write(Event::Start({
-                                    let mut element = element.clone();
+        writer.write_event(Event::Start({
+            let mut element = BytesStart::borrowed(name, name.len());
 
-                                    let attrs = &[(b"domain" as &[u8], &self.domain),
-                                                  (b"port", &self.port),
-                                                  (b"path", &self.path),
-                                                  (b"registerProcedure", &self.register_procedure),
-                                                  (b"protocol", &self.protocol)];
-                                    element.extend_attributes(attrs.into_iter().map(|v| *v));
+            let attrs = &[(b"domain" as &[u8], self.domain.as_bytes()),
+                          (b"port", self.port.as_bytes()),
+                          (b"path", self.path.as_bytes()),
+                          (b"registerProcedure", self.register_procedure.as_bytes()),
+                          (b"protocol", self.protocol.as_bytes())];
+            element.extend_attributes(attrs.into_iter().map(|v| *v));
 
-                                    element
-                                }))?;
+            element
+        }))?;
 
-        writer.write(Event::End(element))
+        writer.write_event(Event::End(BytesEnd::borrowed(name)))?;
+        Ok(())
     }
 }
 

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -144,7 +144,7 @@ impl Cloud {
 }
 
 impl FromXml for Cloud {
-    fn from_xml<R: ::std::io::BufRead>(mut reader: Reader<R>, 
+    fn from_xml<R: ::std::io::BufRead>(mut reader: Reader<R>,
                                        mut atts: Attributes)
                                        -> Result<(Self, Reader<R>), Error> {
         let mut domain = None;
@@ -160,16 +160,16 @@ impl FromXml for Cloud {
                         domain = Some(att.unescape_and_decode_value(&reader)?);
                     }
                     b"port" if port.is_none() => {
-                        port  = Some(att.unescape_and_decode_value(&reader)?);
+                        port = Some(att.unescape_and_decode_value(&reader)?);
                     }
                     b"path" if path.is_none() => {
-                        path  = Some(att.unescape_and_decode_value(&reader)?);
+                        path = Some(att.unescape_and_decode_value(&reader)?);
                     }
                     b"registerProcedure" if register_procedure.is_none() => {
-                        register_procedure  = Some(att.unescape_and_decode_value(&reader)?);
+                        register_procedure = Some(att.unescape_and_decode_value(&reader)?);
                     }
                     b"protocol" if protocol.is_none() => {
-                        protocol  = Some(att.unescape_and_decode_value(&reader)?);
+                        protocol = Some(att.unescape_and_decode_value(&reader)?);
                     }
                     _ => {}
                 }
@@ -184,7 +184,7 @@ impl FromXml for Cloud {
                 Ok(Event::End(_)) => depth -= 1,
                 Ok(Event::Eof) => break,
                 Err(e) => return Err(e.into()),
-                _ => {},
+                _ => {}
             }
         }
 
@@ -210,18 +210,21 @@ impl ToXml for Cloud {
     fn to_xml<W: ::std::io::Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"cloud";
 
-        writer.write_event(Event::Start({
-            let mut element = BytesStart::borrowed(name, name.len());
+        writer
+            .write_event(Event::Start({
+                                          let mut element = BytesStart::borrowed(name, name.len());
 
-            let attrs = &[(b"domain" as &[u8], self.domain.as_bytes()),
-                          (b"port", self.port.as_bytes()),
-                          (b"path", self.path.as_bytes()),
-                          (b"registerProcedure", self.register_procedure.as_bytes()),
-                          (b"protocol", self.protocol.as_bytes())];
-            element.extend_attributes(attrs.into_iter().map(|v| *v));
+                                          let attrs = &[(b"domain" as &[u8],
+                                                         self.domain.as_bytes()),
+                                                        (b"port", self.port.as_bytes()),
+                                                        (b"path", self.path.as_bytes()),
+                                                        (b"registerProcedure",
+                                                         self.register_procedure.as_bytes()),
+                                                        (b"protocol", self.protocol.as_bytes())];
+                                          element.extend_attributes(attrs.into_iter().map(|v| *v));
 
-            element
-        }))?;
+                                          element
+                                      }))?;
 
         writer.write_event(Event::End(BytesEnd::borrowed(name)))?;
         Ok(())

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -176,7 +176,17 @@ impl FromXml for Cloud {
             }
         }
 
-        skip_element!(reader);
+        let mut depth = 1;
+        let mut buf = Vec::new();
+        while depth > 0 {
+            match reader.read_event(&mut buf) {
+                Ok(Event::Start(_)) => depth += 1,
+                Ok(Event::End(_)) => depth -= 1,
+                Ok(Event::Eof) => break,
+                Err(e) => return Err(e.into()),
+                _ => {},
+            }
+        }
 
         let domain = domain.unwrap_or_default();
         let port = port.unwrap_or_default();

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -144,9 +144,9 @@ impl Cloud {
 }
 
 impl FromXml for Cloud {
-    fn from_xml<R: ::std::io::BufRead>(mut reader: Reader<R>,
+    fn from_xml<R: ::std::io::BufRead>(reader: &mut Reader<R>,
                                        mut atts: Attributes)
-                                       -> Result<(Self, Reader<R>), Error> {
+                                       -> Result<Self, Error> {
         let mut domain = None;
         let mut port = None;
         let mut path = None;
@@ -194,14 +194,13 @@ impl FromXml for Cloud {
         let register_procedure = register_procedure.unwrap_or_default();
         let protocol = protocol.unwrap_or_default();
 
-        Ok((Cloud {
-                domain: domain,
-                port: port,
-                path: path,
-                register_procedure: register_procedure,
-                protocol: protocol,
-            },
-            reader))
+        Ok(Cloud {
+               domain: domain,
+               port: port,
+               path: path,
+               register_procedure: register_procedure,
+               protocol: protocol,
+           })
 
     }
 }

--- a/src/enclosure.rs
+++ b/src/enclosure.rs
@@ -127,7 +127,17 @@ impl FromXml for Enclosure {
             }
         }
 
-        skip_element!(reader);
+        let mut depth = 1;
+        let mut buf = Vec::new();
+        while depth > 0 {
+            match reader.read_event(&mut buf) {
+                Ok(Event::Start(_)) => depth += 1,
+                Ok(Event::End(_)) => depth -= 1,
+                Ok(Event::Eof) => break,
+                Err(e) => return Err(e.into()),
+                _ => {},
+            }
+        }
 
         let url = url.unwrap_or_default();
         let length = length.unwrap_or_default();

--- a/src/enclosure.rs
+++ b/src/enclosure.rs
@@ -9,7 +9,7 @@ use error::Error;
 use fromxml::FromXml;
 use mime::Mime;
 use quick_xml::errors::Error as XmlError;
-use quick_xml::events::{Event, BytesStart, BytesEnd};
+use quick_xml::events::{Event, BytesStart};
 use quick_xml::events::attributes::Attributes;
 use quick_xml::reader::Reader;
 use quick_xml::writer::Writer;
@@ -156,19 +156,14 @@ impl ToXml for Enclosure {
     fn to_xml<W: ::std::io::Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"enclosure";
 
-        writer
-            .write_event(Event::Start({
-                                          let mut element = BytesStart::borrowed(name, name.len());
+        let mut element = BytesStart::borrowed(name, name.len());
 
-                                          let attrs = &[(b"url" as &[u8], self.url.as_bytes()),
-                                                        (b"length", self.length.as_bytes()),
-                                                        (b"type", self.mime_type.as_bytes())];
-                                          element.extend_attributes(attrs.into_iter().map(|v| *v));
+        let attrs = &[(b"url" as &[u8], self.url.as_bytes()),
+                      (b"length", self.length.as_bytes()),
+                      (b"type", self.mime_type.as_bytes())];
+        element.extend_attributes(attrs.into_iter().map(|v| *v));
 
-                                          element
-                                      }))?;
-
-        writer.write_event(Event::End(BytesEnd::borrowed(name)))?;
+        writer.write_event(Event::Empty(element))?;
         Ok(())
     }
 }

--- a/src/enclosure.rs
+++ b/src/enclosure.rs
@@ -117,10 +117,10 @@ impl FromXml for Enclosure {
                         url = Some(attr.unescape_and_decode_value(&reader)?);
                     }
                     b"length" if length.is_none() => {
-                        length  = Some(attr.unescape_and_decode_value(&reader)?);
+                        length = Some(attr.unescape_and_decode_value(&reader)?);
                     }
                     b"type" if mime_type.is_none() => {
-                        mime_type  = Some(attr.unescape_and_decode_value(&reader)?);
+                        mime_type = Some(attr.unescape_and_decode_value(&reader)?);
                     }
                     _ => {}
                 }
@@ -135,7 +135,7 @@ impl FromXml for Enclosure {
                 Ok(Event::End(_)) => depth -= 1,
                 Ok(Event::Eof) => break,
                 Err(e) => return Err(e.into()),
-                _ => {},
+                _ => {}
             }
         }
 
@@ -156,16 +156,17 @@ impl ToXml for Enclosure {
     fn to_xml<W: ::std::io::Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"enclosure";
 
-        writer.write_event(Event::Start({
-            let mut element = BytesStart::borrowed(name, name.len());
+        writer
+            .write_event(Event::Start({
+                                          let mut element = BytesStart::borrowed(name, name.len());
 
-            let attrs = &[(b"url" as &[u8], self.url.as_bytes()),
-                          (b"length", self.length.as_bytes()),
-                          (b"type", self.mime_type.as_bytes())];
-            element.extend_attributes(attrs.into_iter().map(|v| *v));
+                                          let attrs = &[(b"url" as &[u8], self.url.as_bytes()),
+                                                        (b"length", self.length.as_bytes()),
+                                                        (b"type", self.mime_type.as_bytes())];
+                                          element.extend_attributes(attrs.into_iter().map(|v| *v));
 
-            element
-        }))?;
+                                          element
+                                      }))?;
 
         writer.write_event(Event::End(BytesEnd::borrowed(name)))?;
         Ok(())

--- a/src/enclosure.rs
+++ b/src/enclosure.rs
@@ -103,9 +103,9 @@ impl Enclosure {
 }
 
 impl FromXml for Enclosure {
-    fn from_xml<R: ::std::io::BufRead>(mut reader: Reader<R>,
+    fn from_xml<R: ::std::io::BufRead>(reader: &mut Reader<R>,
                                        mut atts: Attributes)
-                                       -> Result<(Self, Reader<R>), Error> {
+                                       -> Result<Self, Error> {
         let mut url = None;
         let mut length = None;
         let mut mime_type = None;
@@ -143,12 +143,11 @@ impl FromXml for Enclosure {
         let length = length.unwrap_or_default();
         let mime_type = mime_type.unwrap_or_default();
 
-        Ok((Enclosure {
-                url: url,
-                length: length,
-                mime_type: mime_type,
-            },
-            reader))
+        Ok(Enclosure {
+               url: url,
+               length: length,
+               mime_type: mime_type,
+           })
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@
 // it under the terms of the MIT License and/or Apache 2.0 License.
 
 use chrono::ParseError as DateParseError;
-use quick_xml::error::Error as XmlError;
+use quick_xml::errors::Error as XmlError;
 use std::error::Error as StdError;
 use std::fmt;
 use std::io::Error as IOError;

--- a/src/extension/dublincore.rs
+++ b/src/extension/dublincore.rs
@@ -154,15 +154,19 @@ impl DublinCoreExtension {
 
 impl ToXml for DublinCoreExtension {
     fn to_xml<W: ::std::io::Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
-        writer.write_text_elements(b"dc:contributor", &self.contributors)?;
+        writer
+            .write_text_elements(b"dc:contributor", &self.contributors)?;
         writer.write_text_elements(b"dc:coverage", &self.coverages)?;
         writer.write_text_elements(b"dc:creator", &self.creators)?;
         writer.write_text_elements(b"dc:date", &self.dates)?;
-        writer.write_text_elements(b"dc:description", &self.descriptions)?;
+        writer
+            .write_text_elements(b"dc:description", &self.descriptions)?;
         writer.write_text_elements(b"dc:format", &self.formats)?;
-        writer.write_text_elements(b"dc:identifier", &self.identifiers)?;
+        writer
+            .write_text_elements(b"dc:identifier", &self.identifiers)?;
         writer.write_text_elements(b"dc:language", &self.languages)?;
-        writer.write_text_elements(b"dc:publisher", &self.publishers)?;
+        writer
+            .write_text_elements(b"dc:publisher", &self.publishers)?;
         writer.write_text_elements(b"dc:relation", &self.relations)?;
         writer.write_text_elements(b"dc:rights", &self.rights)?;
         writer.write_text_elements(b"dc:source", &self.sources)?;

--- a/src/extension/dublincore.rs
+++ b/src/extension/dublincore.rs
@@ -8,10 +8,10 @@
 use error::Error;
 use extension::Extension;
 use extension::remove_extension_values;
-use quick_xml::XmlWriter;
-use quick_xml::error::Error as XmlError;
+use quick_xml::Writer;
+use quick_xml::errors::Error as XmlError;
 use std::collections::HashMap;
-use toxml::{ToXml, XmlWriterExt};
+use toxml::{ToXml, WriterExt};
 
 /// The Dublin Core XML namespace.
 pub static NAMESPACE: &'static str = "http://purl.org/dc/elements/1.1/";
@@ -153,20 +153,16 @@ impl DublinCoreExtension {
 }
 
 impl ToXml for DublinCoreExtension {
-    fn to_xml<W: ::std::io::Write>(&self, writer: &mut XmlWriter<W>) -> Result<(), XmlError> {
-        writer
-            .write_text_elements(b"dc:contributor", &self.contributors)?;
+    fn to_xml<W: ::std::io::Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
+        writer.write_text_elements(b"dc:contributor", &self.contributors)?;
         writer.write_text_elements(b"dc:coverage", &self.coverages)?;
         writer.write_text_elements(b"dc:creator", &self.creators)?;
         writer.write_text_elements(b"dc:date", &self.dates)?;
-        writer
-            .write_text_elements(b"dc:description", &self.descriptions)?;
+        writer.write_text_elements(b"dc:description", &self.descriptions)?;
         writer.write_text_elements(b"dc:format", &self.formats)?;
-        writer
-            .write_text_elements(b"dc:identifier", &self.identifiers)?;
+        writer.write_text_elements(b"dc:identifier", &self.identifiers)?;
         writer.write_text_elements(b"dc:language", &self.languages)?;
-        writer
-            .write_text_elements(b"dc:publisher", &self.publishers)?;
+        writer.write_text_elements(b"dc:publisher", &self.publishers)?;
         writer.write_text_elements(b"dc:relation", &self.relations)?;
         writer.write_text_elements(b"dc:rights", &self.rights)?;
         writer.write_text_elements(b"dc:source", &self.sources)?;
@@ -256,7 +252,7 @@ impl DublinCoreExtensionBuilder {
         self
     }
 
-    /// Set the formats that exists under `DublinCoreExtension`.
+    /// Get the formats that exists under `DublinCoreExtension`.
     pub fn formats(mut self, formats: Vec<String>) -> DublinCoreExtensionBuilder {
         self.formats = formats;
         self

--- a/src/extension/itunes/itunes_channel_extension.rs
+++ b/src/extension/itunes/itunes_channel_extension.rs
@@ -12,7 +12,7 @@ use extension::itunes::ITunesCategory;
 use extension::itunes::ITunesOwner;
 use extension::remove_extension_value;
 use quick_xml::errors::Error as XmlError;
-use quick_xml::events::{Event, BytesStart, BytesEnd};
+use quick_xml::events::{Event, BytesStart};
 use quick_xml::writer::Writer;
 use std::collections::HashMap;
 use toxml::{ToXml, WriterExt};
@@ -502,8 +502,7 @@ impl ToXml for ITunesChannelExtension {
             let name = b"itunes:image";
             let mut element = BytesStart::borrowed(name, name.len());
             element.push_attribute(("href", &**image));
-            writer.write_event(Event::Start(element))?;
-            writer.write_event(Event::End(BytesEnd::borrowed(name)))?;
+            writer.write_event(Event::Empty(element))?;
         }
 
         if let Some(explicit) = self.explicit.as_ref() {

--- a/src/extension/itunes/itunes_item_extension.rs
+++ b/src/extension/itunes/itunes_item_extension.rs
@@ -9,10 +9,11 @@ use super::parse_image;
 use error::Error;
 use extension::Extension;
 use extension::remove_extension_value;
-use quick_xml::{Element, Event, XmlWriter};
-use quick_xml::error::Error as XmlError;
+use quick_xml::errors::Error as XmlError;
+use quick_xml::events::{Event, BytesStart, BytesEnd};
+use quick_xml::writer::Writer;
 use std::collections::HashMap;
-use toxml::{ToXml, XmlWriterExt};
+use toxml::{ToXml, WriterExt};
 
 /// An iTunes item element extension.
 #[derive(Debug, Default, Clone, PartialEq)]
@@ -398,7 +399,7 @@ impl ITunesItemExtension {
 }
 
 impl ToXml for ITunesItemExtension {
-    fn to_xml<W: ::std::io::Write>(&self, writer: &mut XmlWriter<W>) -> Result<(), XmlError> {
+    fn to_xml<W: ::std::io::Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         if let Some(author) = self.author.as_ref() {
             writer.write_text_element(b"itunes:author", author)?;
         }
@@ -408,15 +409,11 @@ impl ToXml for ITunesItemExtension {
         }
 
         if let Some(image) = self.image.as_ref() {
-            let element = Element::new(b"itunes:image");
-            writer
-                .write(Event::Start({
-                                        let mut element = element.clone();
-                                        element.extend_attributes(::std::iter::once((b"href",
-                                                                                     image)));
-                                        element
-                                    }))?;
-            writer.write(Event::End(element))?;
+            let name = b"itunes:image";
+            let mut element = BytesStart::borrowed(name, name.len());
+            element.push_attribute(("href", &**image));
+            writer.write_event(Event::Start(element))?;
+            writer.write_event(Event::End(BytesEnd::borrowed(name)))?;
         }
 
         if let Some(duration) = self.duration.as_ref() {

--- a/src/extension/itunes/itunes_owner.rs
+++ b/src/extension/itunes/itunes_owner.rs
@@ -91,7 +91,8 @@ impl ToXml for ITunesOwner {
     fn to_xml<W: ::std::io::Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"itunes:owner";
 
-        writer.write_event(Event::Start(BytesStart::borrowed(name, name.len())))?;
+        writer
+            .write_event(Event::Start(BytesStart::borrowed(name, name.len())))?;
 
         if let Some(name) = self.name.as_ref() {
             writer.write_text_element(b"name", name)?;

--- a/src/extension/itunes/itunes_owner.rs
+++ b/src/extension/itunes/itunes_owner.rs
@@ -6,9 +6,10 @@
 // it under the terms of the MIT License and/or Apache 2.0 License.
 
 use error::Error;
-use quick_xml::{Element, Event, XmlWriter};
-use quick_xml::error::Error as XmlError;
-use toxml::{ToXml, XmlWriterExt};
+use quick_xml::errors::Error as XmlError;
+use quick_xml::events::{Event, BytesStart, BytesEnd};
+use quick_xml::writer::Writer;
+use toxml::{ToXml, WriterExt};
 
 /// The contact information for the owner of an iTunes podcast.
 #[derive(Debug, Default, Clone, PartialEq)]
@@ -87,10 +88,10 @@ impl ITunesOwner {
 }
 
 impl ToXml for ITunesOwner {
-    fn to_xml<W: ::std::io::Write>(&self, writer: &mut XmlWriter<W>) -> Result<(), XmlError> {
-        let element = Element::new(b"itunes:owner");
+    fn to_xml<W: ::std::io::Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
+        let name = b"itunes:owner";
 
-        writer.write(Event::Start(element.clone()))?;
+        writer.write_event(Event::Start(BytesStart::borrowed(name, name.len())))?;
 
         if let Some(name) = self.name.as_ref() {
             writer.write_text_element(b"name", name)?;
@@ -100,7 +101,8 @@ impl ToXml for ITunesOwner {
             writer.write_text_element(b"email", email)?;
         }
 
-        writer.write(Event::End(element))
+        writer.write_event(Event::End(BytesEnd::borrowed(name)))?;
+        Ok(())
     }
 }
 

--- a/src/extension/mod.rs
+++ b/src/extension/mod.rs
@@ -63,15 +63,22 @@ impl Extension {
 impl ToXml for Extension {
     fn to_xml<W: ::std::io::Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
 
-        writer.write_event(Event::Start({
-            let name_len = self.name.len();
-            let mut element = BytesStart::borrowed(self.name.as_bytes(), name_len);
-            element.extend_attributes(self.attrs.iter().map(|a| (a.0.as_bytes(), a.1.as_ref())));
-            element
-        }))?;
+        writer
+            .write_event(Event::Start({
+                                          let name_len = self.name.len();
+                                          let mut element =
+                                              BytesStart::borrowed(self.name.as_bytes(), name_len);
+                                          element.extend_attributes(self.attrs
+                                                                        .iter()
+                                                                        .map(|a| {
+                    (a.0.as_bytes(), a.1.as_ref())
+                }));
+                                          element
+                                      }))?;
 
         if let Some(value) = self.value.as_ref() {
-            writer.write_event(Event::Text(BytesText::borrowed(value.as_bytes())))?;
+            writer
+                .write_event(Event::Text(BytesText::borrowed(value.as_bytes())))?;
         }
 
         for extensions in self.children.values() {

--- a/src/fromxml.rs
+++ b/src/fromxml.rs
@@ -37,7 +37,11 @@ macro_rules! element_text {
 
 macro_rules! parse_extension {
     ($reader:ident, $element:ident, $ns:ident, $name:ident, $extensions:expr) => ({
-        let result = ::fromxml::parse_extension($reader, $element.attributes(), $ns, $name, &mut $extensions);
+        let result = ::fromxml::parse_extension($reader,
+                                                $element.attributes(),
+                                                $ns,
+                                                $name,
+                                                &mut $extensions);
         $reader = result.1;
         try!(result.0)
     })

--- a/src/fromxml.rs
+++ b/src/fromxml.rs
@@ -148,15 +148,7 @@ fn parse_extension_element<R: BufRead>(mut reader: Reader<R>,
                 let child = parse_extension_element(reader, element.attributes());
                 reader = child.1;
                 let ext = try_reader!(child.0, reader);
-
-                let name = {
-                    let split = element.name().splitn(2, |b| *b == b':').collect::<Vec<_>>();
-                    if split.len() == 2 {
-                        try_reader!(str::from_utf8(unsafe { split.get_unchecked(1) }), reader)
-                    } else {
-                        try_reader!(str::from_utf8(unsafe { split.get_unchecked(0) }), reader)
-                    }
-                };
+                let name = try_reader!(str::from_utf8(element.local_name()), reader);
 
                 let ext = {
                     if let Some(list) = children.get_mut(name) {

--- a/src/guid.rs
+++ b/src/guid.rs
@@ -6,7 +6,7 @@
 // it under the terms of the MIT License and/or Apache 2.0 License.
 
 use error::Error;
-use fromxml::FromXml;
+use fromxml::{FromXml, element_text};
 use quick_xml::errors::Error as XmlError;
 use quick_xml::events::{Event, BytesStart, BytesEnd, BytesText};
 use quick_xml::events::attributes::Attributes;
@@ -99,9 +99,9 @@ impl Default for Guid {
 }
 
 impl FromXml for Guid {
-    fn from_xml<R: ::std::io::BufRead>(mut reader: Reader<R>,
+    fn from_xml<R: ::std::io::BufRead>(reader: &mut Reader<R>,
                                        mut atts: Attributes)
-                                       -> Result<(Self, Reader<R>), Error> {
+                                       -> Result<Self, Error> {
         let mut is_permalink = true;
 
         for attr in atts.with_checks(false) {
@@ -113,13 +113,12 @@ impl FromXml for Guid {
             }
         }
 
-        let content = element_text!(reader).unwrap_or_default();
+        let content = element_text(reader)?.unwrap_or_default();
 
-        Ok((Guid {
-                value: content,
-                is_permalink: is_permalink,
-            },
-            reader))
+        Ok(Guid {
+               value: content,
+               is_permalink: is_permalink,
+           })
     }
 }
 

--- a/src/guid.rs
+++ b/src/guid.rs
@@ -126,16 +126,12 @@ impl FromXml for Guid {
 impl ToXml for Guid {
     fn to_xml<W: ::std::io::Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"guid";
+        let mut element = BytesStart::borrowed(name, name.len());
+        if !self.is_permalink {
+            element.push_attribute(("isPermaLink", "false"));
+        }
 
-        writer
-            .write_event(Event::Start({
-                                          let mut element = BytesStart::borrowed(name, name.len());
-                                          if !self.is_permalink {
-                                              element.push_attribute((b"isPermaLink".as_ref(),
-                                                                      b"false".as_ref()));
-                                          }
-                                          element
-                                      }))?;
+        writer.write_event(Event::Start(element))?;
 
         writer
             .write_event(Event::Text(BytesText::borrowed(self.value.as_bytes())))?;

--- a/src/guid.rs
+++ b/src/guid.rs
@@ -127,15 +127,18 @@ impl ToXml for Guid {
     fn to_xml<W: ::std::io::Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"guid";
 
-        writer.write_event(Event::Start({
-            let mut element = BytesStart::borrowed(name, name.len());
-            if !self.is_permalink {
-                element.push_attribute((b"isPermaLink".as_ref(), b"false".as_ref()));
-            }
-            element
-        }))?;
+        writer
+            .write_event(Event::Start({
+                                          let mut element = BytesStart::borrowed(name, name.len());
+                                          if !self.is_permalink {
+                                              element.push_attribute((b"isPermaLink".as_ref(),
+                                                                      b"false".as_ref()));
+                                          }
+                                          element
+                                      }))?;
 
-        writer.write_event(Event::Text(BytesText::borrowed(self.value.as_bytes())))?;
+        writer
+            .write_event(Event::Text(BytesText::borrowed(self.value.as_bytes())))?;
 
         writer.write_event(Event::End(BytesEnd::borrowed(name)))?;
         Ok(())

--- a/src/image.rs
+++ b/src/image.rs
@@ -260,6 +260,7 @@ impl FromXml for Image {
         let mut height = None;
         let mut description = None;
         let mut buf = Vec::new();
+        let mut skip_buf = Vec::new();
 
         loop {
             match reader.read_event(&mut buf) {
@@ -271,7 +272,7 @@ impl FromXml for Image {
                         b"width" => width = element_text!(reader),
                         b"height" => height = element_text!(reader),
                         b"description" => description = element_text!(reader),
-                        _ => skip_element!(reader),
+                        n => try!(reader.read_to_end(n, &mut skip_buf)),
                     }
                 }
                 Ok(Event::End(_)) => {

--- a/src/image.rs
+++ b/src/image.rs
@@ -305,7 +305,8 @@ impl ToXml for Image {
     fn to_xml<W: ::std::io::Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"image";
 
-        writer.write_event(Event::Start(BytesStart::borrowed(name, name.len())))?;
+        writer
+            .write_event(Event::Start(BytesStart::borrowed(name, name.len())))?;
 
         writer.write_text_element(b"url", &self.url)?;
         writer.write_text_element(b"title", &self.title)?;

--- a/src/image.rs
+++ b/src/image.rs
@@ -272,7 +272,7 @@ impl FromXml for Image {
                         b"width" => width = element_text!(reader),
                         b"height" => height = element_text!(reader),
                         b"description" => description = element_text!(reader),
-                        n => try!(reader.read_to_end(n, &mut skip_buf)),
+                        n => reader.read_to_end(n, &mut skip_buf)?,
                     }
                 }
                 Ok(Event::End(_)) => {
@@ -324,7 +324,7 @@ impl ToXml for Image {
             writer.write_text_element(b"description", description)?;
         }
 
-        try!(writer.write_event(Event::End(BytesEnd::borrowed(name))));
+        writer.write_event(Event::End(BytesEnd::borrowed(name)))?;
         Ok(())
     }
 }

--- a/src/item.rs
+++ b/src/item.rs
@@ -460,7 +460,8 @@ impl FromXml for Item {
                 Ok(Event::Start(element)) => {
                     match element.name() {
                         b"category" => {
-                            let (category, reader_) = Category::from_xml(reader, element.attributes())?;
+                            let (category, reader_) = Category::from_xml(reader,
+                                                                         element.attributes())?;
                             reader = reader_;
                             item.categories.push(category);
                         }
@@ -470,7 +471,8 @@ impl FromXml for Item {
                             item.guid = Some(guid);
                         }
                         b"enclosure" => {
-                            let (enclosure, reader_) = Enclosure::from_xml(reader, element.attributes())?;
+                            let (enclosure, reader_) = Enclosure::from_xml(reader,
+                                                                           element.attributes())?;
                             reader = reader_;
                             item.enclosure = Some(enclosure);
                         }
@@ -523,7 +525,8 @@ impl ToXml for Item {
     fn to_xml<W: ::std::io::Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"item";
 
-        writer.write_event(Event::Start(BytesStart::borrowed(name, name.len())))?;
+        writer
+            .write_event(Event::Start(BytesStart::borrowed(name, name.len())))?;
 
         if let Some(title) = self.title.as_ref() {
             writer.write_text_element(b"title", title)?;

--- a/src/item.rs
+++ b/src/item.rs
@@ -490,7 +490,7 @@ impl FromXml for Item {
                             if let Some((ns, name)) = fromxml::extension_name(n) {
                                 parse_extension!(reader, element, ns, name, item.extensions);
                             } else {
-                                skip_element!(reader);
+                                try!(reader.read_to_end(n, &mut Vec::new()));
                             }
                         }
                     }

--- a/src/item.rs
+++ b/src/item.rs
@@ -492,7 +492,7 @@ impl FromXml for Item {
                             if let Some((ns, name)) = fromxml::extension_name(n) {
                                 parse_extension!(reader, element, ns, name, item.extensions);
                             } else {
-                                try!(reader.read_to_end(n, &mut Vec::new()));
+                                reader.read_to_end(n, &mut Vec::new())?;
                             }
                         }
                     }
@@ -586,7 +586,7 @@ impl ToXml for Item {
             ext.to_xml(writer)?;
         }
 
-        try!(writer.write_event(Event::End(BytesEnd::borrowed(name))));
+        writer.write_event(Event::End(BytesEnd::borrowed(name)))?;
         Ok(())
     }
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -98,14 +98,10 @@ impl FromXml for Source {
 impl ToXml for Source {
     fn to_xml<W: ::std::io::Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"source";
+        let mut element = BytesStart::borrowed(name, name.len());
+        element.push_attribute(("url", &*self.url));
 
-        writer
-            .write_event(Event::Start({
-                                          let mut element = BytesStart::borrowed(name, name.len());
-                                          element.push_attribute((b"url".as_ref(),
-                                                                  self.url.as_bytes()));
-                                          element
-                                      }))?;
+        writer.write_event(Event::Start(element))?;
 
         if let Some(text) = self.title.as_ref().map(|s| s.as_str()) {
             writer

--- a/src/source.rs
+++ b/src/source.rs
@@ -103,9 +103,8 @@ impl ToXml for Source {
 
         writer.write_event(Event::Start(element))?;
 
-        if let Some(text) = self.title.as_ref().map(|s| s.as_str()) {
-            writer
-                .write_event(Event::Text(BytesText::borrowed(text.as_bytes())))?;
+        if let Some(text) = self.title.as_ref().map(|s| s.as_bytes()) {
+            writer.write_event(Event::Text(BytesText::borrowed(text)))?;
         }
 
         writer.write_event(Event::End(BytesEnd::borrowed(name)))?;

--- a/src/source.rs
+++ b/src/source.rs
@@ -6,7 +6,7 @@
 // it under the terms of the MIT License and/or Apache 2.0 License.
 
 use error::Error;
-use fromxml::FromXml;
+use fromxml::{FromXml, element_text};
 use quick_xml::errors::Error as XmlError;
 use quick_xml::events::{Event, BytesStart, BytesEnd, BytesText};
 use quick_xml::events::attributes::Attributes;
@@ -70,9 +70,9 @@ impl Source {
 }
 
 impl FromXml for Source {
-    fn from_xml<R: ::std::io::BufRead>(mut reader: Reader<R>,
+    fn from_xml<R: ::std::io::BufRead>(reader: &mut Reader<R>,
                                        mut atts: Attributes)
-                                       -> Result<(Self, Reader<R>), Error> {
+                                       -> Result<Self, Error> {
         let mut url = None;
 
         for attr in atts.with_checks(false) {
@@ -85,13 +85,12 @@ impl FromXml for Source {
         }
 
         let url = url.unwrap_or_default();
-        let content = element_text!(reader);
+        let content = element_text(reader)?;
 
-        Ok((Source {
-                url: url,
-                title: content,
-            },
-            reader))
+        Ok(Source {
+               url: url,
+               title: content,
+           })
     }
 }
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -70,7 +70,7 @@ impl Source {
 }
 
 impl FromXml for Source {
-    fn from_xml<R: ::std::io::BufRead>(mut reader: Reader<R>, 
+    fn from_xml<R: ::std::io::BufRead>(mut reader: Reader<R>,
                                        mut atts: Attributes)
                                        -> Result<(Self, Reader<R>), Error> {
         let mut url = None;
@@ -99,14 +99,17 @@ impl ToXml for Source {
     fn to_xml<W: ::std::io::Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"source";
 
-        writer.write_event(Event::Start({
-            let mut element = BytesStart::borrowed(name, name.len());
-            element.push_attribute((b"url".as_ref(), self.url.as_bytes()));
-            element
-        }))?;
+        writer
+            .write_event(Event::Start({
+                                          let mut element = BytesStart::borrowed(name, name.len());
+                                          element.push_attribute((b"url".as_ref(),
+                                                                  self.url.as_bytes()));
+                                          element
+                                      }))?;
 
         if let Some(text) = self.title.as_ref().map(|s| s.as_str()) {
-            writer.write_event(Event::Text(BytesText::borrowed(text.as_bytes())))?;
+            writer
+                .write_event(Event::Text(BytesText::borrowed(text.as_bytes())))?;
         }
 
         writer.write_event(Event::End(BytesEnd::borrowed(name)))?;

--- a/src/textinput.rs
+++ b/src/textinput.rs
@@ -133,7 +133,7 @@ impl FromXml for TextInput {
                         b"description" => description = element_text!(reader),
                         b"name" => name = element_text!(reader),
                         b"link" => link = element_text!(reader),
-                        n => try!(reader.read_to_end(n, &mut skip_buf)),
+                        n => reader.read_to_end(n, &mut skip_buf)?,
                     }
                 }
                 Ok(Event::End(_)) => {
@@ -174,7 +174,7 @@ impl ToXml for TextInput {
         writer.write_text_element(b"name", &self.name)?;
         writer.write_text_element(b"link", &self.link)?;
 
-        try!(writer.write_event(Event::End(BytesEnd::borrowed(name))));
+        writer.write_event(Event::End(BytesEnd::borrowed(name)))?;
         Ok(())
     }
 }

--- a/src/textinput.rs
+++ b/src/textinput.rs
@@ -165,7 +165,8 @@ impl ToXml for TextInput {
     fn to_xml<W: ::std::io::Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"textInput";
 
-        writer.write_event(Event::Start(BytesStart::borrowed(name, name.len())))?;
+        writer
+            .write_event(Event::Start(BytesStart::borrowed(name, name.len())))?;
 
         writer.write_text_element(b"title", &self.title)?;
         writer

--- a/src/textinput.rs
+++ b/src/textinput.rs
@@ -123,6 +123,7 @@ impl FromXml for TextInput {
         let mut name = None;
         let mut link = None;
         let mut buf = Vec::new();
+        let mut skip_buf = Vec::new();
 
         loop {
             match reader.read_event(&mut buf) {
@@ -132,7 +133,7 @@ impl FromXml for TextInput {
                         b"description" => description = element_text!(reader),
                         b"name" => name = element_text!(reader),
                         b"link" => link = element_text!(reader),
-                        _ => skip_element!(reader),
+                        n => try!(reader.read_to_end(n, &mut skip_buf)),
                     }
                 }
                 Ok(Event::End(_)) => {

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -294,7 +294,6 @@ fn read_extension() {
                Some(vec![Some("Child 1"), Some("Child 2")]));
 }
 
-
 #[test]
 fn read_itunes() {
     let input = include_str!("data/itunes.xml");


### PR DESCRIPTION
rss is still using the old quick-xml 0.4.2. This PR upgrades it to the last version.

quick-xml 0.7.3 has several new features but the most important is the support for non-utf8 xmls. As a result this should probably close both #1 and #31 

As rss rely heavily on quick-xml, and the API has had many changes, this is not a small PR. Which means there may be some impact for #35. I'm happy to wait for #35 to merge if needed.

There are some impacts in terms of performance: 
- reading is slower: I suppose it is mainly because of systematic unescape and decoding, thus more reliable results)
- writing is faster: This is mainly due to the fact that quick-xml is using `Cow`s everywhere so it was possible to avoid quite a lot of allocations

```
$ cargo benchcmp master quick 
 name              master ns/iter  quick ns/iter  diff ns/iter   diff % 
 read_dublincore   98,630          110,988              12,358   12.53% 
 read_itunes       85,249          98,319               13,070   15.33% 
 read_rss2sample   51,158          52,542                1,384    2.71% 
 write_dublincore  14,961          6,289                -8,672  -57.96% 
 write_itunes      13,161          7,880                -5,281  -40.13% 
 write_rss2sample  12,135          4,472                -7,663  -63.15% 
```

Note that while all tests pass, there are not actually extensive tests on reading part (fromxml) so I may have missed something.