### PR TITLE
Revised docs and made builders a bit nicer to use

### DIFF
--- a/src/category.rs
+++ b/src/category.rs
@@ -37,8 +37,7 @@ impl Category {
     ///
     /// let category_obj = CategoryBuilder::new()
     ///     .name(category)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(category, category_obj.name());
     /// ```
@@ -57,8 +56,7 @@ impl Category {
     ///
     /// let category = CategoryBuilder::new()
     ///     .domain(Some(domain_string.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(domain_string), category.domain());
     /// ```
@@ -68,8 +66,7 @@ impl Category {
     ///
     /// let category = CategoryBuilder::new()
     ///     .domain(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let domain_option = category.domain();
     /// assert!(domain_option.is_none());
@@ -181,8 +178,7 @@ impl CategoryBuilder {
     ///         .name("Podcast")
     ///         .validate()
     ///         .unwrap()
-    ///         .finalize()
-    ///         .unwrap();
+    ///         .finalize();
     /// ```
 
     pub fn validate(self) -> Result<CategoryBuilder, Error> {
@@ -203,13 +199,12 @@ impl CategoryBuilder {
     /// let category = CategoryBuilder::new()
     ///         .name("Title")
     ///         .domain(None)
-    ///         .finalize()
-    ///         .unwrap();
+    ///         .finalize();
     /// ```
-    pub fn finalize(self) -> Result<Category, Error> {
-        Ok(Category {
-               name: self.name,
-               domain: self.domain,
-           })
+    pub fn finalize(self) -> Category {
+        Category {
+            name: self.name,
+            domain: self.domain,
+        }
     }
 }

--- a/src/category.rs
+++ b/src/category.rs
@@ -88,7 +88,7 @@ impl FromXml for Category {
         for attr in atts.with_checks(false) {
             if let Ok(attr) = attr {
                 if attr.key == b"domain" {
-                    domain = Some(attr.unescape_and_decode_value(&reader)?);
+                    domain = Some(attr.unescape_and_decode_value(reader)?);
                     break;
                 }
             }

--- a/src/category.rs
+++ b/src/category.rs
@@ -143,11 +143,11 @@ impl CategoryBuilder {
     /// ```
     /// use rss::CategoryBuilder;
     ///
-    /// let mut category_builder = CategoryBuilder::new();
-    /// category_builder.name("Podcast");
+    /// let category_builder = CategoryBuilder::new()
+    ///     .name("Podcast");
     /// ```
-    pub fn name(mut self, name: &str) -> CategoryBuilder {
-        self.name = name.to_string();
+    pub fn name<S: Into<String>>(mut self, name: S) -> CategoryBuilder {
+        self.name = name.into();
         self
     }
 
@@ -158,8 +158,8 @@ impl CategoryBuilder {
     /// ```
     /// use rss::CategoryBuilder;
     ///
-    /// let mut category_builder = CategoryBuilder::new();
-    /// category_builder.domain(Some("http://www.example.com".to_string()));
+    /// let category_builder = CategoryBuilder::new()
+    ///     .domain(Some("http://www.example.com".to_string()));
     /// ```
     pub fn domain(mut self, domain: Option<String>) -> CategoryBuilder {
         self.domain = domain;

--- a/src/category.rs
+++ b/src/category.rs
@@ -5,7 +5,6 @@
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the MIT License and/or Apache 2.0 License.
 
-
 use error::Error;
 use fromxml::{FromXml, element_text};
 use quick_xml::errors::Error as XmlError;
@@ -26,50 +25,49 @@ pub struct Category {
 }
 
 impl Category {
-    /// Get the category that exists under `Category`.
+    /// Return the name of this `Category`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{CategoryBuilder, Category};
+    /// use rss::CategoryBuilder;
     ///
-    /// let category = "podcast";
+    /// let name = "Podcast";
     ///
-    /// let category_obj = CategoryBuilder::new()
-    ///     .name(category)
+    /// let category = CategoryBuilder::default()
+    ///     .name(name)
     ///     .finalize();
     ///
-    /// assert_eq!(category, category_obj.name());
+    /// assert_eq!(name, category.name());
     /// ```
     pub fn name(&self) -> &str {
         self.name.as_str()
     }
 
-    /// Get the optional domain that exists under `Category`.
+    /// Return the domain of this `Category`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{CategoryBuilder, Category};
+    /// use rss::CategoryBuilder;
     ///
-    /// let domain_string = "http://jupiterbroadcasting.com/";
+    /// let domain = "http://jupiterbroadcasting.com/";
     ///
-    /// let category = CategoryBuilder::new()
-    ///     .domain(domain_string.to_string())
+    /// let category = CategoryBuilder::default()
+    ///     .domain(domain.to_string())
     ///     .finalize();
     ///
-    /// assert_eq!(Some(domain_string), category.domain());
+    /// assert_eq!(Some(domain), category.domain());
     /// ```
     ///
     /// ```
-    /// use rss::{CategoryBuilder, Category};
+    /// use rss::CategoryBuilder;
     ///
-    /// let category = CategoryBuilder::new()
+    /// let category = CategoryBuilder::default()
     ///     .domain(None)
     ///     .finalize();
     ///
-    /// let domain_option = category.domain();
-    /// assert!(domain_option.is_none());
+    /// assert!(category.domain().is_none());
     /// ```
     pub fn domain(&self) -> Option<&str> {
         self.domain.as_ref().map(|s| s.as_str())
@@ -115,7 +113,7 @@ impl ToXml for Category {
     }
 }
 
-/// This `CategoryBuilder` struct creates the `Category`.
+/// A builder used to create a `Category`.
 #[derive(Debug, Clone, Default)]
 pub struct CategoryBuilder {
     name: String,
@@ -123,64 +121,53 @@ pub struct CategoryBuilder {
 }
 
 impl CategoryBuilder {
-    /// Construct a new `CategoryBuilder` and return default values.
+    /// Set the name of the `Category`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::CategoryBuilder;
     ///
-    /// let category_builder = CategoryBuilder::new();
-    /// ```
-    pub fn new() -> CategoryBuilder {
-        CategoryBuilder::default()
-    }
-
-    /// Set the category that exists under `Category`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rss::CategoryBuilder;
-    ///
-    /// let category_builder = CategoryBuilder::new()
+    /// let builder = CategoryBuilder::default()
     ///     .name("Podcast");
     /// ```
-    pub fn name<S: Into<String>>(mut self, name: S) -> CategoryBuilder {
+    pub fn name<S>(mut self, name: S) -> CategoryBuilder
+        where S: Into<String>
+    {
         self.name = name.into();
         self
     }
 
-    /// Set the optional domain that exists under `Category`.
+    /// Set the domain for the `Category`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::CategoryBuilder;
     ///
-    /// let category_builder = CategoryBuilder::new()
+    /// let builder = CategoryBuilder::default()
     ///     .domain("http://www.example.com".to_string());
     /// ```
-    pub fn domain<O: Into<Option<String>>>(mut self, domain: O) -> CategoryBuilder {
+    pub fn domain<V>(mut self, domain: V) -> CategoryBuilder
+        where V: Into<Option<String>>
+    {
         self.domain = domain.into();
         self
     }
 
-    /// Validate the contents of `Category`.
+    /// Validate the contents of this `CategoryBuilder`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::CategoryBuilder;
     ///
-    /// let category_builder = CategoryBuilder::new()
-    ///         .domain("http://www.example.com".to_string())
-    ///         .name("Podcast")
-    ///         .validate()
-    ///         .unwrap()
-    ///         .finalize();
+    /// let builder = CategoryBuilder::default()
+    ///     .name("Podcast")
+    ///     .domain("http://www.example.com".to_string())
+    ///     .validate()
+    ///     .unwrap();
     /// ```
-
     pub fn validate(self) -> Result<CategoryBuilder, Error> {
         if let Some(ref domain) = self.domain {
             Url::parse(domain)?;
@@ -189,17 +176,17 @@ impl CategoryBuilder {
         Ok(self)
     }
 
-    /// Construct the `Category` from the `CategoryBuilder`.
+    /// Construct the `Category` from this `CategoryBuilder`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::CategoryBuilder;
     ///
-    /// let category = CategoryBuilder::new()
-    ///         .name("Title")
-    ///         .domain(None)
-    ///         .finalize();
+    /// let category = CategoryBuilder::default()
+    ///     .name("Podcast")
+    ///     .domain("http://www.example.com".to_string())
+    ///     .finalize();
     /// ```
     pub fn finalize(self) -> Category {
         Category {

--- a/src/category.rs
+++ b/src/category.rs
@@ -55,7 +55,7 @@ impl Category {
     /// let domain_string = "http://jupiterbroadcasting.com/";
     ///
     /// let category = CategoryBuilder::new()
-    ///     .domain(Some(domain_string.to_string()))
+    ///     .domain(domain_string.to_string())
     ///     .finalize();
     ///
     /// assert_eq!(Some(domain_string), category.domain());
@@ -159,10 +159,10 @@ impl CategoryBuilder {
     /// use rss::CategoryBuilder;
     ///
     /// let category_builder = CategoryBuilder::new()
-    ///     .domain(Some("http://www.example.com".to_string()));
+    ///     .domain("http://www.example.com".to_string());
     /// ```
-    pub fn domain(mut self, domain: Option<String>) -> CategoryBuilder {
-        self.domain = domain;
+    pub fn domain<O: Into<Option<String>>>(mut self, domain: O) -> CategoryBuilder {
+        self.domain = domain.into();
         self
     }
 
@@ -174,7 +174,7 @@ impl CategoryBuilder {
     /// use rss::CategoryBuilder;
     ///
     /// let category_builder = CategoryBuilder::new()
-    ///         .domain(Some("http://www.example.com".to_string()))
+    ///         .domain("http://www.example.com".to_string())
     ///         .name("Podcast")
     ///         .validate()
     ///         .unwrap()

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -2085,7 +2085,7 @@ impl ChannelBuilder {
         }
 
         for day in self.skip_days.as_slice() {
-            match Day::from_str(day.as_str()) {
+            match SkipDay::from_str(day.as_str()) {
                 Ok(_) => (),
                 Err(err) => return Err(Error::Validation(err.to_string())),
             };
@@ -2102,7 +2102,7 @@ impl ChannelBuilder {
         }
 
         if self.ttl.is_some() && self.ttl.unwrap() < 0 {
-            return Err(Error::Validation("Channel ttl cannot be a negative value.".to_string()));
+            return Err(Error::Validation("Channel TTL cannot be a negative value.".to_string()));
         }
 
         Ok(self)
@@ -2185,7 +2185,7 @@ impl ChannelBuilder {
 }
 
 /// Enumerations of protocols for `SkipDays`.
-enum Day {
+enum SkipDay {
     /// Monday
     Monday,
 
@@ -2208,20 +2208,20 @@ enum Day {
     Sunday,
 }
 
-impl FromStr for Day {
+impl FromStr for SkipDay {
     type Err = &'static str;
 
-    /// Convert `&str` to `Day`.
+    /// Convert `&str` to `SkipDay`.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "Monday" => Ok(Day::Monday),
-            "Tuesday" => Ok(Day::Tuesday),
-            "Wednesday" => Ok(Day::Wednesday),
-            "Thursday" => Ok(Day::Thursday),
-            "Friday" => Ok(Day::Friday),
-            "Saturday" => Ok(Day::Saturday),
-            "Sunday" => Ok(Day::Sunday),
-            _ => Err("not a valid value"),
+            "Monday" => Ok(SkipDay::Monday),
+            "Tuesday" => Ok(SkipDay::Tuesday),
+            "Wednesday" => Ok(SkipDay::Wednesday),
+            "Thursday" => Ok(SkipDay::Thursday),
+            "Friday" => Ok(SkipDay::Friday),
+            "Saturday" => Ok(SkipDay::Saturday),
+            "Sunday" => Ok(SkipDay::Sunday),
+            _ => Err("Skip Day is not not a valid value"),
         }
     }
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1286,7 +1286,7 @@ impl Channel {
 
 impl ToString for Channel {
     fn to_string(&self) -> String {
-        let buf = self.write_to(Vec::new()).unwrap_or(Vec::new());
+        let buf = self.write_to(Vec::new()).unwrap_or_default();
         // this unwrap should be safe since the bytes written from the Channel are all valid utf8
         String::from_utf8(buf).unwrap()
     }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -658,7 +658,7 @@ impl Channel {
     ///
     /// ```
     /// use rss::ChannelBuilder;
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder};
+    /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
     /// let itunes_ext = ITunesChannelExtensionBuilder::default()
     ///     .author("author".to_string())
@@ -1960,7 +1960,7 @@ impl FromStr for SkipDay {
             "Friday" => Ok(SkipDay::Friday),
             "Saturday" => Ok(SkipDay::Saturday),
             "Sunday" => Ok(SkipDay::Sunday),
-            _ => Err("Skip Day is not not a valid value"),
+            _ => Err("Skip Day is not a valid value"),
         }
     }
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -95,8 +95,7 @@ impl Channel {
     ///
     /// let channel = ChannelBuilder::new()
     ///     .title(title)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(title.to_string(), channel.title());
     /// ```
@@ -116,8 +115,7 @@ impl Channel {
     ///
     /// let channel = ChannelBuilder::new()
     ///     .link(link)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(link.to_string(), channel.link());
     /// ```
@@ -140,8 +138,7 @@ impl Channel {
     ///
     /// let channel = ChannelBuilder::new()
     ///     .description(description.as_ref())
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(description.to_string(), channel.description());
     /// ```
@@ -161,8 +158,7 @@ impl Channel {
     ///
     /// let channel = ChannelBuilder::new()
     ///     .language(Some(language_string.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(language_string), channel.language());
     /// ```
@@ -172,8 +168,7 @@ impl Channel {
     ///
     /// let channel = ChannelBuilder::new()
     ///     .language(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(channel.language().is_none());
     /// ```
@@ -194,8 +189,7 @@ impl Channel {
     ///
     /// let channel = ChannelBuilder::new()
     ///     .copyright(Some(copyright_string.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(copyright_string), channel.copyright());
     /// ```
@@ -205,8 +199,7 @@ impl Channel {
     ///
     /// let channel = ChannelBuilder::new()
     ///     .copyright(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(channel.copyright().is_none());
     /// ```
@@ -227,8 +220,7 @@ impl Channel {
     ///
     /// let channel = ChannelBuilder::new()
     ///     .managing_editor(Some(managing_editor_string.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(managing_editor_string), channel.managing_editor());
     /// ```
@@ -238,8 +230,7 @@ impl Channel {
     ///
     /// let channel = ChannelBuilder::new()
     ///     .managing_editor(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(channel.managing_editor().is_none());
     /// ```
@@ -259,8 +250,7 @@ impl Channel {
     ///
     /// let channel = ChannelBuilder::new()
     ///     .webmaster(Some(webmaster_string.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(webmaster_string), channel.webmaster());
     /// ```
@@ -270,8 +260,7 @@ impl Channel {
     ///
     /// let channel = ChannelBuilder::new()
     ///     .webmaster(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(channel.webmaster().is_none());
     /// ```
@@ -291,8 +280,7 @@ impl Channel {
     ///
     /// let channel = ChannelBuilder::new()
     ///     .pub_date(Some(pub_date.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(pub_date), channel.pub_date());
     /// ```
@@ -302,8 +290,7 @@ impl Channel {
     ///
     /// let channel = ChannelBuilder::new()
     ///     .pub_date(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(channel.pub_date().is_none());
     /// ```
@@ -323,8 +310,7 @@ impl Channel {
     ///
     /// let channel = ChannelBuilder::new()
     ///     .last_build_date(Some(last_build_date.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let local = channel.last_build_date();
     /// assert!(local.is_some());
@@ -337,8 +323,7 @@ impl Channel {
     ///
     /// let channel = ChannelBuilder::new()
     ///     .last_build_date(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(channel.last_build_date().is_none());
     /// ```
@@ -357,21 +342,18 @@ impl Channel {
     /// let category_1 = CategoryBuilder::new()
     ///     .domain(None)
     ///     .name("Media")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let category_2 = CategoryBuilder::new()
     ///     .domain(Some("http://jupiterbroadcasting.com".to_string()))
     ///     .name("Podcast")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let categories_vec = vec![category_1, category_2];
     ///
     /// let channel = ChannelBuilder::new()
     ///     .categories(categories_vec.clone())
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let categories = channel.categories();
     /// assert!(!categories.is_empty());
@@ -384,8 +366,7 @@ impl Channel {
     ///
     /// let channel = ChannelBuilder::new()
     ///     .categories(Vec::new())
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(channel.categories().is_empty());
     /// ```
@@ -406,8 +387,7 @@ impl Channel {
     ///
     /// let channel = ChannelBuilder::new()
     ///     .generator(Some(generator_string.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(generator_string), channel.generator());
     /// ```
@@ -417,8 +397,7 @@ impl Channel {
     ///
     /// let channel = ChannelBuilder::new()
     ///     .generator(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(channel.generator().is_none());
     /// ```
@@ -438,8 +417,7 @@ impl Channel {
     ///
     /// let channel = ChannelBuilder::new()
     ///     .docs(Some(docs_string.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let docs_option = channel.docs();
     /// assert!(docs_option.is_some());
@@ -452,8 +430,7 @@ impl Channel {
     ///
     /// let channel = ChannelBuilder::new()
     ///     .docs(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(channel.docs().is_none());
     /// ```
@@ -474,13 +451,11 @@ impl Channel {
     ///     .path("/RPC2")
     ///     .register_procedure("pingMe")
     ///     .protocol("soap")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let channel = ChannelBuilder::new()
     ///     .cloud(Some(cloud))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(channel.cloud().is_some());
     /// ```
@@ -490,8 +465,7 @@ impl Channel {
     ///
     /// let channel = ChannelBuilder::new()
     ///     .cloud(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(channel.cloud().is_none());
     /// ```
@@ -511,8 +485,7 @@ impl Channel {
     ///
     /// let channel = ChannelBuilder::new()
     ///     .ttl(Some(ttl_num))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(ttl_num.to_string().as_str()), channel.ttl());
     /// ```
@@ -522,8 +495,7 @@ impl Channel {
     ///
     /// let channel = ChannelBuilder::new()
     ///     .ttl(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(channel.ttl().is_none());
     /// ```
@@ -546,14 +518,12 @@ impl Channel {
     ///     .height(None)
     ///     .width(None)
     ///     .description(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let channel = ChannelBuilder::new()
     ///     .image(Some(image))
     ///     .link("http://www.jupiterbroadcasting.com/")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(channel.image().is_some());
     /// ```
@@ -564,8 +534,7 @@ impl Channel {
     /// let channel = ChannelBuilder::new()
     ///     .image(None)
     ///     .link("http://www.jupiterbroadcasting.com/")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(channel.image().is_none());
     /// ```
@@ -584,8 +553,7 @@ impl Channel {
     /// let channel = ChannelBuilder::new()
     ///     .rating(None)
     ///     .link("http://www.jupiterbroadcasting.com/")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(channel.rating().is_none());
     /// ```
@@ -606,14 +574,12 @@ impl Channel {
     ///     .description("Provided Feedback")
     ///     .name("Comment")
     ///     .link("http://www.example.com/feedback")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let channel = ChannelBuilder::new()
     ///     .text_input(Some(text_input))
     ///     .link("http://www.jupiterbroadcasting.com/")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(channel.text_input().is_some());
     /// ```
@@ -624,8 +590,7 @@ impl Channel {
     /// let channel = ChannelBuilder::new()
     ///     .text_input(None)
     ///     .link("http://www.jupiterbroadcasting.com/")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(channel.text_input().is_none());
     /// ```
@@ -645,8 +610,7 @@ impl Channel {
     /// let channel = ChannelBuilder::new()
     ///     .skip_hours(skip_hours_vec.clone())
     ///     .link("http://www.jupiterbroadcasting.com/")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let skip_hours  = channel.skip_hours();
     /// assert!(!skip_hours.is_empty());
@@ -665,8 +629,7 @@ impl Channel {
     /// let channel = ChannelBuilder::new()
     ///     .skip_hours(Vec::new())
     ///     .link("http://www.jupiterbroadcasting.com/")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(channel.skip_hours().is_empty());
     /// ```
@@ -689,8 +652,7 @@ impl Channel {
     /// let channel = ChannelBuilder::new()
     ///     .skip_days(skip_days_vec.clone())
     ///     .link("http://www.jupiterbroadcasting.com/")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let skip_days = channel.skip_days();
     /// assert!(!skip_days.is_empty());
@@ -709,8 +671,7 @@ impl Channel {
     /// let channel = ChannelBuilder::new()
     ///     .skip_days(Vec::new())
     ///     .link("http://www.jupiterbroadcasting.com/")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(channel.skip_days().is_empty());
     /// ```
@@ -748,8 +709,7 @@ impl Channel {
     ///     .guid(None)
     ///     .pub_date(None)
     ///     .source(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let item_2 = ItemBuilder::new()
     ///     .title(None)
@@ -761,16 +721,14 @@ impl Channel {
     ///     .guid(None)
     ///     .pub_date(None)
     ///     .source(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let items_vec = vec![item_1, item_2];
     ///
     /// let channel = ChannelBuilder::new()
     ///     .items(items_vec.clone())
     ///     .link("http://www.jupiterbroadcasting.com/")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let items = channel.items();
     /// assert!(!items.is_empty());
@@ -784,8 +742,7 @@ impl Channel {
     /// let channel = ChannelBuilder::new()
     ///     .items(Vec::new())
     ///     .link("http://www.jupiterbroadcasting.com/")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(channel.items().is_empty());
     /// ```
@@ -806,19 +763,16 @@ impl Channel {
     /// let owner = ITunesOwnerBuilder::new()
     ///     .email(Some("email@example.com".to_string()))
     ///     .name(Some("name".to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let subcategory = ITunesCategoryBuilder::new()
     ///     .text("text")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let category = ITunesCategoryBuilder::new()
     ///     .text("text")
     ///     .subcategory(Some(Box::new(subcategory)))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let categories = vec![category];
     ///
@@ -834,13 +788,11 @@ impl Channel {
     ///     .complete(Some("complete".to_string()))
     ///     .owner(Some(owner))
     ///     .categories(categories)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let channel = ChannelBuilder::new()
     ///     .itunes_ext(Some(itunes_channel))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(channel.itunes_ext().is_some());
     /// ```
@@ -850,8 +802,7 @@ impl Channel {
     ///
     /// let channel = ChannelBuilder::new()
     ///     .itunes_ext(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(channel.itunes_ext().is_none());
     /// ```
@@ -1048,7 +999,7 @@ impl Channel {
                          .register_procedure(val.register_procedure())
                          .protocol(val.protocol())
                          .validate()?
-                         .finalize()?)
+                         .finalize())
             }
         };
 
@@ -1063,7 +1014,7 @@ impl Channel {
                                  .name(cat.name())
                                  .domain(domain)
                                  .validate()?
-                                 .finalize()?);
+                                 .finalize());
         }
 
         let mut skip_hours: Vec<i64> = Vec::new();
@@ -1097,7 +1048,7 @@ impl Channel {
                          .height(height)
                          .description(description)
                          .validate()?
-                         .finalize()?)
+                         .finalize())
             }
         };
 
@@ -1110,7 +1061,7 @@ impl Channel {
                          .name(val.name())
                          .link(val.link())
                          .validate()?
-                         .finalize()?)
+                         .finalize())
             }
         };
 
@@ -1127,7 +1078,7 @@ impl Channel {
                                   .name(cat.name())
                                   .domain(domain)
                                   .validate()?
-                                  .finalize()?);
+                                  .finalize());
             }
 
             let enclosure = match item.enclosure() {
@@ -1138,7 +1089,7 @@ impl Channel {
                              .length(i64::from_str(eval.length())?)
                              .mime_type(eval.mime_type())
                              .validate()?
-                             .finalize()?)
+                             .finalize())
                 }
             };
 
@@ -1148,7 +1099,7 @@ impl Channel {
                     Some(GuidBuilder::new()
                              .value(gval.value())
                              .is_permalink(Some(gval.is_permalink()))
-                             .finalize()?)
+                             .finalize())
                 }
             };
 
@@ -1164,7 +1115,7 @@ impl Channel {
                              .url(sval.url())
                              .title(title)
                              .validate()?
-                             .finalize()?)
+                             .finalize())
                 }
             };
 
@@ -1210,7 +1161,7 @@ impl Channel {
                            .guid(guid)
                            .source(source)
                            .validate()?
-                           .finalize()?);
+                           .finalize());
         }
 
         let ttl = match self.ttl() {
@@ -1258,29 +1209,29 @@ impl Channel {
             Some(val) => Some(val.to_string()),
         };
 
-        ChannelBuilder::new()
-            .title(self.title())
-            .link(self.link())
-            .description(self.description())
-            .language(language)
-            .copyright(copyright)
-            .managing_editor(managing_editor)
-            .webmaster(webmaster)
-            .pub_date(pub_date)
-            .last_build_date(last_build_date)
-            .generator(generator)
-            .docs(docs)
-            .rating(None)
-            .ttl(ttl)
-            .cloud(cloud)
-            .categories(channel_cat)
-            .image(image)
-            .text_input(text_input)
-            .skip_hours(skip_hours)
-            .skip_days(self.skip_days().to_vec())
-            .items(items)
-            .validate()?
-            .finalize()
+        Ok(ChannelBuilder::new()
+               .title(self.title())
+               .link(self.link())
+               .description(self.description())
+               .language(language)
+               .copyright(copyright)
+               .managing_editor(managing_editor)
+               .webmaster(webmaster)
+               .pub_date(pub_date)
+               .last_build_date(last_build_date)
+               .generator(generator)
+               .docs(docs)
+               .rating(None)
+               .ttl(ttl)
+               .cloud(cloud)
+               .categories(channel_cat)
+               .image(image)
+               .text_input(text_input)
+               .skip_hours(skip_hours)
+               .skip_days(self.skip_days().to_vec())
+               .items(items)
+               .validate()?
+               .finalize())
     }
 }
 
@@ -1751,8 +1702,7 @@ impl ChannelBuilder {
     /// use rss::{ChannelBuilder, CategoryBuilder};
     ///
     /// let category = CategoryBuilder::new()
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     /// let categories = vec![category];
     ///
     /// let mut channel_builder = ChannelBuilder::new();
@@ -1811,8 +1761,7 @@ impl ChannelBuilder {
     /// let cloud = CloudBuilder::new()
     ///     .domain("http://rpc.sys.com/")
     ///     .protocol("soap")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let mut channel_builder = ChannelBuilder::new();
     /// channel_builder.cloud(Some(cloud));
@@ -1853,8 +1802,7 @@ impl ChannelBuilder {
     /// let image = ImageBuilder::new()
     ///     .url(url)
     ///     .link(link)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let mut channel_builder = ChannelBuilder::new();
     /// channel_builder.image(Some(image));
@@ -1889,8 +1837,7 @@ impl ChannelBuilder {
     ///
     /// let text_input = TextInputBuilder::new()
     ///     .link("http://www.example.com/feedback")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let mut channel_builder = ChannelBuilder::new();
     /// channel_builder.text_input(Some(text_input));
@@ -1948,8 +1895,7 @@ impl ChannelBuilder {
     ///
     /// let item = ItemBuilder::new()
     ///     .title(Some(title))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     /// let items = vec![item];
     ///
     /// let mut channel_builder = ChannelBuilder::new();
@@ -1973,19 +1919,16 @@ impl ChannelBuilder {
     /// let owner = ITunesOwnerBuilder::new()
     ///     .email(Some("email@example.com".to_string()))
     ///     .name(Some("name".to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let subcategory = ITunesCategoryBuilder::new()
     ///     .text("text")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let category = ITunesCategoryBuilder::new()
     ///     .text("text")
     ///     .subcategory(Some(Box::new(subcategory)))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let categories = vec![category];
     ///
@@ -2001,8 +1944,7 @@ impl ChannelBuilder {
     ///     .complete(Some("complete".to_string()))
     ///     .owner(Some(owner))
     ///     .categories(categories)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let mut channel_builder = ChannelBuilder::new();
     /// channel_builder.itunes_ext(Some(itunes_channel));
@@ -2066,8 +2008,9 @@ impl ChannelBuilder {
     ///         .skip_hours(Vec::new())
     ///         .skip_days(Vec::new())
     ///         .items(Vec::new())
-    ///         .validate().unwrap()
-    ///         .finalize().unwrap();
+    ///         .validate()
+    ///         .unwrap()
+    ///         .finalize();
     /// ```
     pub fn validate(self) -> Result<ChannelBuilder, Error> {
         Url::parse(self.link.as_str())?;
@@ -2144,43 +2087,33 @@ impl ChannelBuilder {
     ///         .items(Vec::new())
     ///         .finalize();
     /// ```
-    pub fn finalize(self) -> Result<Channel, Error> {
-        let mut skip_hours: Vec<String> = Vec::new();
-        for hour in self.skip_hours.as_slice() {
-            skip_hours.push(hour.to_string());
+    pub fn finalize(self) -> Channel {
+        Channel {
+            title: self.title,
+            link: self.link,
+            description: self.description,
+            language: self.language,
+            copyright: self.copyright,
+            managing_editor: self.managing_editor,
+            webmaster: self.webmaster,
+            pub_date: self.pub_date,
+            last_build_date: self.last_build_date,
+            categories: self.categories,
+            generator: self.generator,
+            docs: self.docs,
+            cloud: self.cloud,
+            ttl: self.ttl.map(|n| n.to_string()),
+            image: self.image,
+            rating: self.rating,
+            text_input: self.text_input,
+            skip_hours: self.skip_hours.into_iter().map(|n| n.to_string()).collect(),
+            skip_days: self.skip_days,
+            items: self.items,
+            itunes_ext: self.itunes_ext,
+            dublin_core_ext: self.dublin_core_ext,
+            extensions: self.extensions,
+            namespaces: self.namespaces,
         }
-
-        let ttl = match self.ttl {
-            None => None,
-            Some(val) => Some(val.to_string()),
-        };
-
-        Ok(Channel {
-               title: self.title,
-               link: self.link,
-               description: self.description,
-               language: self.language,
-               copyright: self.copyright,
-               managing_editor: self.managing_editor,
-               webmaster: self.webmaster,
-               pub_date: self.pub_date,
-               last_build_date: self.last_build_date,
-               categories: self.categories,
-               generator: self.generator,
-               docs: self.docs,
-               cloud: self.cloud,
-               ttl: ttl,
-               image: self.image,
-               rating: self.rating,
-               text_input: self.text_input,
-               skip_hours: skip_hours,
-               skip_days: self.skip_days,
-               items: self.items,
-               itunes_ext: self.itunes_ext,
-               dublin_core_ext: self.dublin_core_ext,
-               extensions: self.extensions,
-               namespaces: self.namespaces,
-           })
     }
 }
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -157,7 +157,7 @@ impl Channel {
     /// let language_string = "en";
     ///
     /// let channel = ChannelBuilder::new()
-    ///     .language(Some(language_string.to_string()))
+    ///     .language(language_string.to_string())
     ///     .finalize();
     ///
     /// assert_eq!(Some(language_string), channel.language());
@@ -188,7 +188,7 @@ impl Channel {
     ///     "Copyright 2002, Spartanburg Herald-Journal";
     ///
     /// let channel = ChannelBuilder::new()
-    ///     .copyright(Some(copyright_string.to_string()))
+    ///     .copyright(copyright_string.to_string())
     ///     .finalize();
     ///
     /// assert_eq!(Some(copyright_string), channel.copyright());
@@ -219,7 +219,7 @@ impl Channel {
     ///     "chris@jupiterbroadcasting.com (Chris Fisher)";
     ///
     /// let channel = ChannelBuilder::new()
-    ///     .managing_editor(Some(managing_editor_string.to_string()))
+    ///     .managing_editor(managing_editor_string.to_string())
     ///     .finalize();
     ///
     /// assert_eq!(Some(managing_editor_string), channel.managing_editor());
@@ -249,7 +249,7 @@ impl Channel {
     ///     "chris@jupiterbroadcasting.com (Chris Fisher)";
     ///
     /// let channel = ChannelBuilder::new()
-    ///     .webmaster(Some(webmaster_string.to_string()))
+    ///     .webmaster(webmaster_string.to_string())
     ///     .finalize();
     ///
     /// assert_eq!(Some(webmaster_string), channel.webmaster());
@@ -279,7 +279,7 @@ impl Channel {
     /// let pub_date = "Sun, 13 Mar 2016 20:02:02 -0700";
     ///
     /// let channel = ChannelBuilder::new()
-    ///     .pub_date(Some(pub_date.to_string()))
+    ///     .pub_date(pub_date.to_string())
     ///     .finalize();
     ///
     /// assert_eq!(Some(pub_date), channel.pub_date());
@@ -309,7 +309,7 @@ impl Channel {
     /// let last_build_date = "Sun, 13 Mar 2016 20:02:02 -0700";
     ///
     /// let channel = ChannelBuilder::new()
-    ///     .last_build_date(Some(last_build_date.to_string()))
+    ///     .last_build_date(last_build_date.to_string())
     ///     .finalize();
     ///
     /// let local = channel.last_build_date();
@@ -345,7 +345,7 @@ impl Channel {
     ///     .finalize();
     ///
     /// let category_2 = CategoryBuilder::new()
-    ///     .domain(Some("http://jupiterbroadcasting.com".to_string()))
+    ///     .domain("http://jupiterbroadcasting.com".to_string())
     ///     .name("Podcast")
     ///     .finalize();
     ///
@@ -386,7 +386,7 @@ impl Channel {
     /// http://reinventedsoftware.com/feeder/";
     ///
     /// let channel = ChannelBuilder::new()
-    ///     .generator(Some(generator_string.to_string()))
+    ///     .generator(generator_string.to_string())
     ///     .finalize();
     ///
     /// assert_eq!(Some(generator_string), channel.generator());
@@ -416,7 +416,7 @@ impl Channel {
     /// let docs_string = "http://blogs.law.harvard.edu/tech/rss/";
     ///
     /// let channel = ChannelBuilder::new()
-    ///     .docs(Some(docs_string.to_string()))
+    ///     .docs(docs_string.to_string())
     ///     .finalize();
     ///
     /// let docs_option = channel.docs();
@@ -454,7 +454,7 @@ impl Channel {
     ///     .finalize();
     ///
     /// let channel = ChannelBuilder::new()
-    ///     .cloud(Some(cloud))
+    ///     .cloud(cloud)
     ///     .finalize();
     ///
     /// assert!(channel.cloud().is_some());
@@ -484,7 +484,7 @@ impl Channel {
     /// let ttl_num = 60;
     ///
     /// let channel = ChannelBuilder::new()
-    ///     .ttl(Some(ttl_num))
+    ///     .ttl(ttl_num)
     ///     .finalize();
     ///
     /// assert_eq!(Some(ttl_num.to_string().as_str()), channel.ttl());
@@ -521,7 +521,7 @@ impl Channel {
     ///     .finalize();
     ///
     /// let channel = ChannelBuilder::new()
-    ///     .image(Some(image))
+    ///     .image(image)
     ///     .link("http://www.jupiterbroadcasting.com/")
     ///     .finalize();
     ///
@@ -577,7 +577,7 @@ impl Channel {
     ///     .finalize();
     ///
     /// let channel = ChannelBuilder::new()
-    ///     .text_input(Some(text_input))
+    ///     .text_input(text_input)
     ///     .link("http://www.jupiterbroadcasting.com/")
     ///     .finalize();
     ///
@@ -699,8 +699,8 @@ impl Channel {
     /// let title = "Making Music with Linux | LAS 408".to_string();
     ///
     /// let item_1 = ItemBuilder::new()
-    ///     .title(Some(title))
-    ///     .link(Some(link))
+    ///     .title(title)
+    ///     .link(link)
     ///     .description(None)
     ///     .author(None)
     ///     .categories(Vec::new())
@@ -713,7 +713,7 @@ impl Channel {
     /// let item_2 = ItemBuilder::new()
     ///     .title(None)
     ///     .link(None)
-    ///     .description(Some(description))
+    ///     .description(description)
     ///     .author(None)
     ///     .categories(Vec::new())
     ///     .enclosure(None)
@@ -760,8 +760,8 @@ impl Channel {
     /// ITunesOwnerBuilder, ITunesCategoryBuilder};
     ///
     /// let owner = ITunesOwnerBuilder::new()
-    ///     .email(Some("email@example.com".to_string()))
-    ///     .name(Some("name".to_string()))
+    ///     .email("email@example.com".to_string())
+    ///     .name("name".to_string())
     ///     .finalize();
     ///
     /// let subcategory = ITunesCategoryBuilder::new()
@@ -770,27 +770,27 @@ impl Channel {
     ///
     /// let category = ITunesCategoryBuilder::new()
     ///     .text("text")
-    ///     .subcategory(Some(Box::new(subcategory)))
+    ///     .subcategory(Box::new(subcategory))
     ///     .finalize();
     ///
     /// let categories = vec![category];
     ///
     /// let itunes_channel = ITunesChannelExtensionBuilder::new()
-    ///     .author(Some("author".to_string()))
-    ///     .block(Some("block".to_string()))
-    ///     .image(Some("image".to_string()))
-    ///     .explicit(Some("explicit".to_string()))
-    ///     .subtitle(Some("subtitle".to_string()))
-    ///     .summary(Some("summary".to_string()))
-    ///     .keywords(Some("keywords".to_string()))
-    ///     .new_feed_url(Some("new_feed_url".to_string()))
-    ///     .complete(Some("complete".to_string()))
-    ///     .owner(Some(owner))
+    ///     .author("author".to_string())
+    ///     .block("block".to_string())
+    ///     .image("image".to_string())
+    ///     .explicit("explicit".to_string())
+    ///     .subtitle("subtitle".to_string())
+    ///     .summary("summary".to_string())
+    ///     .keywords("keywords".to_string())
+    ///     .new_feed_url("new_feed_url".to_string())
+    ///     .complete("complete".to_string())
+    ///     .owner(owner)
     ///     .categories(categories)
     ///     .finalize();
     ///
     /// let channel = ChannelBuilder::new()
-    ///     .itunes_ext(Some(itunes_channel))
+    ///     .itunes_ext(itunes_channel)
     ///     .finalize();
     ///
     /// assert!(channel.itunes_ext().is_some());
@@ -1002,21 +1002,16 @@ impl Channel {
             }
         };
 
-        let mut channel_cat: Vec<Category> = Vec::new();
+        let mut categories = Vec::new();
         for cat in self.categories() {
-            let domain = match cat.domain() {
-                None => None,
-                Some(val) => Some(val.to_string()),
-            };
-
-            channel_cat.push(CategoryBuilder::new()
-                                 .name(cat.name())
-                                 .domain(domain)
-                                 .validate()?
-                                 .finalize());
+            categories.push(CategoryBuilder::new()
+                                .name(cat.name())
+                                .domain(cat.domain().map(|s| s.into()))
+                                .validate()?
+                                .finalize());
         }
 
-        let mut skip_hours: Vec<i64> = Vec::new();
+        let mut skip_hours = Vec::new();
         for hour in self.skip_hours() {
             skip_hours.push(i64::from_str(hour.as_str())?);
         }
@@ -1064,20 +1059,16 @@ impl Channel {
             }
         };
 
-        let mut items: Vec<Item> = Vec::new();
-        for item in self.items() {
-            let mut item_cat: Vec<Category> = Vec::new();
-            for cat in item.categories() {
-                let domain = match cat.domain() {
-                    None => None,
-                    Some(val) => Some(val.to_string()),
-                };
+        let mut items = Vec::new();
 
-                item_cat.push(CategoryBuilder::new()
-                                  .name(cat.name())
-                                  .domain(domain)
-                                  .validate()?
-                                  .finalize());
+        for item in self.items() {
+            let mut categories = Vec::new();
+            for cat in item.categories() {
+                categories.push(CategoryBuilder::new()
+                                    .name(cat.name())
+                                    .domain(cat.domain().map(|s| s.into()))
+                                    .validate()?
+                                    .finalize());
             }
 
             let enclosure = match item.enclosure() {
@@ -1097,7 +1088,7 @@ impl Channel {
                 Some(gval) => {
                     Some(GuidBuilder::new()
                              .value(gval.value())
-                             .is_permalink(Some(gval.is_permalink()))
+                             .is_permalink(gval.is_permalink())
                              .finalize())
                 }
             };
@@ -1155,7 +1146,7 @@ impl Channel {
                            .author(author)
                            .pub_date(pub_date)
                            .comments(comments)
-                           .categories(item_cat)
+                           .categories(categories)
                            .enclosure(enclosure)
                            .guid(guid)
                            .source(source)
@@ -1223,7 +1214,7 @@ impl Channel {
                .rating(None)
                .ttl(ttl)
                .cloud(cloud)
-               .categories(channel_cat)
+               .categories(categories)
                .image(image)
                .text_input(text_input)
                .skip_hours(skip_hours)
@@ -1595,10 +1586,10 @@ impl ChannelBuilder {
     /// use rss::ChannelBuilder;
     ///
     /// let channel_builder = ChannelBuilder::new()
-    ///     .language(Some("en".to_string()));
+    ///     .language("en".to_string());
     /// ```
-    pub fn language(mut self, language: Option<String>) -> ChannelBuilder {
-        self.language = language;
+    pub fn language<V: Into<Option<String>>>(mut self, language: V) -> ChannelBuilder {
+        self.language = language.into();
         self
     }
 
@@ -1611,10 +1602,10 @@ impl ChannelBuilder {
     /// use rss::ChannelBuilder;
     ///
     /// let channel_builder = ChannelBuilder::new()
-    ///     .copyright(Some("Copyright 2002, Spartanburg Herald-Journal".to_string()));
+    ///     .copyright("Copyright 2002, Spartanburg Herald-Journal".to_string());
     /// ```
-    pub fn copyright(mut self, copyright: Option<String>) -> ChannelBuilder {
-        self.copyright = copyright;
+    pub fn copyright<V: Into<Option<String>>>(mut self, copyright: V) -> ChannelBuilder {
+        self.copyright = copyright.into();
         self
     }
 
@@ -1627,10 +1618,12 @@ impl ChannelBuilder {
     /// use rss::ChannelBuilder;
     ///
     /// let channel_builder = ChannelBuilder::new()
-    ///     .managing_editor(Some("chris@jupiterbroadcasting.com (Chris Fisher)".to_string()));
+    ///     .managing_editor("chris@jupiterbroadcasting.com (Chris Fisher)".to_string());
     /// ```
-    pub fn managing_editor(mut self, managing_editor: Option<String>) -> ChannelBuilder {
-        self.managing_editor = managing_editor;
+    pub fn managing_editor<V>(mut self, managing_editor: V) -> ChannelBuilder
+        where V: Into<Option<String>>
+    {
+        self.managing_editor = managing_editor.into();
         self
     }
 
@@ -1643,10 +1636,10 @@ impl ChannelBuilder {
     /// use rss::ChannelBuilder;
     ///
     /// let channel_builder = ChannelBuilder::new()
-    ///     .webmaster(Some("chris@jupiterbroadcasting.com (Chris Fisher)".to_string()));
+    ///     .webmaster("chris@jupiterbroadcasting.com (Chris Fisher)".to_string());
     /// ```
-    pub fn webmaster(mut self, webmaster: Option<String>) -> ChannelBuilder {
-        self.webmaster = webmaster;
+    pub fn webmaster<V: Into<Option<String>>>(mut self, webmaster: V) -> ChannelBuilder {
+        self.webmaster = webmaster.into();
         self
     }
 
@@ -1659,10 +1652,10 @@ impl ChannelBuilder {
     /// use rss::ChannelBuilder;
     ///
     /// let channel_builder = ChannelBuilder::new()
-    ///     .pub_date(Some("Sun, 13 Mar 2016 20:02:02 -0700".to_string()));
+    ///     .pub_date("Sun, 13 Mar 2016 20:02:02 -0700".to_string());
     /// ```
-    pub fn pub_date(mut self, pub_date: Option<String>) -> ChannelBuilder {
-        self.pub_date = pub_date;
+    pub fn pub_date<V: Into<Option<String>>>(mut self, pub_date: V) -> ChannelBuilder {
+        self.pub_date = pub_date.into();
         self
     }
 
@@ -1675,10 +1668,12 @@ impl ChannelBuilder {
     /// use rss::ChannelBuilder;
     ///
     /// let channel_builder = ChannelBuilder::new()
-    ///     .last_build_date(Some("Sun, 13 Mar 2016 20:02:02 -0700".to_string()));
+    ///     .last_build_date("Sun, 13 Mar 2016 20:02:02 -0700".to_string());
     /// ```
-    pub fn last_build_date(mut self, last_build_date: Option<String>) -> ChannelBuilder {
-        self.last_build_date = last_build_date;
+    pub fn last_build_date<V>(mut self, last_build_date: V) -> ChannelBuilder
+        where V: Into<Option<String>>
+    {
+        self.last_build_date = last_build_date.into();
         self
     }
 
@@ -1696,8 +1691,8 @@ impl ChannelBuilder {
     /// let channel_builder = ChannelBuilder::new()
     ///     .categories(vec![category]);
     /// ```
-    pub fn categories(mut self, categories: Vec<Category>) -> ChannelBuilder {
-        self.categories = categories;
+    pub fn categories<V: Into<Vec<Category>>>(mut self, categories: V) -> ChannelBuilder {
+        self.categories = categories.into();
         self
     }
 
@@ -1713,10 +1708,10 @@ impl ChannelBuilder {
     ///     http://reinventedsoftware.com/feeder/".to_string();
     ///
     /// let channel_builder = ChannelBuilder::new()
-    ///     .generator(Some(generator));
+    ///     .generator(generator);
     /// ```
-    pub fn generator(mut self, generator: Option<String>) -> ChannelBuilder {
-        self.generator = generator;
+    pub fn generator<V: Into<Option<String>>>(mut self, generator: V) -> ChannelBuilder {
+        self.generator = generator.into();
         self
     }
 
@@ -1729,10 +1724,10 @@ impl ChannelBuilder {
     /// use rss::ChannelBuilder;
     ///
     /// let channel_builder = ChannelBuilder::new()
-    ///     .docs(Some("http://blogs.law.harvard.edu/tech/rss/".to_string()));
+    ///     .docs("http://blogs.law.harvard.edu/tech/rss/".to_string());
     /// ```
-    pub fn docs(mut self, docs: Option<String>) -> ChannelBuilder {
-        self.docs = docs;
+    pub fn docs<V: Into<Option<String>>>(mut self, docs: V) -> ChannelBuilder {
+        self.docs = docs.into();
         self
     }
 
@@ -1750,10 +1745,10 @@ impl ChannelBuilder {
     ///     .finalize();
     ///
     /// let channel_builder = ChannelBuilder::new()
-    ///     .cloud(Some(cloud));
+    ///     .cloud(cloud);
     /// ```
-    pub fn cloud(mut self, cloud: Option<Cloud>) -> ChannelBuilder {
-        self.cloud = cloud;
+    pub fn cloud<V: Into<Option<Cloud>>>(mut self, cloud: V) -> ChannelBuilder {
+        self.cloud = cloud.into();
         self
     }
 
@@ -1766,10 +1761,10 @@ impl ChannelBuilder {
     /// use rss::ChannelBuilder;
     ///
     /// let channel_builder = ChannelBuilder::new()
-    ///     .ttl(Some(60));
+    ///     .ttl(60);
     /// ```
-    pub fn ttl(mut self, ttl: Option<i64>) -> ChannelBuilder {
-        self.ttl = ttl;
+    pub fn ttl<V: Into<Option<i64>>>(mut self, ttl: V) -> ChannelBuilder {
+        self.ttl = ttl.into();
         self
     }
 
@@ -1787,10 +1782,10 @@ impl ChannelBuilder {
     ///     .finalize();
     ///
     /// let channel_builder = ChannelBuilder::new()
-    ///     .image(Some(image));
+    ///     .image(image);
     /// ```
-    pub fn image(mut self, image: Option<Image>) -> ChannelBuilder {
-        self.image = image;
+    pub fn image<V: Into<Option<Image>>>(mut self, image: V) -> ChannelBuilder {
+        self.image = image.into();
         self
     }
 
@@ -1802,10 +1797,10 @@ impl ChannelBuilder {
     /// use rss::ChannelBuilder;
     ///
     /// let channel_builder = ChannelBuilder::new()
-    ///     .rating(Some("PG-13".to_string()));
+    ///     .rating("PG-13".to_string());
     /// ```
-    pub fn rating(mut self, rating: Option<String>) -> ChannelBuilder {
-        self.rating = rating;
+    pub fn rating<V: Into<Option<String>>>(mut self, rating: V) -> ChannelBuilder {
+        self.rating = rating.into();
         self
     }
 
@@ -1822,10 +1817,10 @@ impl ChannelBuilder {
     ///     .finalize();
     ///
     /// let channel_builder = ChannelBuilder::new()
-    ///     .text_input(Some(text_input));
+    ///     .text_input(text_input);
     /// ```
-    pub fn text_input(mut self, text_input: Option<TextInput>) -> ChannelBuilder {
-        self.text_input = text_input;
+    pub fn text_input<V: Into<Option<TextInput>>>(mut self, text_input: V) -> ChannelBuilder {
+        self.text_input = text_input.into();
         self
     }
 
@@ -1840,8 +1835,8 @@ impl ChannelBuilder {
     /// let channel_builder = ChannelBuilder::new()
     ///     .skip_hours(vec![0, 12, 18]);
     /// ```
-    pub fn skip_hours(mut self, skip_hours: Vec<i64>) -> ChannelBuilder {
-        self.skip_hours = skip_hours;
+    pub fn skip_hours<V: Into<Vec<i64>>>(mut self, skip_hours: V) -> ChannelBuilder {
+        self.skip_hours = skip_hours.into();
         self
     }
 
@@ -1856,8 +1851,8 @@ impl ChannelBuilder {
     /// let channel_builder = ChannelBuilder::new()
     ///     .skip_days(vec!["Monday".to_string(), "Tuesday".to_string()]);
     /// ```
-    pub fn skip_days(mut self, skip_days: Vec<String>) -> ChannelBuilder {
-        self.skip_days = skip_days;
+    pub fn skip_days<V: Into<Vec<String>>>(mut self, skip_days: V) -> ChannelBuilder {
+        self.skip_days = skip_days.into();
         self
     }
 
@@ -1870,14 +1865,14 @@ impl ChannelBuilder {
     /// use rss::{ChannelBuilder, ItemBuilder};
     ///
     /// let item = ItemBuilder::new()
-    ///     .title(Some("Making Music with Linux | LAS 408".to_string()))
+    ///     .title("Making Music with Linux | LAS 408".to_string())
     ///     .finalize();
     ///
     /// let channel_builder = ChannelBuilder::new()
     ///     .items(vec![item]);
     /// ```
-    pub fn items(mut self, items: Vec<Item>) -> ChannelBuilder {
-        self.items = items;
+    pub fn items<V: Into<Vec<Item>>>(mut self, items: V) -> ChannelBuilder {
+        self.items = items.into();
         self
     }
 
@@ -1892,8 +1887,8 @@ impl ChannelBuilder {
     ///     ITunesCategoryBuilder};
     ///
     /// let owner = ITunesOwnerBuilder::new()
-    ///     .email(Some("email@example.com".to_string()))
-    ///     .name(Some("name".to_string()))
+    ///     .email("email@example.com".to_string())
+    ///     .name("name".to_string())
     ///     .finalize();
     ///
     /// let subcategory = ITunesCategoryBuilder::new()
@@ -1902,48 +1897,50 @@ impl ChannelBuilder {
     ///
     /// let category = ITunesCategoryBuilder::new()
     ///     .text("text")
-    ///     .subcategory(Some(Box::new(subcategory)))
+    ///     .subcategory(Box::new(subcategory))
     ///     .finalize();
     ///
     /// let itunes_channel = ITunesChannelExtensionBuilder::new()
-    ///     .author(Some("author".to_string()))
-    ///     .block(Some("block".to_string()))
-    ///     .image(Some("image".to_string()))
-    ///     .explicit(Some("explicit".to_string()))
-    ///     .subtitle(Some("subtitle".to_string()))
-    ///     .summary(Some("summary".to_string()))
-    ///     .keywords(Some("keywords".to_string()))
-    ///     .new_feed_url(Some("new_feed_url".to_string()))
-    ///     .complete(Some("complete".to_string()))
-    ///     .owner(Some(owner))
+    ///     .author("author".to_string())
+    ///     .block("block".to_string())
+    ///     .image("image".to_string())
+    ///     .explicit("explicit".to_string())
+    ///     .subtitle("subtitle".to_string())
+    ///     .summary("summary".to_string())
+    ///     .keywords("keywords".to_string())
+    ///     .new_feed_url("new_feed_url".to_string())
+    ///     .complete("complete".to_string())
+    ///     .owner(owner)
     ///     .categories(vec![category])
     ///     .finalize();
     ///
     /// let channel_builder = ChannelBuilder::new()
-    ///     .itunes_ext(Some(itunes_channel));
+    ///     .itunes_ext(itunes_channel);
     /// ```
-    pub fn itunes_ext(mut self, itunes_ext: Option<ITunesChannelExtension>) -> ChannelBuilder {
-        self.itunes_ext = itunes_ext;
+    pub fn itunes_ext<V>(mut self, itunes_ext: V) -> ChannelBuilder
+        where V: Into<Option<ITunesChannelExtension>>
+    {
+        self.itunes_ext = itunes_ext.into();
         self
     }
 
     /// Set the optional dublin_core_ext that exists under `Channel`.
-    pub fn dublin_core_ext(mut self,
-                           dublin_core_ext: Option<DublinCoreExtension>)
-                           -> ChannelBuilder {
-        self.dublin_core_ext = dublin_core_ext;
+    pub fn dublin_core_ext<V>(mut self, dublin_core_ext: V) -> ChannelBuilder
+        where V: Into<Option<DublinCoreExtension>>
+    {
+        self.dublin_core_ext = dublin_core_ext.into();
         self
     }
 
     /// Set the extensions that exists under `Channel`.
-    pub fn extensions(mut self, extensions: ExtensionMap) -> ChannelBuilder {
-        self.extensions = extensions;
+    pub fn extensions<V: Into<ExtensionMap>>(mut self, extensions: V) -> ChannelBuilder {
+        self.extensions = extensions.into();
         self
     }
 
     /// Set the namespaces that exists under `Channel`.
-    pub fn namespaces(mut self, namespaces: HashMap<String, String>) -> ChannelBuilder {
-        self.namespaces = namespaces;
+    pub fn namespaces<V: Into<HashMap<String, String>>>(mut self, namespaces: V) -> ChannelBuilder {
+        self.namespaces = namespaces.into();
         self
     }
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -84,79 +84,76 @@ pub struct Channel {
 }
 
 impl Channel {
-    /// Get the title that exists under `Channel`.
+    /// Return the title of this `Channel`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
-    /// let title = "The Linux Action Show! OGG";
+    /// let title = "The Linux Action Show! OGG".to_string();
     ///
-    /// let channel = ChannelBuilder::new()
-    ///     .title(title)
+    /// let channel = ChannelBuilder::default()
+    ///     .title(title.as_str())
     ///     .finalize();
     ///
-    /// assert_eq!(title.to_string(), channel.title());
+    /// assert_eq!(title, channel.title());
     /// ```
     pub fn title(&self) -> &str {
         self.title.as_str()
     }
 
-
-    /// Get the link that exists under `Channel`.
+    /// Return the web site URL for this `Channel`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
-    /// let link = "http://www.jupiterbroadcasting.com/";
+    /// let link = "http://www.jupiterbroadcasting.com/".to_string();
     ///
-    /// let channel = ChannelBuilder::new()
-    ///     .link(link)
+    /// let channel = ChannelBuilder::default()
+    ///     .link(link.as_str())
     ///     .finalize();
     ///
-    /// assert_eq!(link.to_string(), channel.link());
+    /// assert_eq!(link, channel.link());
     /// ```
     pub fn link(&self) -> &str {
         self.link.as_str()
     }
 
-
-    /// Get the description that exists under `Channel`.
+    /// Return the description of this `Channel`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
-    /// let description = "Ogg Vorbis audio versions of The Linux ".to_string()
-    /// + "Action Show! A show that covers everything geeks care about in the "
-    /// + "computer industry. Get a solid dose of Linux, gadgets, news events "
-    /// + "and much more!";
+    /// let description = "Ogg Vorbis audio versions of The Linux \
+    ///     Action Show! A show that covers everything geeks care about in the \
+    ///     computer industry. Get a solid dose of Linux, gadgets, news events \
+    ///     and much more!".to_string();
     ///
-    /// let channel = ChannelBuilder::new()
-    ///     .description(description.as_ref())
+    /// let channel = ChannelBuilder::default()
+    ///     .description(description.as_str())
     ///     .finalize();
     ///
-    /// assert_eq!(description.to_string(), channel.description());
+    /// assert_eq!(description, channel.description());
     /// ```
     pub fn description(&self) -> &str {
         self.description.as_str()
     }
 
-
-    /// Get the optional language that exists under `Channel`.
+    /// Return the langauge of this `Channel`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
-    /// let language_string = "en";
+    /// let language_string = "en-US";
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let channel = ChannelBuilder::default()
     ///     .language(language_string.to_string())
     ///     .finalize();
     ///
@@ -164,9 +161,9 @@ impl Channel {
     /// ```
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let channel = ChannelBuilder::default()
     ///     .language(None)
     ///     .finalize();
     ///
@@ -176,28 +173,26 @@ impl Channel {
         self.language.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the optional copyright that exists under `Channel`.
+    /// Return the copyright notice for the content of this `Channel`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
-    /// let copyright_string =
-    ///     "Copyright 2002, Spartanburg Herald-Journal";
+    /// let copyright = "Copyright 2002, Spartanburg Herald-Journal";
     ///
-    /// let channel = ChannelBuilder::new()
-    ///     .copyright(copyright_string.to_string())
+    /// let channel = ChannelBuilder::default()
+    ///     .copyright(copyright.to_string())
     ///     .finalize();
     ///
-    /// assert_eq!(Some(copyright_string), channel.copyright());
+    /// assert_eq!(Some(copyright), channel.copyright());
     /// ```
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let channel = ChannelBuilder::default()
     ///     .copyright(None)
     ///     .finalize();
     ///
@@ -207,28 +202,26 @@ impl Channel {
         self.copyright.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the optional managing editor that exists under `Channel`.
+    /// Return the email address for the managing editor of this `Channel`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
-    /// let managing_editor_string =
-    ///     "chris@jupiterbroadcasting.com (Chris Fisher)";
+    /// let managing_editor = "chris@jupiterbroadcasting.com (Chris Fisher)";
     ///
-    /// let channel = ChannelBuilder::new()
-    ///     .managing_editor(managing_editor_string.to_string())
+    /// let channel = ChannelBuilder::default()
+    ///     .managing_editor(managing_editor.to_string())
     ///     .finalize();
     ///
-    /// assert_eq!(Some(managing_editor_string), channel.managing_editor());
+    /// assert_eq!(Some(managing_editor), channel.managing_editor());
     /// ```
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let channel = ChannelBuilder::default()
     ///     .managing_editor(None)
     ///     .finalize();
     ///
@@ -238,27 +231,26 @@ impl Channel {
         self.managing_editor.as_ref().map(|s| s.as_str())
     }
 
-    /// Get the optional web master that exists under `Channel`.
+    /// Return the email address for webmaster of this `Channel`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
-    /// let webmaster_string =
-    ///     "chris@jupiterbroadcasting.com (Chris Fisher)";
+    /// let webmaster = "chris@jupiterbroadcasting.com (Chris Fisher)";
     ///
-    /// let channel = ChannelBuilder::new()
-    ///     .webmaster(webmaster_string.to_string())
+    /// let channel = ChannelBuilder::default()
+    ///     .webmaster(webmaster.to_string())
     ///     .finalize();
     ///
-    /// assert_eq!(Some(webmaster_string), channel.webmaster());
+    /// assert_eq!(Some(webmaster), channel.webmaster());
     /// ```
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let channel = ChannelBuilder::default()
     ///     .webmaster(None)
     ///     .finalize();
     ///
@@ -268,17 +260,16 @@ impl Channel {
         self.webmaster.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the optional pub date that exists under `Channel`.
+    /// Return the publication date for the content of this `Channel`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
     /// let pub_date = "Sun, 13 Mar 2016 20:02:02 -0700";
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let channel = ChannelBuilder::default()
     ///     .pub_date(pub_date.to_string())
     ///     .finalize();
     ///
@@ -286,9 +277,9 @@ impl Channel {
     /// ```
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let channel = ChannelBuilder::default()
     ///     .pub_date(None)
     ///     .finalize();
     ///
@@ -298,30 +289,26 @@ impl Channel {
         self.pub_date.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the optional last build date that exists under `Channel`.
+    /// Return the time that the content of this `Channel` was last changed.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
     /// let last_build_date = "Sun, 13 Mar 2016 20:02:02 -0700";
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let channel = ChannelBuilder::default()
     ///     .last_build_date(last_build_date.to_string())
     ///     .finalize();
-    ///
-    /// let local = channel.last_build_date();
-    /// assert!(local.is_some());
     ///
     /// assert_eq!(Some(last_build_date), channel.last_build_date());
     /// ```
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let channel = ChannelBuilder::default()
     ///     .last_build_date(None)
     ///     .finalize();
     ///
@@ -331,40 +318,30 @@ impl Channel {
         self.last_build_date.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the categories that exists under `Channel`.
+    /// Return the categories that this `Channel` belongs to.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel, CategoryBuilder};
+    /// use rss::{ChannelBuilder, CategoryBuilder};
     ///
-    /// let category_1 = CategoryBuilder::new()
-    ///     .domain(None)
-    ///     .name("Media")
-    ///     .finalize();
-    ///
-    /// let category_2 = CategoryBuilder::new()
-    ///     .domain("http://jupiterbroadcasting.com".to_string())
+    /// let category = CategoryBuilder::default()
     ///     .name("Podcast")
     ///     .finalize();
     ///
-    /// let categories_vec = vec![category_1, category_2];
+    /// let categories = vec![category];
     ///
-    /// let channel = ChannelBuilder::new()
-    ///     .categories(categories_vec.clone())
+    /// let channel = ChannelBuilder::default()
+    ///     .categories(categories.clone())
     ///     .finalize();
     ///
-    /// let categories = channel.categories();
-    /// assert!(!categories.is_empty());
-    ///
-    /// assert_eq!(categories_vec.clone().len(), categories.len());
+    /// assert_eq!(categories.as_slice(), channel.categories());
     /// ```
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let channel = ChannelBuilder::default()
     ///     .categories(Vec::new())
     ///     .finalize();
     ///
@@ -374,28 +351,27 @@ impl Channel {
         &self.categories
     }
 
-
-    /// Get the optional generator that exists under `Channel`.
+    /// Return the name of the program used to generate the contents of this `Channel`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
-    /// let generator_string = "Feeder 2.5.12(2294); Mac OS X Version 10.9.5 (Build 13F34)
-    /// http://reinventedsoftware.com/feeder/";
+    /// let generator = "Feeder 2.5.12(2294); Mac OS X Version 10.9.5 (Build 13F34) \
+    ///     http://reinventedsoftware.com/feeder/";
     ///
-    /// let channel = ChannelBuilder::new()
-    ///     .generator(generator_string.to_string())
+    /// let channel = ChannelBuilder::default()
+    ///     .generator(generator.to_string())
     ///     .finalize();
     ///
-    /// assert_eq!(Some(generator_string), channel.generator());
+    /// assert_eq!(Some(generator), channel.generator());
     /// ```
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let channel = ChannelBuilder::default()
     ///     .generator(None)
     ///     .finalize();
     ///
@@ -405,30 +381,26 @@ impl Channel {
         self.generator.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the optional docs that exists under `Channel`.
+    /// Return a URL that points to the documentation of the RSS format used in this `Channel`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
-    /// let docs_string = "http://blogs.law.harvard.edu/tech/rss/";
+    /// let docs = "http://blogs.law.harvard.edu/tech/rss/";
     ///
-    /// let channel = ChannelBuilder::new()
-    ///     .docs(docs_string.to_string())
+    /// let channel = ChannelBuilder::default()
+    ///     .docs(docs.to_string())
     ///     .finalize();
     ///
-    /// let docs_option = channel.docs();
-    /// assert!(docs_option.is_some());
-    ///
-    /// assert_eq!(Some(docs_string), channel.docs());
+    /// assert_eq!(Some(docs), channel.docs());
     /// ```
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let channel = ChannelBuilder::default()
     ///     .docs(None)
     ///     .finalize();
     ///
@@ -438,14 +410,15 @@ impl Channel {
         self.docs.as_ref().map(|s| s.as_str())
     }
 
-    /// Get the optional cloud that exists under `Channel`.
+    /// Return the information used to register with a cloud for notifications of updates to the
+    /// `Channel`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel, CloudBuilder};
+    /// use rss::{ChannelBuilder, CloudBuilder};
     ///
-    /// let cloud = CloudBuilder::new()
+    /// let cloud = CloudBuilder::default()
     ///     .domain("http://rpc.sys.com/")
     ///     .port(80)
     ///     .path("/RPC2")
@@ -453,7 +426,7 @@ impl Channel {
     ///     .protocol("soap")
     ///     .finalize();
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let channel = ChannelBuilder::default()
     ///     .cloud(cloud)
     ///     .finalize();
     ///
@@ -461,9 +434,9 @@ impl Channel {
     /// ```
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let channel = ChannelBuilder::default()
     ///     .cloud(None)
     ///     .finalize();
     ///
@@ -473,27 +446,27 @@ impl Channel {
         self.cloud.as_ref()
     }
 
-
-    /// Get the optional ttl that exists under `Channel`.
+    /// Return the time to live of this `Channel`. This indicates the number of minutes the
+    /// `Channel` can be cached before needing to be refreshed.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::{ChannelBuilder, Channel};
     ///
-    /// let ttl_num = 60;
+    /// let ttl = 60;
     ///
-    /// let channel = ChannelBuilder::new()
-    ///     .ttl(ttl_num)
+    /// let channel = ChannelBuilder::default()
+    ///     .ttl(ttl)
     ///     .finalize();
     ///
-    /// assert_eq!(Some(ttl_num.to_string().as_str()), channel.ttl());
+    /// assert_eq!(Some(ttl.to_string().as_str()), channel.ttl());
     /// ```
     ///
     /// ```
     /// use rss::{ChannelBuilder, Channel};
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let channel = ChannelBuilder::default()
     ///     .ttl(None)
     ///     .finalize();
     ///
@@ -503,37 +476,29 @@ impl Channel {
         self.ttl.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the optional image that exists under `Channel`.
+    /// Return the image to be displayed with this `Channel`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel, ImageBuilder};
+    /// use rss::{ChannelBuilder, ImageBuilder};
     ///
-    /// let image = ImageBuilder::new()
-    ///     .link("http://www.jupiterbroadcasting.com")
+    /// let image = ImageBuilder::default()
     ///     .url("http://jupiterbroadcasting.com/images/LAS-300-Badge.jpg")
-    ///     .title("LAS 300 Logo")
-    ///     .height(None)
-    ///     .width(None)
-    ///     .description(None)
     ///     .finalize();
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let channel = ChannelBuilder::default()
     ///     .image(image)
-    ///     .link("http://www.jupiterbroadcasting.com/")
     ///     .finalize();
     ///
     /// assert!(channel.image().is_some());
     /// ```
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let channel = ChannelBuilder::default()
     ///     .image(None)
-    ///     .link("http://www.jupiterbroadcasting.com/")
     ///     .finalize();
     ///
     /// assert!(channel.image().is_none());
@@ -542,17 +507,15 @@ impl Channel {
         self.image.as_ref()
     }
 
-
-    /// Get the optional rating that exists under `Channel`.
+    /// Return the [PICS](https://www.w3.org/PICS/) rating for this `Channel`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let channel = ChannelBuilder::default()
     ///     .rating(None)
-    ///     .link("http://www.jupiterbroadcasting.com/")
     ///     .finalize();
     ///
     /// assert!(channel.rating().is_none());
@@ -561,35 +524,32 @@ impl Channel {
         self.rating.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the optional text input that exists under `Channel`.
+    /// Return the information for a text box to be displayed with this `Channel`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel, TextInputBuilder};
+    /// use rss::{ChannelBuilder, TextInputBuilder};
     ///
-    /// let text_input = TextInputBuilder::new()
+    /// let text_input = TextInputBuilder::default()
     ///     .title("Enter Comment")
     ///     .description("Provided Feedback")
     ///     .name("Comment")
     ///     .link("http://www.example.com/feedback")
     ///     .finalize();
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let channel = ChannelBuilder::default()
     ///     .text_input(text_input)
-    ///     .link("http://www.jupiterbroadcasting.com/")
     ///     .finalize();
     ///
     /// assert!(channel.text_input().is_some());
     /// ```
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let channel = ChannelBuilder::default()
     ///     .text_input(None)
-    ///     .link("http://www.jupiterbroadcasting.com/")
     ///     .finalize();
     ///
     /// assert!(channel.text_input().is_none());
@@ -598,37 +558,28 @@ impl Channel {
         self.text_input.as_ref()
     }
 
-    /// Get the skip hours that exists under `Channel`.
+    /// Return the hours that aggregators can skip for refreshing content.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
-    /// let skip_hours_vec: Vec<i64> = vec![6,7,8,14,22];
+    /// let skip_hours = vec![6, 7, 8, 14, 22];
     ///
-    /// let channel = ChannelBuilder::new()
-    ///     .skip_hours(skip_hours_vec.clone())
-    ///     .link("http://www.jupiterbroadcasting.com/")
+    /// let channel = ChannelBuilder::default()
+    ///     .skip_hours(skip_hours.clone())
     ///     .finalize();
     ///
-    /// let skip_hours  = channel.skip_hours();
-    /// assert!(!skip_hours.is_empty());
-    ///
-    /// let len = skip_hours_vec.clone().len();
-    /// assert_eq!(len, skip_hours.len());
-    ///
-    /// for x in 0..len {
-    ///     assert_eq!(skip_hours_vec[x].to_string(), skip_hours[x]);
-    /// }
+    /// let skip_hours_str = skip_hours.iter().map(|n| n.to_string()).collect::<Vec<_>>();
+    /// assert_eq!(skip_hours_str.as_slice(), channel.skip_hours());
     /// ```
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let channel = ChannelBuilder::default()
     ///     .skip_hours(Vec::new())
-    ///     .link("http://www.jupiterbroadcasting.com/")
     ///     .finalize();
     ///
     /// assert!(channel.skip_hours().is_empty());
@@ -637,39 +588,27 @@ impl Channel {
         &self.skip_hours
     }
 
-
-    /// Get the skip days that exists under `Channel`.
+    /// Return the days that aggregators can skip for refreshing content.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::{ChannelBuilder, Channel};
     ///
-    /// let skip_days_vec: Vec<String> = vec!["Monday".to_string(), "Sunday".to_string(),
-    ///     "Thursday".to_string(), "Wednesday".to_string()];
+    /// let skip_days = vec!["Monday".to_string(), "Sunday".to_string()];
     ///
-    /// let channel = ChannelBuilder::new()
-    ///     .skip_days(skip_days_vec.clone())
-    ///     .link("http://www.jupiterbroadcasting.com/")
+    /// let channel = ChannelBuilder::default()
+    ///     .skip_days(skip_days.clone())
     ///     .finalize();
     ///
-    /// let skip_days = channel.skip_days();
-    /// assert!(!skip_days.is_empty());
-    ///
-    /// let len = skip_days_vec.clone().len();
-    /// assert_eq!(len, skip_days.len());
-    ///
-    /// for x in 0..len {
-    ///     assert_eq!(skip_days_vec[x], skip_days[x].clone());
-    /// }
+    /// assert_eq!(skip_days.as_slice(), channel.skip_days());
     /// ```
     ///
     /// ```
     /// use rss::{ChannelBuilder, Channel};
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let channel = ChannelBuilder::default()
     ///     .skip_days(Vec::new())
-    ///     .link("http://www.jupiterbroadcasting.com/")
     ///     .finalize();
     ///
     /// assert!(channel.skip_days().is_empty());
@@ -678,69 +617,33 @@ impl Channel {
         &self.skip_days
     }
 
-
-    /// Get the items that exists under `Channel`.
+    /// Return the `Item`s in this `Channel`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel, ItemBuilder};
-    ///
-    /// let link = "http://www.jupiterbroadcasting.com/97561/making-music-with-linux-las-408/"
-    ///     .to_string();
-    ///
-    /// let description = "<![CDATA[<p>In special Rasberry Pi 3 \
-    ///     edition of the show we look at the new hardware, review & chat with \
-    ///     Mycroft CTO Ryan Sipes on how important the Raspberry Pi is for \
-    ///     development of their open artificial intelligence platform & get \
-    ///     the latest news.</p><p>Plus replacing Spotify on Linux, the new \
-    ///     Microsoft lock-in, our hosts face a moral quandary & more!</p>]]>".to_string();
+    /// use rss::{ChannelBuilder, ItemBuilder};
     ///
     /// let title = "Making Music with Linux | LAS 408".to_string();
     ///
-    /// let item_1 = ItemBuilder::new()
+    /// let item = ItemBuilder::default()
     ///     .title(title)
-    ///     .link(link)
-    ///     .description(None)
-    ///     .author(None)
-    ///     .categories(Vec::new())
-    ///     .enclosure(None)
-    ///     .guid(None)
-    ///     .pub_date(None)
-    ///     .source(None)
     ///     .finalize();
     ///
-    /// let item_2 = ItemBuilder::new()
-    ///     .title(None)
-    ///     .link(None)
-    ///     .description(description)
-    ///     .author(None)
-    ///     .categories(Vec::new())
-    ///     .enclosure(None)
-    ///     .guid(None)
-    ///     .pub_date(None)
-    ///     .source(None)
+    /// let items = vec![item];
+    ///
+    /// let channel = ChannelBuilder::default()
+    ///     .items(items.clone())
     ///     .finalize();
     ///
-    /// let items_vec = vec![item_1, item_2];
-    ///
-    /// let channel = ChannelBuilder::new()
-    ///     .items(items_vec.clone())
-    ///     .link("http://www.jupiterbroadcasting.com/")
-    ///     .finalize();
-    ///
-    /// let items = channel.items();
-    /// assert!(!items.is_empty());
-    ///
-    /// assert_eq!(items_vec.clone().len(), items.len());
+    /// assert_eq!(items.as_slice(), channel.items());
     /// ```
     ///
     /// ```
     /// use rss::{ChannelBuilder, Channel};
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let channel = ChannelBuilder::default()
     ///     .items(Vec::new())
-    ///     .link("http://www.jupiterbroadcasting.com/")
     ///     .finalize();
     ///
     /// assert!(channel.items().is_empty());
@@ -749,57 +652,29 @@ impl Channel {
         &self.items
     }
 
-
-    /// Get the optional `ITunesChannelExtension` under `Channel`.
+    /// Return the `ITunesChannelExtension` for this `Channel`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder,
-    /// ITunesOwnerBuilder, ITunesCategoryBuilder};
+    /// use rss::ChannelBuilder;
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder};
     ///
-    /// let owner = ITunesOwnerBuilder::new()
-    ///     .email("email@example.com".to_string())
-    ///     .name("name".to_string())
-    ///     .finalize();
-    ///
-    /// let subcategory = ITunesCategoryBuilder::new()
-    ///     .text("text")
-    ///     .finalize();
-    ///
-    /// let category = ITunesCategoryBuilder::new()
-    ///     .text("text")
-    ///     .subcategory(Box::new(subcategory))
-    ///     .finalize();
-    ///
-    /// let categories = vec![category];
-    ///
-    /// let itunes_channel = ITunesChannelExtensionBuilder::new()
+    /// let itunes_ext = ITunesChannelExtensionBuilder::default()
     ///     .author("author".to_string())
-    ///     .block("block".to_string())
-    ///     .image("image".to_string())
-    ///     .explicit("explicit".to_string())
-    ///     .subtitle("subtitle".to_string())
-    ///     .summary("summary".to_string())
-    ///     .keywords("keywords".to_string())
-    ///     .new_feed_url("new_feed_url".to_string())
-    ///     .complete("complete".to_string())
-    ///     .owner(owner)
-    ///     .categories(categories)
     ///     .finalize();
     ///
-    /// let channel = ChannelBuilder::new()
-    ///     .itunes_ext(itunes_channel)
+    /// let channel = ChannelBuilder::default()
+    ///     .itunes_ext(itunes_ext)
     ///     .finalize();
     ///
     /// assert!(channel.itunes_ext().is_some());
     /// ```
     ///
     /// ```
-    /// use rss::{ChannelBuilder, Channel};
+    /// use rss::ChannelBuilder;
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let channel = ChannelBuilder::default()
     ///     .itunes_ext(None)
     ///     .finalize();
     ///
@@ -809,17 +684,17 @@ impl Channel {
         self.itunes_ext.as_ref()
     }
 
-    /// Get the optional `DublinCoreExtension` under `Channel`.
+    /// Return the `DublinCoreExtension` for this `Channel`.
     pub fn dublin_core_ext(&self) -> Option<&DublinCoreExtension> {
         self.dublin_core_ext.as_ref()
     }
 
-    /// Get the `ExtensionMap` under `Channel`.
+    /// Return the extensions for this `Channel`.
     pub fn extensions(&self) -> &ExtensionMap {
         &self.extensions
     }
 
-    /// Get the namespaces under `Channel`.
+    /// Return the namespaces for this `Channel`.
     pub fn namespaces(&self) -> &HashMap<String, String> {
         &self.namespaces
     }
@@ -971,27 +846,22 @@ impl Channel {
         Ok(writer.into_inner())
     }
 
-    /// Validate `Channel`
+    /// Validate the contents of this `Channel`.
     ///
     /// ## Examples
-    /// ```
-    /// extern crate rss;
     ///
+    /// ```
     /// use rss::Channel;
     ///
-    /// fn main()
-    /// {
-    ///     let input = include_str!("tests/data/rss2sample.xml");
-    ///
-    ///     let channel = input.parse::<Channel>().unwrap();
-    ///     channel.validate().unwrap();
-    /// }
+    /// let input = include_str!("tests/data/rss2sample.xml");
+    /// let channel = input.parse::<Channel>().unwrap();
+    /// channel.validate().unwrap();
     /// ```
     pub fn validate(&self) -> Result<Channel, Error> {
         let cloud = match self.cloud() {
             None => None,
             Some(val) => {
-                Some(CloudBuilder::new()
+                Some(CloudBuilder::default()
                          .domain(val.domain())
                          .port(i64::from_str(val.port())?)
                          .path(val.path())
@@ -1004,7 +874,7 @@ impl Channel {
 
         let mut categories = Vec::new();
         for cat in self.categories() {
-            categories.push(CategoryBuilder::new()
+            categories.push(CategoryBuilder::default()
                                 .name(cat.name())
                                 .domain(cat.domain().map(|s| s.into()))
                                 .validate()?
@@ -1034,7 +904,7 @@ impl Channel {
                     Some(dval) => Some(dval.to_string()),
                 };
 
-                Some(ImageBuilder::new()
+                Some(ImageBuilder::default()
                          .url(val.url())
                          .title(val.title())
                          .link(val.link())
@@ -1049,7 +919,7 @@ impl Channel {
         let text_input = match self.text_input() {
             None => None,
             Some(val) => {
-                Some(TextInputBuilder::new()
+                Some(TextInputBuilder::default()
                          .title(val.title())
                          .description(val.description())
                          .name(val.name())
@@ -1064,7 +934,7 @@ impl Channel {
         for item in self.items() {
             let mut categories = Vec::new();
             for cat in item.categories() {
-                categories.push(CategoryBuilder::new()
+                categories.push(CategoryBuilder::default()
                                     .name(cat.name())
                                     .domain(cat.domain().map(|s| s.into()))
                                     .validate()?
@@ -1074,7 +944,7 @@ impl Channel {
             let enclosure = match item.enclosure() {
                 None => None,
                 Some(eval) => {
-                    Some(EnclosureBuilder::new()
+                    Some(EnclosureBuilder::default()
                              .url(eval.url())
                              .length(i64::from_str(eval.length())?)
                              .mime_type(eval.mime_type())
@@ -1086,7 +956,7 @@ impl Channel {
             let guid = match item.guid() {
                 None => None,
                 Some(gval) => {
-                    Some(GuidBuilder::new()
+                    Some(GuidBuilder::default()
                              .value(gval.value())
                              .is_permalink(gval.is_permalink())
                              .finalize())
@@ -1101,7 +971,7 @@ impl Channel {
                         Some(tval) => Some(tval.to_string()),
                     };
 
-                    Some(SourceBuilder::new()
+                    Some(SourceBuilder::default()
                              .url(sval.url())
                              .title(title)
                              .validate()?
@@ -1139,7 +1009,7 @@ impl Channel {
                 Some(val) => Some(val.to_string()),
             };
 
-            items.push(ItemBuilder::new()
+            items.push(ItemBuilder::default()
                            .title(title)
                            .link(link)
                            .description(description)
@@ -1199,7 +1069,7 @@ impl Channel {
             Some(val) => Some(val.to_string()),
         };
 
-        Ok(ChannelBuilder::new()
+        Ok(ChannelBuilder::default()
                .title(self.title())
                .link(self.link())
                .description(self.description())
@@ -1481,7 +1351,7 @@ impl FromStr for Channel {
     }
 }
 
-/// This `ChannelBuilder` struct creates the `Channel`.
+/// A builder used to create a `Channel`.
 #[derive(Debug, Clone, Default)]
 pub struct ChannelBuilder {
     title: String,
@@ -1511,53 +1381,41 @@ pub struct ChannelBuilder {
 }
 
 impl ChannelBuilder {
-    /// Construct a new `ChannelBuilder` and return default values.
+    /// Set the title of the `Channel`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let channel_builder = ChannelBuilder::new();
-    /// ```
-    pub fn new() -> ChannelBuilder {
-        ChannelBuilder::default()
-    }
-
-
-    /// Set the title that exists under `Channel`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rss::ChannelBuilder;
-    ///
-    /// let channel_builder = ChannelBuilder::new()
+    /// let builder = ChannelBuilder::default()
     ///     .title("The Linux Action Show! OGG");
     /// ```
-    pub fn title<S: Into<String>>(mut self, title: S) -> ChannelBuilder {
+    pub fn title<S>(mut self, title: S) -> ChannelBuilder
+        where S: Into<String>
+    {
         self.title = title.into();
         self
     }
 
-
-    /// Set the link that exists under `Channel`.
+    /// Set the web site URL for the `Channel`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let channel_builder = ChannelBuilder::new()
+    /// let builder = ChannelBuilder::default()
     ///     .link("http://www.jupiterbroadcasting.com");
     /// ```
-    pub fn link<S: Into<String>>(mut self, link: S) -> ChannelBuilder {
+    pub fn link<S>(mut self, link: S) -> ChannelBuilder
+        where S: Into<String>
+    {
         self.link = link.into();
         self
     }
 
-
-    /// Set the description that exists under `Channel`.
+    /// Set the description of the `Channel`.
     ///
     /// # Examples
     ///
@@ -1569,55 +1427,58 @@ impl ChannelBuilder {
     ///     computer industry. Get a solid dose of Linux, gadgets, news events \
     ///     and much more!".to_string();
     ///
-    /// let channel_builder = ChannelBuilder::new()
+    /// let builder = ChannelBuilder::default()
     ///     .description(description);
     /// ```
-    pub fn description<S: Into<String>>(mut self, description: S) -> ChannelBuilder {
+    pub fn description<S>(mut self, description: S) -> ChannelBuilder
+        where S: Into<String>
+    {
         self.description = description.into();
         self
     }
 
-
-    /// Set the optional language that exists under `Channel`.
+    /// Set the language of the `Channel`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let channel_builder = ChannelBuilder::new()
+    /// let builder = ChannelBuilder::default()
     ///     .language("en".to_string());
     /// ```
-    pub fn language<V: Into<Option<String>>>(mut self, language: V) -> ChannelBuilder {
+    pub fn language<V>(mut self, language: V) -> ChannelBuilder
+        where V: Into<Option<String>>
+    {
         self.language = language.into();
         self
     }
 
-
-    /// Set the optional copyright that exists under `Channel`.
+    /// Set the copyright notice for the content of the `Channel`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let channel_builder = ChannelBuilder::new()
+    /// let builder = ChannelBuilder::default()
     ///     .copyright("Copyright 2002, Spartanburg Herald-Journal".to_string());
     /// ```
-    pub fn copyright<V: Into<Option<String>>>(mut self, copyright: V) -> ChannelBuilder {
+    pub fn copyright<V>(mut self, copyright: V) -> ChannelBuilder
+        where V: Into<Option<String>>
+    {
         self.copyright = copyright.into();
         self
     }
 
-
-    /// Set the optional managing editor that exists under `Channel`.
+    /// Set the email address for the managing editor of the `Channel`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let channel_builder = ChannelBuilder::new()
+    /// let builder = ChannelBuilder::default()
     ///     .managing_editor("chris@jupiterbroadcasting.com (Chris Fisher)".to_string());
     /// ```
     pub fn managing_editor<V>(mut self, managing_editor: V) -> ChannelBuilder
@@ -1627,47 +1488,48 @@ impl ChannelBuilder {
         self
     }
 
-
-    /// Set the optional web master that exists under `Channel`.
+    /// Set the email address for the webmaster of the `Channel`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let channel_builder = ChannelBuilder::new()
+    /// let builder = ChannelBuilder::default()
     ///     .webmaster("chris@jupiterbroadcasting.com (Chris Fisher)".to_string());
     /// ```
-    pub fn webmaster<V: Into<Option<String>>>(mut self, webmaster: V) -> ChannelBuilder {
+    pub fn webmaster<V>(mut self, webmaster: V) -> ChannelBuilder
+        where V: Into<Option<String>>
+    {
         self.webmaster = webmaster.into();
         self
     }
 
-
-    /// Set the optional pub date that exists under `Channel`.
+    /// Set the publication date for the content of the `Channel`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let channel_builder = ChannelBuilder::new()
+    /// let builder = ChannelBuilder::default()
     ///     .pub_date("Sun, 13 Mar 2016 20:02:02 -0700".to_string());
     /// ```
-    pub fn pub_date<V: Into<Option<String>>>(mut self, pub_date: V) -> ChannelBuilder {
+    pub fn pub_date<V>(mut self, pub_date: V) -> ChannelBuilder
+        where V: Into<Option<String>>
+    {
         self.pub_date = pub_date.into();
         self
     }
 
-
-    /// Set the optional last build date that exists under `Channel`.
+    /// Set the time that the content of the `Channel` was last changed.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let channel_builder = ChannelBuilder::new()
+    /// let builder = ChannelBuilder::default()
     ///     .last_build_date("Sun, 13 Mar 2016 20:02:02 -0700".to_string());
     /// ```
     pub fn last_build_date<V>(mut self, last_build_date: V) -> ChannelBuilder
@@ -1677,27 +1539,28 @@ impl ChannelBuilder {
         self
     }
 
-
-    /// Set the optional categories that exists under `Channel`.
+    /// Set the categories that the `Channel` belongs to.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::{ChannelBuilder, CategoryBuilder};
     ///
-    /// let category = CategoryBuilder::new()
+    /// let category = CategoryBuilder::default()
+    ///     .name("Podcast")
     ///     .finalize();
     ///
-    /// let channel_builder = ChannelBuilder::new()
+    /// let builder = ChannelBuilder::default()
     ///     .categories(vec![category]);
     /// ```
-    pub fn categories<V: Into<Vec<Category>>>(mut self, categories: V) -> ChannelBuilder {
+    pub fn categories<V>(mut self, categories: V) -> ChannelBuilder
+        where V: Into<Vec<Category>>
+    {
         self.categories = categories.into();
         self
     }
 
-
-    /// Set the optional generator that exists under `Channel`.
+    /// Set the name of the program used to generate the contents of the `Channel`.
     ///
     /// # Examples
     ///
@@ -1707,177 +1570,189 @@ impl ChannelBuilder {
     /// let generator = "Feeder 2.5.12(2294); Mac OS X Version 10.9.5 (Build 13F34) \
     ///     http://reinventedsoftware.com/feeder/".to_string();
     ///
-    /// let channel_builder = ChannelBuilder::new()
+    /// let builder = ChannelBuilder::default()
     ///     .generator(generator);
     /// ```
-    pub fn generator<V: Into<Option<String>>>(mut self, generator: V) -> ChannelBuilder {
+    pub fn generator<V>(mut self, generator: V) -> ChannelBuilder
+        where V: Into<Option<String>>
+    {
         self.generator = generator.into();
         self
     }
 
-
-    /// Set the optional docs that exists under `Channel`.
+    /// Set the URL that points to the documentation of the RSS format used in the `Channel`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let channel_builder = ChannelBuilder::new()
+    /// let builder = ChannelBuilder::default()
     ///     .docs("http://blogs.law.harvard.edu/tech/rss/".to_string());
     /// ```
-    pub fn docs<V: Into<Option<String>>>(mut self, docs: V) -> ChannelBuilder {
+    pub fn docs<V>(mut self, docs: V) -> ChannelBuilder
+        where V: Into<Option<String>>
+    {
         self.docs = docs.into();
         self
     }
 
-
-    /// Set the optional cloud that exists under `Channel`.
+    /// Set the information used to register with a cloud for notifications of updates to the
+    /// `Channel`
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::{ChannelBuilder, CloudBuilder};
     ///
-    /// let cloud = CloudBuilder::new()
+    /// let cloud = CloudBuilder::default()
     ///     .domain("http://rpc.sys.com/")
     ///     .protocol("soap")
     ///     .finalize();
     ///
-    /// let channel_builder = ChannelBuilder::new()
+    /// let builder = ChannelBuilder::default()
     ///     .cloud(cloud);
     /// ```
-    pub fn cloud<V: Into<Option<Cloud>>>(mut self, cloud: V) -> ChannelBuilder {
+    pub fn cloud<V>(mut self, cloud: V) -> ChannelBuilder
+        where V: Into<Option<Cloud>>
+    {
         self.cloud = cloud.into();
         self
     }
 
-
-    /// Set the optional ttl that exists under `Channel`.
+    /// Set the time to live of the `Channel`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let channel_builder = ChannelBuilder::new()
+    /// let builder = ChannelBuilder::default()
     ///     .ttl(60);
     /// ```
-    pub fn ttl<V: Into<Option<i64>>>(mut self, ttl: V) -> ChannelBuilder {
+    pub fn ttl<V>(mut self, ttl: V) -> ChannelBuilder
+        where V: Into<Option<i64>>
+    {
         self.ttl = ttl.into();
         self
     }
 
-
-    /// Set the optional image that exists under `Channel`.
+    /// Set the image to be display with the `Channel`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::{ChannelBuilder, ImageBuilder};
     ///
-    /// let image = ImageBuilder::new()
+    /// let image = ImageBuilder::default()
     ///     .url("http://jupiterbroadcasting.com/images/LAS-300-Badge.jpg")
     ///     .link("http://www.jupiterbroadcasting.com/")
     ///     .finalize();
     ///
-    /// let channel_builder = ChannelBuilder::new()
+    /// let builder = ChannelBuilder::default()
     ///     .image(image);
     /// ```
-    pub fn image<V: Into<Option<Image>>>(mut self, image: V) -> ChannelBuilder {
+    pub fn image<V>(mut self, image: V) -> ChannelBuilder
+        where V: Into<Option<Image>>
+    {
         self.image = image.into();
         self
     }
 
-    /// Set the optional rating that exists under `Channel`.
+    /// Set the [PICS](https://www.w3.org/PICS/) rating for the `Channel`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let channel_builder = ChannelBuilder::new()
+    /// let builder = ChannelBuilder::default()
     ///     .rating("PG-13".to_string());
     /// ```
-    pub fn rating<V: Into<Option<String>>>(mut self, rating: V) -> ChannelBuilder {
+    pub fn rating<V>(mut self, rating: V) -> ChannelBuilder
+        where V: Into<Option<String>>
+    {
         self.rating = rating.into();
         self
     }
 
-
-    /// Set the optional text input that exists under `Channel`.
+    /// Set the information for a text box to be displayed with the `Channel`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::{ChannelBuilder, TextInputBuilder};
     ///
-    /// let text_input = TextInputBuilder::new()
+    /// let text_input = TextInputBuilder::default()
     ///     .link("http://www.example.com/feedback")
     ///     .finalize();
     ///
-    /// let channel_builder = ChannelBuilder::new()
+    /// let builder = ChannelBuilder::default()
     ///     .text_input(text_input);
     /// ```
-    pub fn text_input<V: Into<Option<TextInput>>>(mut self, text_input: V) -> ChannelBuilder {
+    pub fn text_input<V>(mut self, text_input: V) -> ChannelBuilder
+        where V: Into<Option<TextInput>>
+    {
         self.text_input = text_input.into();
         self
     }
 
-
-    /// Set the optional skipdays that exists under `Channel`.
+    /// Set the hours that aggregators can skip for refreshing content.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let channel_builder = ChannelBuilder::new()
+    /// let builder = ChannelBuilder::default()
     ///     .skip_hours(vec![0, 12, 18]);
     /// ```
-    pub fn skip_hours<V: Into<Vec<i64>>>(mut self, skip_hours: V) -> ChannelBuilder {
+    pub fn skip_hours<V>(mut self, skip_hours: V) -> ChannelBuilder
+        where V: Into<Vec<i64>>
+    {
         self.skip_hours = skip_hours.into();
         self
     }
 
-
-    /// Set the optional skipdays that exists under `Channel`.
+    /// Set the days that aggregators can skip for refreshing content.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let channel_builder = ChannelBuilder::new()
+    /// let builder = ChannelBuilder::default()
     ///     .skip_days(vec!["Monday".to_string(), "Tuesday".to_string()]);
     /// ```
-    pub fn skip_days<V: Into<Vec<String>>>(mut self, skip_days: V) -> ChannelBuilder {
+    pub fn skip_days<V>(mut self, skip_days: V) -> ChannelBuilder
+        where V: Into<Vec<String>>
+    {
         self.skip_days = skip_days.into();
         self
     }
 
-
-    /// Set the optional items that exists under `Channel`.
+    /// Set the `Item`s in this `Channel`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::{ChannelBuilder, ItemBuilder};
     ///
-    /// let item = ItemBuilder::new()
+    /// let item = ItemBuilder::default()
     ///     .title("Making Music with Linux | LAS 408".to_string())
     ///     .finalize();
     ///
-    /// let channel_builder = ChannelBuilder::new()
+    /// let builder = ChannelBuilder::default()
     ///     .items(vec![item]);
     /// ```
-    pub fn items<V: Into<Vec<Item>>>(mut self, items: V) -> ChannelBuilder {
+    pub fn items<V>(mut self, items: V) -> ChannelBuilder
+        where V: Into<Vec<Item>>
+    {
         self.items = items.into();
         self
     }
 
-
-    /// Set the optional itunes channel extension that exists under `Channel`.
+    /// Set the `ITunesChannelExtension` for the `Channel`.
     ///
     /// # Examples
     ///
@@ -1886,21 +1761,21 @@ impl ChannelBuilder {
     /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesOwnerBuilder,
     ///     ITunesCategoryBuilder};
     ///
-    /// let owner = ITunesOwnerBuilder::new()
+    /// let owner = ITunesOwnerBuilder::default()
     ///     .email("email@example.com".to_string())
     ///     .name("name".to_string())
     ///     .finalize();
     ///
-    /// let subcategory = ITunesCategoryBuilder::new()
+    /// let subcategory = ITunesCategoryBuilder::default()
     ///     .text("text")
     ///     .finalize();
     ///
-    /// let category = ITunesCategoryBuilder::new()
+    /// let category = ITunesCategoryBuilder::default()
     ///     .text("text")
     ///     .subcategory(Box::new(subcategory))
     ///     .finalize();
     ///
-    /// let itunes_channel = ITunesChannelExtensionBuilder::new()
+    /// let itunes_channel = ITunesChannelExtensionBuilder::default()
     ///     .author("author".to_string())
     ///     .block("block".to_string())
     ///     .image("image".to_string())
@@ -1914,7 +1789,7 @@ impl ChannelBuilder {
     ///     .categories(vec![category])
     ///     .finalize();
     ///
-    /// let channel_builder = ChannelBuilder::new()
+    /// let builder = ChannelBuilder::default()
     ///     .itunes_ext(itunes_channel);
     /// ```
     pub fn itunes_ext<V>(mut self, itunes_ext: V) -> ChannelBuilder
@@ -1924,7 +1799,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// Set the optional dublin_core_ext that exists under `Channel`.
+    /// Set the `DublinCoreExtension` for the `Channel`.
     pub fn dublin_core_ext<V>(mut self, dublin_core_ext: V) -> ChannelBuilder
         where V: Into<Option<DublinCoreExtension>>
     {
@@ -1932,55 +1807,40 @@ impl ChannelBuilder {
         self
     }
 
-    /// Set the extensions that exists under `Channel`.
-    pub fn extensions<V: Into<ExtensionMap>>(mut self, extensions: V) -> ChannelBuilder {
+    /// Set the extensions for the `Channel`.
+    pub fn extensions<V>(mut self, extensions: V) -> ChannelBuilder
+        where V: Into<ExtensionMap>
+    {
         self.extensions = extensions.into();
         self
     }
 
-    /// Set the namespaces that exists under `Channel`.
-    pub fn namespaces<V: Into<HashMap<String, String>>>(mut self, namespaces: V) -> ChannelBuilder {
+    /// Set the namespaces for the `Channel`.
+    pub fn namespaces<V>(mut self, namespaces: V) -> ChannelBuilder
+        where V: Into<HashMap<String, String>>
+    {
         self.namespaces = namespaces.into();
         self
     }
 
-
-    /// Validate the contents of `Channel`.
+    /// Validate the contents of this `ChannelBuilder`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let description = "Ogg Vorbis audio versions of The Linux ".to_string()
-    /// + "Action Show! A show that covers everything geeks care about in the "
-    /// + "computer industry. Get a solid dose of Linux, gadgets, news events "
-    /// + "and much more!";
+    /// let description = "Ogg Vorbis audio versions of The Linux \
+    ///     Action Show! A show that covers everything geeks care about in the \
+    ///     computer industry. Get a solid dose of Linux, gadgets, news events \
+    ///     and much more!";
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let builder = ChannelBuilder::default()
     ///         .title("The Linux Action Show! OGG")
     ///         .link("http://www.jupiterbroadcasting.com")
-    ///         .description(description.as_ref())
-    ///         .language(None)
-    ///         .copyright(None)
-    ///         .managing_editor(None)
-    ///         .webmaster(None)
-    ///         .pub_date(None)
-    ///         .last_build_date(None)
-    ///         .categories(Vec::new())
-    ///         .generator(None)
-    ///         .docs(None)
-    ///         .cloud(None)
-    ///         .ttl(None)
-    ///         .image(None)
-    ///         .rating(None)
-    ///         .text_input(None)
-    ///         .skip_hours(Vec::new())
-    ///         .skip_days(Vec::new())
-    ///         .items(Vec::new())
+    ///         .description(description)
     ///         .validate()
-    ///         .unwrap()
-    ///         .finalize();
+    ///         .unwrap();
     /// ```
     pub fn validate(self) -> Result<ChannelBuilder, Error> {
         Url::parse(self.link.as_str())?;
@@ -2021,40 +1881,22 @@ impl ChannelBuilder {
         Ok(self)
     }
 
-
-    /// Construct the `Channel` from the `ChannelBuilder`.
+    /// Construct the `Channel` from this `ChannelBuilder`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let description = "Ogg Vorbis audio versions of The Linux \n
+    /// let description = "Ogg Vorbis audio versions of The Linux \
     ///     Action Show! A show that covers everything geeks care about in the \
     ///     computer industry. Get a solid dose of Linux, gadgets, news events \
     ///     and much more!";
     ///
-    /// let channel = ChannelBuilder::new()
+    /// let channel = ChannelBuilder::default()
     ///         .title("The Linux Action Show! OGG")
     ///         .link("http://www.jupiterbroadcasting.com")
     ///         .description(description)
-    ///         .language(None)
-    ///         .copyright(None)
-    ///         .managing_editor(None)
-    ///         .webmaster(None)
-    ///         .pub_date(None)
-    ///         .last_build_date(None)
-    ///         .categories(Vec::new())
-    ///         .generator(None)
-    ///         .docs(None)
-    ///         .cloud(None)
-    ///         .ttl(None)
-    ///         .image(None)
-    ///         .rating(None)
-    ///         .text_input(None)
-    ///         .skip_hours(Vec::new())
-    ///         .skip_days(Vec::new())
-    ///         .items(Vec::new())
     ///         .finalize();
     /// ```
     pub fn finalize(self) -> Channel {
@@ -2087,26 +1929,20 @@ impl ChannelBuilder {
     }
 }
 
-/// Enumerations of protocols for `SkipDays`.
+/// Enumerations of values for `SkipDays`.
 enum SkipDay {
     /// Monday
     Monday,
-
     /// Tuesday
     Tuesday,
-
     /// Wednesday
     Wednesday,
-
     /// Thursday
     Thursday,
-
     /// Friday
     Friday,
-
     /// Saturday
     Saturday,
-
     /// Sunday
     Sunday,
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -645,9 +645,8 @@ impl Channel {
     /// ```
     /// use rss::{ChannelBuilder, Channel};
     ///
-    /// let skip_days_vec: Vec<String> = vec!["Monday".to_string(),
-    /// "Sunday".to_string(), "Thursday".to_owned(),
-    ///     "Wednesday".to_string()];
+    /// let skip_days_vec: Vec<String> = vec!["Monday".to_string(), "Sunday".to_string(),
+    ///     "Thursday".to_string(), "Wednesday".to_string()];
     ///
     /// let channel = ChannelBuilder::new()
     ///     .skip_days(skip_days_vec.clone())
@@ -687,15 +686,15 @@ impl Channel {
     /// ```
     /// use rss::{ChannelBuilder, Channel, ItemBuilder};
     ///
-    /// let link = "http://www.jupiterbroadcasting.com/97561/".to_string()
-    /// + "making-music-with-linux-las-408/";
+    /// let link = "http://www.jupiterbroadcasting.com/97561/making-music-with-linux-las-408/"
+    ///     .to_string();
     ///
-    /// let description = "<![CDATA[<p>In special Rasberry Pi 3 ".to_string()
-    /// + "edition of the show we look at the new hardware, review & chat with "
-    /// + "Mycroft CTO Ryan Sipes on how important the Raspberry Pi is for "
-    /// + "development of their open artificial intelligence platform & get "
-    /// + "the latest news.</p><p>Plus replacing Spotify on Linux, the new "
-    /// + "Microsoft lock-in, our hosts face a moral quandary & more!</p>]]>";
+    /// let description = "<![CDATA[<p>In special Rasberry Pi 3 \
+    ///     edition of the show we look at the new hardware, review & chat with \
+    ///     Mycroft CTO Ryan Sipes on how important the Raspberry Pi is for \
+    ///     development of their open artificial intelligence platform & get \
+    ///     the latest news.</p><p>Plus replacing Spotify on Linux, the new \
+    ///     Microsoft lock-in, our hosts face a moral quandary & more!</p>]]>".to_string();
     ///
     /// let title = "Making Music with Linux | LAS 408".to_string();
     ///
@@ -1542,11 +1541,11 @@ impl ChannelBuilder {
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let mut channel_builder = ChannelBuilder::new();
-    /// channel_builder.title("The Linux Action Show! OGG");
+    /// let channel_builder = ChannelBuilder::new()
+    ///     .title("The Linux Action Show! OGG");
     /// ```
-    pub fn title(mut self, title: &str) -> ChannelBuilder {
-        self.title = title.to_string();
+    pub fn title<S: Into<String>>(mut self, title: S) -> ChannelBuilder {
+        self.title = title.into();
         self
     }
 
@@ -1558,11 +1557,11 @@ impl ChannelBuilder {
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let mut channel_builder = ChannelBuilder::new();
-    /// channel_builder.link("http://www.jupiterbroadcasting.com");
+    /// let channel_builder = ChannelBuilder::new()
+    ///     .link("http://www.jupiterbroadcasting.com");
     /// ```
-    pub fn link(mut self, link: &str) -> ChannelBuilder {
-        self.link = link.to_string();
+    pub fn link<S: Into<String>>(mut self, link: S) -> ChannelBuilder {
+        self.link = link.into();
         self
     }
 
@@ -1574,16 +1573,16 @@ impl ChannelBuilder {
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let description = "Ogg Vorbis audio versions of The Linux ".to_string()
-    /// + "Action Show! A show that covers everything geeks care about in the "
-    /// + "computer industry. Get a solid dose of Linux, gadgets, news events "
-    /// + "and much more!";
+    /// let description = "Ogg Vorbis audio versions of The Linux \
+    ///     Action Show! A show that covers everything geeks care about in the \
+    ///     computer industry. Get a solid dose of Linux, gadgets, news events \
+    ///     and much more!".to_string();
     ///
-    /// let mut channel_builder = ChannelBuilder::new();
-    /// channel_builder.description(description.as_ref());
+    /// let channel_builder = ChannelBuilder::new()
+    ///     .description(description);
     /// ```
-    pub fn description(mut self, description: &str) -> ChannelBuilder {
-        self.description = description.to_string();
+    pub fn description<S: Into<String>>(mut self, description: S) -> ChannelBuilder {
+        self.description = description.into();
         self
     }
 
@@ -1595,8 +1594,8 @@ impl ChannelBuilder {
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let mut channel_builder = ChannelBuilder::new();
-    /// channel_builder.language(Some("en".to_string()));
+    /// let channel_builder = ChannelBuilder::new()
+    ///     .language(Some("en".to_string()));
     /// ```
     pub fn language(mut self, language: Option<String>) -> ChannelBuilder {
         self.language = language;
@@ -1611,10 +1610,8 @@ impl ChannelBuilder {
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let copyright = "Copyright 2002, Spartanburg Herald-Journal".to_string();
-    ///
-    /// let mut channel_builder = ChannelBuilder::new();
-    /// channel_builder.copyright(Some(copyright));
+    /// let channel_builder = ChannelBuilder::new()
+    ///     .copyright(Some("Copyright 2002, Spartanburg Herald-Journal".to_string()));
     /// ```
     pub fn copyright(mut self, copyright: Option<String>) -> ChannelBuilder {
         self.copyright = copyright;
@@ -1629,11 +1626,8 @@ impl ChannelBuilder {
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let managing_editor =
-    ///     "chris@jupiterbroadcasting.com (Chris Fisher)".to_string();
-    ///
-    /// let mut channel_builder = ChannelBuilder::new();
-    /// channel_builder.managing_editor(Some(managing_editor));
+    /// let channel_builder = ChannelBuilder::new()
+    ///     .managing_editor(Some("chris@jupiterbroadcasting.com (Chris Fisher)".to_string()));
     /// ```
     pub fn managing_editor(mut self, managing_editor: Option<String>) -> ChannelBuilder {
         self.managing_editor = managing_editor;
@@ -1648,11 +1642,8 @@ impl ChannelBuilder {
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let webmaster =
-    ///     "chris@jupiterbroadcasting.com (Chris Fisher)".to_string();
-    ///
-    /// let mut channel_builder = ChannelBuilder::new();
-    /// channel_builder.webmaster(Some(webmaster));
+    /// let channel_builder = ChannelBuilder::new()
+    ///     .webmaster(Some("chris@jupiterbroadcasting.com (Chris Fisher)".to_string()));
     /// ```
     pub fn webmaster(mut self, webmaster: Option<String>) -> ChannelBuilder {
         self.webmaster = webmaster;
@@ -1667,9 +1658,8 @@ impl ChannelBuilder {
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let mut channel_builder = ChannelBuilder::new();
-    /// channel_builder.pub_date(Some("Sun, 13 Mar 2016 20:02:02
-    /// -0700".to_string()));
+    /// let channel_builder = ChannelBuilder::new()
+    ///     .pub_date(Some("Sun, 13 Mar 2016 20:02:02 -0700".to_string()));
     /// ```
     pub fn pub_date(mut self, pub_date: Option<String>) -> ChannelBuilder {
         self.pub_date = pub_date;
@@ -1684,9 +1674,8 @@ impl ChannelBuilder {
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let mut channel_builder = ChannelBuilder::new();
-    /// channel_builder.last_build_date(Some("Sun, 13 Mar 2016 20:02:02
-    /// -0700".to_string()));
+    /// let channel_builder = ChannelBuilder::new()
+    ///     .last_build_date(Some("Sun, 13 Mar 2016 20:02:02 -0700".to_string()));
     /// ```
     pub fn last_build_date(mut self, last_build_date: Option<String>) -> ChannelBuilder {
         self.last_build_date = last_build_date;
@@ -1703,10 +1692,9 @@ impl ChannelBuilder {
     ///
     /// let category = CategoryBuilder::new()
     ///     .finalize();
-    /// let categories = vec![category];
     ///
-    /// let mut channel_builder = ChannelBuilder::new();
-    /// channel_builder.categories(categories);
+    /// let channel_builder = ChannelBuilder::new()
+    ///     .categories(vec![category]);
     /// ```
     pub fn categories(mut self, categories: Vec<Category>) -> ChannelBuilder {
         self.categories = categories;
@@ -1721,12 +1709,11 @@ impl ChannelBuilder {
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let generator = "Feeder 2.5.12(2294); ".to_string()
-    /// + "Mac OS X Version 10.9.5 (Build 13F34) "
-    /// + "http://reinventedsoftware.com/feeder/";
+    /// let generator = "Feeder 2.5.12(2294); Mac OS X Version 10.9.5 (Build 13F34) \
+    ///     http://reinventedsoftware.com/feeder/".to_string();
     ///
-    /// let mut channel_builder = ChannelBuilder::new();
-    /// channel_builder.generator(Some(generator));
+    /// let channel_builder = ChannelBuilder::new()
+    ///     .generator(Some(generator));
     /// ```
     pub fn generator(mut self, generator: Option<String>) -> ChannelBuilder {
         self.generator = generator;
@@ -1741,9 +1728,8 @@ impl ChannelBuilder {
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let mut channel_builder = ChannelBuilder::new();
-    /// channel_builder.docs(Some("http://blogs.law.harvard.edu/tech/rss/".
-    /// to_owned()));
+    /// let channel_builder = ChannelBuilder::new()
+    ///     .docs(Some("http://blogs.law.harvard.edu/tech/rss/".to_string()));
     /// ```
     pub fn docs(mut self, docs: Option<String>) -> ChannelBuilder {
         self.docs = docs;
@@ -1763,8 +1749,8 @@ impl ChannelBuilder {
     ///     .protocol("soap")
     ///     .finalize();
     ///
-    /// let mut channel_builder = ChannelBuilder::new();
-    /// channel_builder.cloud(Some(cloud));
+    /// let channel_builder = ChannelBuilder::new()
+    ///     .cloud(Some(cloud));
     /// ```
     pub fn cloud(mut self, cloud: Option<Cloud>) -> ChannelBuilder {
         self.cloud = cloud;
@@ -1779,8 +1765,8 @@ impl ChannelBuilder {
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let mut channel_builder = ChannelBuilder::new();
-    /// channel_builder.ttl(Some(60));
+    /// let channel_builder = ChannelBuilder::new()
+    ///     .ttl(Some(60));
     /// ```
     pub fn ttl(mut self, ttl: Option<i64>) -> ChannelBuilder {
         self.ttl = ttl;
@@ -1795,17 +1781,13 @@ impl ChannelBuilder {
     /// ```
     /// use rss::{ChannelBuilder, ImageBuilder};
     ///
-    /// let url = "http://jupiterbroadcasting.com/images/LAS-300-Badge.jpg";
-    ///
-    /// let link = "http://www.jupiterbroadcasting.com/";
-    ///
     /// let image = ImageBuilder::new()
-    ///     .url(url)
-    ///     .link(link)
+    ///     .url("http://jupiterbroadcasting.com/images/LAS-300-Badge.jpg")
+    ///     .link("http://www.jupiterbroadcasting.com/")
     ///     .finalize();
     ///
-    /// let mut channel_builder = ChannelBuilder::new();
-    /// channel_builder.image(Some(image));
+    /// let channel_builder = ChannelBuilder::new()
+    ///     .image(Some(image));
     /// ```
     pub fn image(mut self, image: Option<Image>) -> ChannelBuilder {
         self.image = image;
@@ -1819,8 +1801,8 @@ impl ChannelBuilder {
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let mut channel_builder = ChannelBuilder::new();
-    /// channel_builder.rating(Some("PG-13".to_string()));
+    /// let channel_builder = ChannelBuilder::new()
+    ///     .rating(Some("PG-13".to_string()));
     /// ```
     pub fn rating(mut self, rating: Option<String>) -> ChannelBuilder {
         self.rating = rating;
@@ -1839,8 +1821,8 @@ impl ChannelBuilder {
     ///     .link("http://www.example.com/feedback")
     ///     .finalize();
     ///
-    /// let mut channel_builder = ChannelBuilder::new();
-    /// channel_builder.text_input(Some(text_input));
+    /// let channel_builder = ChannelBuilder::new()
+    ///     .text_input(Some(text_input));
     /// ```
     pub fn text_input(mut self, text_input: Option<TextInput>) -> ChannelBuilder {
         self.text_input = text_input;
@@ -1855,10 +1837,8 @@ impl ChannelBuilder {
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let hours: Vec<i64> = vec![0, 12, 18];
-    ///
-    /// let mut channel_builder = ChannelBuilder::new();
-    /// channel_builder.skip_hours(hours);
+    /// let channel_builder = ChannelBuilder::new()
+    ///     .skip_hours(vec![0, 12, 18]);
     /// ```
     pub fn skip_hours(mut self, skip_hours: Vec<i64>) -> ChannelBuilder {
         self.skip_hours = skip_hours;
@@ -1873,10 +1853,8 @@ impl ChannelBuilder {
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let days = vec!["Monday".to_string(), "Tuesday".to_owned()];
-    ///
-    /// let mut channel_builder = ChannelBuilder::new();
-    /// channel_builder.skip_days(days);
+    /// let channel_builder = ChannelBuilder::new()
+    ///     .skip_days(vec!["Monday".to_string(), "Tuesday".to_string()]);
     /// ```
     pub fn skip_days(mut self, skip_days: Vec<String>) -> ChannelBuilder {
         self.skip_days = skip_days;
@@ -1891,15 +1869,12 @@ impl ChannelBuilder {
     /// ```
     /// use rss::{ChannelBuilder, ItemBuilder};
     ///
-    /// let title = "Making Music with Linux | LAS 408".to_string();
-    ///
     /// let item = ItemBuilder::new()
-    ///     .title(Some(title))
+    ///     .title(Some("Making Music with Linux | LAS 408".to_string()))
     ///     .finalize();
-    /// let items = vec![item];
     ///
-    /// let mut channel_builder = ChannelBuilder::new();
-    /// channel_builder.items(items);
+    /// let channel_builder = ChannelBuilder::new()
+    ///     .items(vec![item]);
     /// ```
     pub fn items(mut self, items: Vec<Item>) -> ChannelBuilder {
         self.items = items;
@@ -1913,8 +1888,8 @@ impl ChannelBuilder {
     ///
     /// ```
     /// use rss::ChannelBuilder;
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder,
-    /// ITunesOwnerBuilder, ITunesCategoryBuilder};
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesOwnerBuilder,
+    ///     ITunesCategoryBuilder};
     ///
     /// let owner = ITunesOwnerBuilder::new()
     ///     .email(Some("email@example.com".to_string()))
@@ -1930,8 +1905,6 @@ impl ChannelBuilder {
     ///     .subcategory(Some(Box::new(subcategory)))
     ///     .finalize();
     ///
-    /// let categories = vec![category];
-    ///
     /// let itunes_channel = ITunesChannelExtensionBuilder::new()
     ///     .author(Some("author".to_string()))
     ///     .block(Some("block".to_string()))
@@ -1943,11 +1916,11 @@ impl ChannelBuilder {
     ///     .new_feed_url(Some("new_feed_url".to_string()))
     ///     .complete(Some("complete".to_string()))
     ///     .owner(Some(owner))
-    ///     .categories(categories)
+    ///     .categories(vec![category])
     ///     .finalize();
     ///
-    /// let mut channel_builder = ChannelBuilder::new();
-    /// channel_builder.itunes_ext(Some(itunes_channel));
+    /// let channel_builder = ChannelBuilder::new()
+    ///     .itunes_ext(Some(itunes_channel));
     /// ```
     pub fn itunes_ext(mut self, itunes_ext: Option<ITunesChannelExtension>) -> ChannelBuilder {
         self.itunes_ext = itunes_ext;
@@ -2059,15 +2032,15 @@ impl ChannelBuilder {
     /// ```
     /// use rss::ChannelBuilder;
     ///
-    /// let description = "Ogg Vorbis audio versions of The Linux ".to_string()
-    /// + "Action Show! A show that covers everything geeks care about in the "
-    /// + "computer industry. Get a solid dose of Linux, gadgets, news events "
-    /// + "and much more!";
+    /// let description = "Ogg Vorbis audio versions of The Linux \n
+    ///     Action Show! A show that covers everything geeks care about in the \
+    ///     computer industry. Get a solid dose of Linux, gadgets, news events \
+    ///     and much more!";
     ///
     /// let channel = ChannelBuilder::new()
     ///         .title("The Linux Action Show! OGG")
     ///         .link("http://www.jupiterbroadcasting.com")
-    ///         .description(description.as_ref())
+    ///         .description(description)
     ///         .language(None)
     ///         .copyright(None)
     ///         .managing_editor(None)

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -411,7 +411,7 @@ impl FromStr for CloudProtocol {
             "http-post" => Ok(CloudProtocol::HttpPost),
             "xml-rpc" => Ok(CloudProtocol::XmlRpc),
             "soap" => Ok(CloudProtocol::Soap),
-            _ => Err("not a valid value"),
+            _ => Err("Cloud Protocol is not a valid value"),
         }
     }
 }

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -44,8 +44,7 @@ impl Cloud {
     /// let cloud = CloudBuilder::new()
     ///     .domain(domain)
     ///     .protocol("soap")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(domain.to_string(), cloud.domain());
     /// ```
@@ -67,8 +66,7 @@ impl Cloud {
     ///     .port(port)
     ///     .domain("http://rpc.sys.com/")
     ///     .protocol("soap")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(port.to_string(), cloud.port());
     /// ```
@@ -90,8 +88,7 @@ impl Cloud {
     ///     .path(path)
     ///     .domain("http://rpc.sys.com/")
     ///     .protocol("soap")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(path, cloud.path());
     /// ```
@@ -112,8 +109,7 @@ impl Cloud {
     ///     .register_procedure(register_procedure)
     ///     .domain("http://rpc.sys.com/")
     ///     .protocol("soap")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     /// assert_eq!(register_procedure, cloud.register_procedure());
     /// ```
     pub fn register_procedure(&self) -> &str {
@@ -133,8 +129,7 @@ impl Cloud {
     /// let cloud = CloudBuilder::new()
     ///     .protocol(protocol)
     ///     .domain("http://rpc.sys.com/")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(protocol, cloud.protocol());
     /// ```
@@ -340,8 +335,9 @@ impl CloudBuilder {
     ///         .path("/RPC2")
     ///         .register_procedure("pingMe")
     ///         .protocol("soap")
-    ///         .validate().unwrap()
-    ///         .finalize().unwrap();
+    ///         .validate()
+    ///         .unwrap()
+    ///         .finalize();
     /// ```
     pub fn validate(self) -> Result<CloudBuilder, Error> {
         if self.port < 0 {
@@ -374,16 +370,14 @@ impl CloudBuilder {
     ///         .protocol("soap")
     ///         .finalize();
     /// ```
-    pub fn finalize(self) -> Result<Cloud, Error> {
-        let port = self.port.to_string();
-
-        Ok(Cloud {
-               domain: self.domain,
-               port: port,
-               path: self.path,
-               register_procedure: self.register_procedure,
-               protocol: self.protocol,
-           })
+    pub fn finalize(self) -> Cloud {
+        Cloud {
+            domain: self.domain,
+            port: self.port.to_string(),
+            path: self.path,
+            register_procedure: self.register_procedure,
+            protocol: self.protocol,
+        }
     }
 }
 

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -157,19 +157,19 @@ impl FromXml for Cloud {
             if let Ok(att) = attr {
                 match att.key {
                     b"domain" if domain.is_none() => {
-                        domain = Some(att.unescape_and_decode_value(&reader)?);
+                        domain = Some(att.unescape_and_decode_value(reader)?);
                     }
                     b"port" if port.is_none() => {
-                        port = Some(att.unescape_and_decode_value(&reader)?);
+                        port = Some(att.unescape_and_decode_value(reader)?);
                     }
                     b"path" if path.is_none() => {
-                        path = Some(att.unescape_and_decode_value(&reader)?);
+                        path = Some(att.unescape_and_decode_value(reader)?);
                     }
                     b"registerProcedure" if register_procedure.is_none() => {
-                        register_procedure = Some(att.unescape_and_decode_value(&reader)?);
+                        register_procedure = Some(att.unescape_and_decode_value(reader)?);
                     }
                     b"protocol" if protocol.is_none() => {
-                        protocol = Some(att.unescape_and_decode_value(&reader)?);
+                        protocol = Some(att.unescape_and_decode_value(reader)?);
                     }
                     _ => {}
                 }
@@ -274,7 +274,6 @@ impl CloudBuilder {
     /// cloud_builder.port(80);
     /// ```
     pub fn port(mut self, port: i64) -> CloudBuilder {
-
         self.port = port;
         self
     }

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -179,11 +179,10 @@ impl FromXml for Cloud {
         let mut depth = 1;
         let mut buf = Vec::new();
         while depth > 0 {
-            match reader.read_event(&mut buf) {
-                Ok(Event::Start(_)) => depth += 1,
-                Ok(Event::End(_)) => depth -= 1,
-                Ok(Event::Eof) => break,
-                Err(e) => return Err(e.into()),
+            match reader.read_event(&mut buf)? {
+                Event::Start(_) => depth += 1,
+                Event::End(_) => depth -= 1,
+                Event::Eof => break,
                 _ => {}
             }
         }

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -89,7 +89,7 @@ impl Cloud {
         self.path.as_str()
     }
 
-    /// Return the register procedure for the`Cloud`.
+    /// Return the register procedure for this `Cloud`.
     ///
     /// # Examples
     ///
@@ -212,19 +212,6 @@ pub struct CloudBuilder {
 }
 
 impl CloudBuilder {
-    /// Create a new `CloudBuilder` with default values.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rss::CloudBuilder;
-    ///
-    /// let builder = CloudBuilder::default();
-    /// ```
-    pub fn new() -> CloudBuilder {
-        CloudBuilder::default()
-    }
-
     /// Set the domain for the `Cloud`.
     ///
     /// # Examples
@@ -274,7 +261,7 @@ impl CloudBuilder {
         self
     }
 
-    /// Set the register procedure for the`Cloud`.
+    /// Set the register procedure for the `Cloud`.
     ///
     /// # Examples
     ///

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -32,18 +32,17 @@ pub struct Cloud {
 }
 
 impl Cloud {
-    /// Get the domain that exists under `Cloud`.
+    /// Return the domain for this `Cloud`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{CloudBuilder, Cloud};
+    /// use rss::CloudBuilder;
     ///
     /// let domain = "http://rpc.sys.com/";
     ///
-    /// let cloud = CloudBuilder::new()
+    /// let cloud = CloudBuilder::default()
     ///     .domain(domain)
-    ///     .protocol("soap")
     ///     .finalize();
     ///
     /// assert_eq!(domain.to_string(), cloud.domain());
@@ -52,20 +51,17 @@ impl Cloud {
         self.domain.as_str()
     }
 
-
-    /// Get the port that exists under `Cloud`.
+    /// Return the port for this `Cloud`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{CloudBuilder, Cloud};
+    /// use rss::CloudBuilder;
     ///
-    /// let port: i64 = 80;
+    /// let port = 80;
     ///
-    /// let cloud = CloudBuilder::new()
+    /// let cloud = CloudBuilder::default()
     ///     .port(port)
-    ///     .domain("http://rpc.sys.com/")
-    ///     .protocol("soap")
     ///     .finalize();
     ///
     /// assert_eq!(port.to_string(), cloud.port());
@@ -74,20 +70,17 @@ impl Cloud {
         self.port.as_str()
     }
 
-
-    /// Get the path that exists under `Cloud`.
+    /// Return the path for this `Cloud`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{CloudBuilder, Cloud};
+    /// use rss::CloudBuilder;
     ///
     /// let path = "/RPC2";
     ///
-    /// let cloud = CloudBuilder::new()
+    /// let cloud = CloudBuilder::default()
     ///     .path(path)
-    ///     .domain("http://rpc.sys.com/")
-    ///     .protocol("soap")
     ///     .finalize();
     ///
     /// assert_eq!(path, cloud.path());
@@ -96,8 +89,7 @@ impl Cloud {
         self.path.as_str()
     }
 
-
-    /// Get the register procedure that exists under `Cloud`.
+    /// Return the register procedure for the`Cloud`.
     ///
     /// # Examples
     ///
@@ -105,19 +97,18 @@ impl Cloud {
     /// use rss::{CloudBuilder, Cloud};
     ///
     /// let register_procedure = "pingMe";
-    /// let cloud = CloudBuilder::new()
+    ///
+    /// let cloud = CloudBuilder::default()
     ///     .register_procedure(register_procedure)
-    ///     .domain("http://rpc.sys.com/")
-    ///     .protocol("soap")
     ///     .finalize();
+    ///
     /// assert_eq!(register_procedure, cloud.register_procedure());
     /// ```
     pub fn register_procedure(&self) -> &str {
         self.register_procedure.as_str()
     }
 
-
-    /// Get the protocol that exists under `Cloud`.
+    /// Return the protocol for this `Cloud`.
     ///
     /// # Examples
     ///
@@ -126,7 +117,7 @@ impl Cloud {
     ///
     /// let protocol = "soap";
     ///
-    /// let cloud = CloudBuilder::new()
+    /// let cloud = CloudBuilder::default()
     ///     .protocol(protocol)
     ///     .domain("http://rpc.sys.com/")
     ///     .finalize();
@@ -210,7 +201,7 @@ impl ToXml for Cloud {
     }
 }
 
-/// This `CloudBuilder` struct creates the `Cloud`.
+/// A builder used to create a `Cloud`.
 #[derive(Debug, Clone, Default)]
 pub struct CloudBuilder {
     domain: String,
@@ -220,46 +211,45 @@ pub struct CloudBuilder {
     protocol: String,
 }
 
-
 impl CloudBuilder {
-    /// Construct a new `CloudBuilder` and return default values.
+    /// Create a new `CloudBuilder` with default values.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::CloudBuilder;
     ///
-    /// let cloud_builder = CloudBuilder::new();
+    /// let builder = CloudBuilder::default();
     /// ```
     pub fn new() -> CloudBuilder {
         CloudBuilder::default()
     }
 
-
-    /// Set the domain that exists under `Cloud`.
+    /// Set the domain for the `Cloud`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::CloudBuilder;
     ///
-    /// let cloud_builder = CloudBuilder::new()
+    /// let builder = CloudBuilder::default()
     ///     .domain("http://rpc.sys.com/");
     /// ```
-    pub fn domain<S: Into<String>>(mut self, domain: S) -> CloudBuilder {
+    pub fn domain<S>(mut self, domain: S) -> CloudBuilder
+        where S: Into<String>
+    {
         self.domain = domain.into();
         self
     }
 
-
-    /// Set the port that exists under `Cloud`.
+    /// Set the port for the `Cloud`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::CloudBuilder;
     ///
-    /// let cloud_builder = CloudBuilder::new()
+    /// let builder = CloudBuilder::default()
     ///     .port(80);
     /// ```
     pub fn port(mut self, port: i64) -> CloudBuilder {
@@ -267,71 +257,72 @@ impl CloudBuilder {
         self
     }
 
-
-    /// Set the path that exists under `Cloud`.
+    /// Set the path for the `Cloud`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::CloudBuilder;
     ///
-    /// let cloud_builder = CloudBuilder::new()
+    /// let builder = CloudBuilder::default()
     ///     .path("/RPC2");
     /// ```
-    pub fn path<S: Into<String>>(mut self, path: S) -> CloudBuilder {
+    pub fn path<S>(mut self, path: S) -> CloudBuilder
+        where S: Into<String>
+    {
         self.path = path.into();
         self
     }
 
-
-    /// Set the register procedure that exists under `Cloud`.
+    /// Set the register procedure for the`Cloud`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::CloudBuilder;
     ///
-    /// let cloud_builder = CloudBuilder::new()
+    /// let builder = CloudBuilder::default()
     ///     .register_procedure("pingMe");
     /// ```
-    pub fn register_procedure<S: Into<String>>(mut self, register_procedure: S) -> CloudBuilder {
+    pub fn register_procedure<S>(mut self, register_procedure: S) -> CloudBuilder
+        where S: Into<String>
+    {
         self.register_procedure = register_procedure.into();
         self
     }
 
-
-    /// Set the protocol that exists under `Cloud`.
+    /// Set the protocol for the `Cloud`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::CloudBuilder;
     ///
-    /// let cloud_builder = CloudBuilder::new()
+    /// let builder = CloudBuilder::default()
     ///     .protocol("soap");
     /// ```
-    pub fn protocol<S: Into<String>>(mut self, protocol: S) -> CloudBuilder {
+    pub fn protocol<S>(mut self, protocol: S) -> CloudBuilder
+        where S: Into<String>
+    {
         self.protocol = protocol.into();
         self
     }
 
-
-    /// Validate the contents of `Cloud`.
+    /// Validate the contents of this `CloudBuilder`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::CloudBuilder;
     ///
-    /// let cloud = CloudBuilder::new()
+    /// let builder = CloudBuilder::default()
     ///         .domain("http://rpc.sys.com/")
     ///         .port(80)
     ///         .path("/RPC2")
     ///         .register_procedure("pingMe")
     ///         .protocol("soap")
     ///         .validate()
-    ///         .unwrap()
-    ///         .finalize();
+    ///         .unwrap();
     /// ```
     pub fn validate(self) -> Result<CloudBuilder, Error> {
         if self.port < 0 {
@@ -348,15 +339,14 @@ impl CloudBuilder {
         Ok(self)
     }
 
-
-    /// Construct the `Cloud` from the `CloudBuilder`.
+    /// Construct the `Cloud` from this `CloudBuilder`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::CloudBuilder;
     ///
-    /// let cloud = CloudBuilder::new()
+    /// let cloud = CloudBuilder::default()
     ///         .domain("http://rpc.sys.com/")
     ///         .port(80)
     ///         .path("/RPC2")
@@ -375,20 +365,16 @@ impl CloudBuilder {
     }
 }
 
-
 /// Enumerations of protocols for `Cloud`.
 #[derive(Clone, Debug)]
 enum CloudProtocol {
     /// http-post
     HttpPost,
-
     /// xml-rpc
     XmlRpc,
-
     /// soap
     Soap,
 }
-
 
 impl FromStr for CloudProtocol {
     type Err = &'static str;

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -182,18 +182,12 @@ impl FromXml for Cloud {
             }
         }
 
-        let domain = domain.unwrap_or_default();
-        let port = port.unwrap_or_default();
-        let path = path.unwrap_or_default();
-        let register_procedure = register_procedure.unwrap_or_default();
-        let protocol = protocol.unwrap_or_default();
-
         Ok(Cloud {
-               domain: domain,
-               port: port,
-               path: path,
-               register_procedure: register_procedure,
-               protocol: protocol,
+               domain: domain.unwrap_or_default(),
+               port: port.unwrap_or_default(),
+               path: path.unwrap_or_default(),
+               register_procedure: register_procedure.unwrap_or_default(),
+               protocol: protocol.unwrap_or_default(),
            })
 
     }
@@ -249,11 +243,11 @@ impl CloudBuilder {
     /// ```
     /// use rss::CloudBuilder;
     ///
-    /// let mut cloud_builder = CloudBuilder::new();
-    /// cloud_builder.domain("http://rpc.sys.com/");
+    /// let cloud_builder = CloudBuilder::new()
+    ///     .domain("http://rpc.sys.com/");
     /// ```
-    pub fn domain(mut self, domain: &str) -> CloudBuilder {
-        self.domain = domain.to_string();
+    pub fn domain<S: Into<String>>(mut self, domain: S) -> CloudBuilder {
+        self.domain = domain.into();
         self
     }
 
@@ -265,8 +259,8 @@ impl CloudBuilder {
     /// ```
     /// use rss::CloudBuilder;
     ///
-    /// let mut cloud_builder = CloudBuilder::new();
-    /// cloud_builder.port(80);
+    /// let cloud_builder = CloudBuilder::new()
+    ///     .port(80);
     /// ```
     pub fn port(mut self, port: i64) -> CloudBuilder {
         self.port = port;
@@ -281,11 +275,11 @@ impl CloudBuilder {
     /// ```
     /// use rss::CloudBuilder;
     ///
-    /// let mut cloud_builder = CloudBuilder::new();
-    /// cloud_builder.path("/RPC2");
+    /// let cloud_builder = CloudBuilder::new()
+    ///     .path("/RPC2");
     /// ```
-    pub fn path(mut self, path: &str) -> CloudBuilder {
-        self.path = path.to_string();
+    pub fn path<S: Into<String>>(mut self, path: S) -> CloudBuilder {
+        self.path = path.into();
         self
     }
 
@@ -297,11 +291,11 @@ impl CloudBuilder {
     /// ```
     /// use rss::CloudBuilder;
     ///
-    /// let mut cloud_builder = CloudBuilder::new();
-    /// cloud_builder.register_procedure("pingMe");
+    /// let cloud_builder = CloudBuilder::new()
+    ///     .register_procedure("pingMe");
     /// ```
-    pub fn register_procedure(mut self, register_procedure: &str) -> CloudBuilder {
-        self.register_procedure = register_procedure.to_string();
+    pub fn register_procedure<S: Into<String>>(mut self, register_procedure: S) -> CloudBuilder {
+        self.register_procedure = register_procedure.into();
         self
     }
 
@@ -313,11 +307,11 @@ impl CloudBuilder {
     /// ```
     /// use rss::CloudBuilder;
     ///
-    /// let mut cloud_builder = CloudBuilder::new();
-    /// cloud_builder.protocol("soap");
+    /// let cloud_builder = CloudBuilder::new()
+    ///     .protocol("soap");
     /// ```
-    pub fn protocol(mut self, protocol: &str) -> CloudBuilder {
-        self.protocol = protocol.to_string();
+    pub fn protocol<S: Into<String>>(mut self, protocol: S) -> CloudBuilder {
+        self.protocol = protocol.into();
         self
     }
 

--- a/src/enclosure.rs
+++ b/src/enclosure.rs
@@ -135,14 +135,10 @@ impl FromXml for Enclosure {
             }
         }
 
-        let url = url.unwrap_or_default();
-        let length = length.unwrap_or_default();
-        let mime_type = mime_type.unwrap_or_default();
-
         Ok(Enclosure {
-               url: url,
-               length: length,
-               mime_type: mime_type,
+               url: url.unwrap_or_default(),
+               length: length.unwrap_or_default(),
+               mime_type: mime_type.unwrap_or_default(),
            })
     }
 }
@@ -193,14 +189,14 @@ impl EnclosureBuilder {
     /// ```
     /// use rss::EnclosureBuilder;
     ///
-    /// let url = "http://www.podtrac.com/pts/".to_string()
-    /// + "redirect.ogg/traffic.libsyn.com/jnite/linuxactionshowep408.ogg";
+    /// let url = "http://www.podtrac.com/pts/redirect.ogg/traffic.libsyn.com/jnite\
+    ///     /linuxactionshowep408.ogg";
     ///
-    /// let mut enclosure_builder = EnclosureBuilder::new();
-    /// enclosure_builder.url(url.as_ref());
+    /// let enclosure_builder = EnclosureBuilder::new()
+    ///     .url(url);
     /// ```
-    pub fn url(mut self, url: &str) -> EnclosureBuilder {
-        self.url = url.to_string();
+    pub fn url<S: Into<String>>(mut self, url: S) -> EnclosureBuilder {
+        self.url = url.into();
         self
     }
 
@@ -212,8 +208,8 @@ impl EnclosureBuilder {
     /// ```
     /// use rss::EnclosureBuilder;
     ///
-    /// let mut enclosure_builder = EnclosureBuilder::new();
-    /// enclosure_builder.length(70772893);
+    /// let enclosure_builder = EnclosureBuilder::new()
+    ///     .length(70772893);
     /// ```
     pub fn length(mut self, length: i64) -> EnclosureBuilder {
         self.length = length;
@@ -228,11 +224,11 @@ impl EnclosureBuilder {
     /// ```
     /// use rss::EnclosureBuilder;
     ///
-    /// let mut enclosure_builder = EnclosureBuilder::new();
-    /// enclosure_builder.mime_type("audio/ogg");
+    /// let enclosure_builder = EnclosureBuilder::new()
+    ///     .mime_type("audio/ogg");
     /// ```
-    pub fn mime_type(mut self, mime_type: &str) -> EnclosureBuilder {
-        self.mime_type = mime_type.to_string();
+    pub fn mime_type<S: Into<String>>(mut self, mime_type: S) -> EnclosureBuilder {
+        self.mime_type = mime_type.into();
         self
     }
 
@@ -244,11 +240,11 @@ impl EnclosureBuilder {
     /// ```
     /// use rss::EnclosureBuilder;
     ///
-    /// let url = "http://www.podtrac.com/pts/redirect.ogg/".to_string()
-    /// + "traffic.libsyn.com/jnite/linuxactionshowep408.ogg";
+    /// let url = "http://www.podtrac.com/pts/redirect.ogg/traffic.libsyn.com/jnite/\
+    ///     linuxactionshowep408.ogg";
     ///
     /// let enclosure = EnclosureBuilder::new()
-    ///         .url(url.as_ref())
+    ///         .url(url)
     ///         .length(70772893)
     ///         .mime_type("audio/ogg")
     ///         .validate()
@@ -281,11 +277,11 @@ impl EnclosureBuilder {
     /// ```
     /// use rss::EnclosureBuilder;
     ///
-    /// let url = "http://www.podtrac.com/pts/redirect.ogg/".to_string()
-    /// + "traffic.libsyn.com/jnite/linuxactionshowep408.ogg";
+    /// let url = "http://www.podtrac.com/pts/redirect.ogg/traffic.libsyn.com/jnite/\
+    ///     linuxactionshowep408.ogg";
     ///
     /// let enclosure = EnclosureBuilder::new()
-    ///         .url(url.as_ref())
+    ///         .url(url)
     ///         .length(70772893)
     ///         .mime_type("audio/ogg")
     ///         .finalize();

--- a/src/enclosure.rs
+++ b/src/enclosure.rs
@@ -263,7 +263,7 @@ impl EnclosureBuilder {
         let mime = self.mime_type.parse::<Mime>();
 
         if mime.is_err() {
-            return Err(Error::Validation(format!("Error: {:?}", mime.unwrap_err())));
+            return Err(Error::Validation(format!("Enclosure Mime Type is invalid: {:?}", mime.unwrap_err())));
         }
 
         if self.length < 0 {

--- a/src/enclosure.rs
+++ b/src/enclosure.rs
@@ -130,11 +130,10 @@ impl FromXml for Enclosure {
         let mut depth = 1;
         let mut buf = Vec::new();
         while depth > 0 {
-            match reader.read_event(&mut buf) {
-                Ok(Event::Start(_)) => depth += 1,
-                Ok(Event::End(_)) => depth -= 1,
-                Ok(Event::Eof) => break,
-                Err(e) => return Err(e.into()),
+            match reader.read_event(&mut buf)? {
+                Event::Start(_) => depth += 1,
+                Event::End(_) => depth -= 1,
+                Event::Eof => break,
                 _ => {}
             }
         }

--- a/src/enclosure.rs
+++ b/src/enclosure.rs
@@ -114,13 +114,13 @@ impl FromXml for Enclosure {
             if let Ok(attr) = attr {
                 match attr.key {
                     b"url" if url.is_none() => {
-                        url = Some(attr.unescape_and_decode_value(&reader)?);
+                        url = Some(attr.unescape_and_decode_value(reader)?);
                     }
                     b"length" if length.is_none() => {
-                        length = Some(attr.unescape_and_decode_value(&reader)?);
+                        length = Some(attr.unescape_and_decode_value(reader)?);
                     }
                     b"type" if mime_type.is_none() => {
-                        mime_type = Some(attr.unescape_and_decode_value(&reader)?);
+                        mime_type = Some(attr.unescape_and_decode_value(reader)?);
                     }
                     _ => {}
                 }

--- a/src/enclosure.rs
+++ b/src/enclosure.rs
@@ -41,8 +41,7 @@ impl Enclosure {
     /// let enclosure = EnclosureBuilder::new()
     ///     .url(url.as_ref())
     ///     .mime_type("audio/ogg")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(url, enclosure.url())
     /// ```
@@ -67,8 +66,7 @@ impl Enclosure {
     ///     .url(url.as_str())
     ///     .length(length)
     ///     .mime_type("audio/ogg")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(length.to_string(), enclosure.length())
     /// ```
@@ -92,8 +90,7 @@ impl Enclosure {
     /// let enclosure = EnclosureBuilder::new()
     ///     .url(url.as_str())
     ///     .mime_type(enclosure_type)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(enclosure_type, enclosure.mime_type())
     /// ```
@@ -254,8 +251,9 @@ impl EnclosureBuilder {
     ///         .url(url.as_ref())
     ///         .length(70772893)
     ///         .mime_type("audio/ogg")
-    ///         .validate().unwrap()
-    ///         .finalize().unwrap();
+    ///         .validate()
+    ///         .unwrap()
+    ///         .finalize();
     /// ```
     pub fn validate(self) -> Result<EnclosureBuilder, Error> {
         Url::parse(self.url.as_str())?;
@@ -263,7 +261,8 @@ impl EnclosureBuilder {
         let mime = self.mime_type.parse::<Mime>();
 
         if mime.is_err() {
-            return Err(Error::Validation(format!("Enclosure Mime Type is invalid: {:?}", mime.unwrap_err())));
+            return Err(Error::Validation(format!("Enclosure Mime Type is invalid: {:?}",
+                                                 mime.unwrap_err())));
         }
 
         if self.length < 0 {
@@ -291,13 +290,11 @@ impl EnclosureBuilder {
     ///         .mime_type("audio/ogg")
     ///         .finalize();
     /// ```
-    pub fn finalize(self) -> Result<Enclosure, Error> {
-        let length = self.length.to_string();
-
-        Ok(Enclosure {
-               url: self.url,
-               length: length,
-               mime_type: self.mime_type,
-           })
+    pub fn finalize(self) -> Enclosure {
+        Enclosure {
+            url: self.url,
+            length: self.length.to_string(),
+            mime_type: self.mime_type,
+        }
     }
 }

--- a/src/enclosure.rs
+++ b/src/enclosure.rs
@@ -28,19 +28,18 @@ pub struct Enclosure {
 }
 
 impl Enclosure {
-    /// Get the url that exists under `Enclosure`.
+    /// Return the URL for this `Enclosure`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{EnclosureBuilder, Enclosure};
+    /// use rss::EnclosureBuilder;
     ///
-    /// let url = "http://www.podtrac.com/pts/redirect.ogg/".to_string()
-    /// + "traffic.libsyn.com/jnite/linuxactionshowep408.ogg";
+    /// let url = "http://www.podtrac.com/pts/redirect.ogg/traffic.libsyn.com/jnite/\
+    ///     linuxactionshowep408.ogg";
     ///
-    /// let enclosure = EnclosureBuilder::new()
-    ///     .url(url.as_ref())
-    ///     .mime_type("audio/ogg")
+    /// let enclosure = EnclosureBuilder::default()
+    ///     .url(url)
     ///     .finalize();
     ///
     /// assert_eq!(url, enclosure.url())
@@ -49,23 +48,17 @@ impl Enclosure {
         self.url.as_str()
     }
 
-
-    /// Get the length that exists under `Enclosure`.
+    /// Return the content length for this `Enclosure`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{EnclosureBuilder, Enclosure};
+    /// use rss::EnclosureBuilder;
     ///
-    /// let length: i64 = 70772893;
+    /// let length = 70772893;
     ///
-    /// let url = "http://www.podtrac.com/pts/redirect.ogg/".to_string()
-    /// + "traffic.libsyn.com/jnite/linuxactionshowep408.ogg";
-    ///
-    /// let enclosure = EnclosureBuilder::new()
-    ///     .url(url.as_str())
+    /// let enclosure = EnclosureBuilder::default()
     ///     .length(length)
-    ///     .mime_type("audio/ogg")
     ///     .finalize();
     ///
     /// assert_eq!(length.to_string(), enclosure.length())
@@ -74,25 +67,20 @@ impl Enclosure {
         self.length.as_str()
     }
 
-
-    /// Get the enclosure type that exists under `Enclosure`.
+    /// Return the content MIME type for this `Enclosure`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{EnclosureBuilder, Enclosure};
+    /// use rss::EnclosureBuilder;
     ///
-    /// let enclosure_type = "audio/ogg";
+    /// let mime_type = "audio/ogg";
     ///
-    /// let url = "http://www.podtrac.com/pts/redirect.ogg/".to_string()
-    /// + "traffic.libsyn.com/jnite/linuxactionshowep408.ogg";
-    ///
-    /// let enclosure = EnclosureBuilder::new()
-    ///     .url(url.as_str())
-    ///     .mime_type(enclosure_type)
+    /// let enclosure = EnclosureBuilder::default()
+    ///     .mime_type(mime_type)
     ///     .finalize();
     ///
-    /// assert_eq!(enclosure_type, enclosure.mime_type())
+    /// assert_eq!(mime_type, enclosure.mime_type())
     /// ```
     pub fn mime_type(&self) -> &str {
         self.mime_type.as_str()
@@ -159,7 +147,7 @@ impl ToXml for Enclosure {
     }
 }
 
-/// This `EnclosureBuilder` struct creates the `Enclosure`.
+/// A builder used to create an `Enclosure`.
 #[derive(Debug, Clone, Default)]
 pub struct EnclosureBuilder {
     url: String,
@@ -168,21 +156,7 @@ pub struct EnclosureBuilder {
 }
 
 impl EnclosureBuilder {
-    /// Construct a new `EnclosureBuilder` and return default values.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rss::EnclosureBuilder;
-    ///
-    /// let enclosure_builder = EnclosureBuilder::new();
-    /// ```
-    pub fn new() -> EnclosureBuilder {
-        EnclosureBuilder::default()
-    }
-
-
-    /// Set the url that exists under `Enclosure`.
+    /// Set the URL for the `Enclosure`.
     ///
     /// # Examples
     ///
@@ -192,23 +166,24 @@ impl EnclosureBuilder {
     /// let url = "http://www.podtrac.com/pts/redirect.ogg/traffic.libsyn.com/jnite\
     ///     /linuxactionshowep408.ogg";
     ///
-    /// let enclosure_builder = EnclosureBuilder::new()
+    /// let builder = EnclosureBuilder::default()
     ///     .url(url);
     /// ```
-    pub fn url<S: Into<String>>(mut self, url: S) -> EnclosureBuilder {
+    pub fn url<S>(mut self, url: S) -> EnclosureBuilder
+        where S: Into<String>
+    {
         self.url = url.into();
         self
     }
 
-
-    /// Set the length that exists under `Enclosure`.
+    /// Set the content length for the `Enclosure`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::EnclosureBuilder;
     ///
-    /// let enclosure_builder = EnclosureBuilder::new()
+    /// let builder = EnclosureBuilder::default()
     ///     .length(70772893);
     /// ```
     pub fn length(mut self, length: i64) -> EnclosureBuilder {
@@ -216,24 +191,24 @@ impl EnclosureBuilder {
         self
     }
 
-
-    /// Set the enclosure_type that exists under `Enclosure`.
+    /// Set the content MIME type for the `Enclosure`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::EnclosureBuilder;
     ///
-    /// let enclosure_builder = EnclosureBuilder::new()
+    /// let builder = EnclosureBuilder::default()
     ///     .mime_type("audio/ogg");
     /// ```
-    pub fn mime_type<S: Into<String>>(mut self, mime_type: S) -> EnclosureBuilder {
+    pub fn mime_type<S>(mut self, mime_type: S) -> EnclosureBuilder
+        where S: Into<String>
+    {
         self.mime_type = mime_type.into();
         self
     }
 
-
-    /// Validate the contents of `Enclosure`.
+    /// Validate the contents of this `EnclosureBuilder`.
     ///
     /// # Examples
     ///
@@ -243,13 +218,12 @@ impl EnclosureBuilder {
     /// let url = "http://www.podtrac.com/pts/redirect.ogg/traffic.libsyn.com/jnite/\
     ///     linuxactionshowep408.ogg";
     ///
-    /// let enclosure = EnclosureBuilder::new()
+    /// let enclosure = EnclosureBuilder::default()
     ///         .url(url)
     ///         .length(70772893)
     ///         .mime_type("audio/ogg")
     ///         .validate()
-    ///         .unwrap()
-    ///         .finalize();
+    ///         .unwrap();
     /// ```
     pub fn validate(self) -> Result<EnclosureBuilder, Error> {
         Url::parse(self.url.as_str())?;
@@ -269,8 +243,7 @@ impl EnclosureBuilder {
         Ok(self)
     }
 
-
-    /// Construct the `Enclosure` from the `EnclosureBuilder`.
+    /// Construct the `Enclosure` from this `EnclosureBuilder`.
     ///
     /// # Examples
     ///
@@ -280,7 +253,7 @@ impl EnclosureBuilder {
     /// let url = "http://www.podtrac.com/pts/redirect.ogg/traffic.libsyn.com/jnite/\
     ///     linuxactionshowep408.ogg";
     ///
-    /// let enclosure = EnclosureBuilder::new()
+    /// let enclosure = EnclosureBuilder::default()
     ///         .url(url)
     ///         .length(70772893)
     ///         .mime_type("audio/ogg")

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,8 +46,8 @@ pub enum Error {
 impl StdError for Error {
     fn description(&self) -> &str {
         match *self {
-            Error::Validation(ref err) => err,
-            Error::FromUrl(ref err) => err,
+            Error::Validation(ref s) |
+            Error::FromUrl(ref s) => s,
             Error::IO(ref err) => err.description(),
             #[cfg(feature = "from_url")]
             Error::ReqParsing(ref err) => err.description(),
@@ -80,17 +80,17 @@ impl StdError for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Validation(ref err) => fmt::Display::fmt(err, f),
-            Error::FromUrl(ref err) => fmt::Display::fmt(err, f),
-            Error::IO(ref err) => fmt::Display::fmt(err, f),
+            Error::Validation(ref s) |
+            Error::FromUrl(ref s) => write!(f, "{}", s),
+            Error::IO(ref err) => err.fmt(f),
             #[cfg(feature = "from_url")]
-            Error::ReqParsing(ref err) => fmt::Display::fmt(err, f),
-            Error::IntParsing(ref err) => fmt::Display::fmt(err, f),
-            Error::DateParsing(ref err) => fmt::Display::fmt(err, f),
-            Error::UrlParsing(ref err) => fmt::Display::fmt(err, f),
-            Error::Utf8(ref err) => fmt::Display::fmt(err, f),
-            Error::XmlParsing(ref err, _) => fmt::Display::fmt(err, f),
-            Error::Xml(ref err) => fmt::Display::fmt(err, f),
+            Error::ReqParsing(ref err) => err.fmt(f),
+            Error::IntParsing(ref err) => err.fmt(f),
+            Error::DateParsing(ref err) => err.fmt(f),
+            Error::UrlParsing(ref err) => err.fmt(f),
+            Error::Utf8(ref err) => err.fmt(f),
+            Error::XmlParsing(ref err, _) => err.fmt(f),
+            Error::Xml(ref err) => err.fmt(f),
             Error::EOF => write!(f, "reached end of input without finding a complete channel"),
         }
     }
@@ -144,7 +144,6 @@ impl From<::reqwest::Error> for Error {
         Error::ReqParsing(err)
     }
 }
-
 
 impl From<IOError> for Error {
     fn from(err: IOError) -> Error {

--- a/src/extension/dublincore.rs
+++ b/src/extension/dublincore.rs
@@ -226,92 +226,100 @@ impl DublinCoreExtensionBuilder {
     }
 
     /// Set the contributors that exists under `DublinCoreExtension`.
-    pub fn contributors(mut self, contributors: Vec<String>) -> DublinCoreExtensionBuilder {
-        self.contributors = contributors;
+    pub fn contributors<V>(mut self, contributors: V) -> DublinCoreExtensionBuilder
+        where V: Into<Vec<String>>
+    {
+        self.contributors = contributors.into();
         self
     }
 
     /// Set the coverages that exists under `DublinCoreExtension`.
-    pub fn coverages(mut self, coverages: Vec<String>) -> DublinCoreExtensionBuilder {
-        self.coverages = coverages;
+    pub fn coverages<V: Into<Vec<String>>>(mut self, coverages: V) -> DublinCoreExtensionBuilder {
+        self.coverages = coverages.into();
         self
     }
 
     /// Set the creators that exists under `DublinCoreExtension`.
-    pub fn creators(mut self, creators: Vec<String>) -> DublinCoreExtensionBuilder {
-        self.creators = creators;
+    pub fn creators<V: Into<Vec<String>>>(mut self, creators: V) -> DublinCoreExtensionBuilder {
+        self.creators = creators.into();
         self
     }
 
     /// Set the dates that exists under `DublinCoreExtension`.
-    pub fn dates(mut self, dates: Vec<String>) -> DublinCoreExtensionBuilder {
-        self.dates = dates;
+    pub fn dates<V: Into<Vec<String>>>(mut self, dates: V) -> DublinCoreExtensionBuilder {
+        self.dates = dates.into();
         self
     }
 
     /// Set the descriptions that exists under `DublinCoreExtension`.
-    pub fn descriptions(mut self, descriptions: Vec<String>) -> DublinCoreExtensionBuilder {
-        self.descriptions = descriptions;
+    pub fn descriptions<V>(mut self, descriptions: V) -> DublinCoreExtensionBuilder
+        where V: Into<Vec<String>>
+    {
+        self.descriptions = descriptions.into();
         self
     }
 
     /// Get the formats that exists under `DublinCoreExtension`.
-    pub fn formats(mut self, formats: Vec<String>) -> DublinCoreExtensionBuilder {
-        self.formats = formats;
+    pub fn formats<V: Into<Vec<String>>>(mut self, formats: V) -> DublinCoreExtensionBuilder {
+        self.formats = formats.into();
         self
     }
 
     /// Set the identifiers that exists under `DublinCoreExtension`.
-    pub fn identifiers(mut self, identifiers: Vec<String>) -> DublinCoreExtensionBuilder {
-        self.identifiers = identifiers;
+    pub fn identifiers<V>(mut self, identifiers: V) -> DublinCoreExtensionBuilder
+        where V: Into<Vec<String>>
+    {
+        self.identifiers = identifiers.into();
         self
     }
 
     /// Set the languages that exists under `DublinCoreExtension`.
-    pub fn languages(mut self, languages: Vec<String>) -> DublinCoreExtensionBuilder {
-        self.languages = languages;
+    pub fn languages<V: Into<Vec<String>>>(mut self, languages: V) -> DublinCoreExtensionBuilder {
+        self.languages = languages.into();
         self
     }
 
     /// Set the publishers that exists under `DublinCoreExtension`.
-    pub fn publishers(mut self, publishers: Vec<String>) -> DublinCoreExtensionBuilder {
-        self.publishers = publishers;
+    pub fn publishers<V: Into<Vec<String>>>(mut self, publishers: V) -> DublinCoreExtensionBuilder {
+        self.publishers = publishers.into();
         self
     }
 
     /// Set the relations that exists under `DublinCoreExtension`.
-    pub fn relations(mut self, relations: Vec<String>) -> DublinCoreExtensionBuilder {
-        self.relations = relations;
+    pub fn relations<V: Into<Vec<String>>>(mut self, relations: V) -> DublinCoreExtensionBuilder {
+        self.relations = relations.into();
         self
     }
 
     /// Set the rights that exists under `DublinCoreExtension`.
-    pub fn rights(mut self, rights: Vec<String>) -> DublinCoreExtensionBuilder {
-        self.rights = rights;
+    pub fn rights<V: Into<Vec<String>>>(mut self, rights: V) -> DublinCoreExtensionBuilder {
+        self.rights = rights.into();
         self
     }
 
     /// Set the sources that exists under `DublinCoreExtension`.
-    pub fn sources(mut self, sources: Vec<String>) -> DublinCoreExtensionBuilder {
-        self.sources = sources;
+    pub fn sources<V: Into<Vec<String>>>(mut self, sources: V) -> DublinCoreExtensionBuilder {
+        self.sources = sources.into();
         self
     }
 
     /// Set the subjects that exists under `DublinCoreExtension`.
-    pub fn subjects(mut self, subjects: Vec<String>) -> DublinCoreExtensionBuilder {
-        self.subjects = subjects;
+    pub fn subjects<V: Into<Vec<String>>>(mut self, subjects: V) -> DublinCoreExtensionBuilder {
+        self.subjects = subjects.into();
         self
     }
 
     /// Set the titles that exists under `DublinCoreExtension`.
-    pub fn titles(mut self, titles: Vec<String>) -> DublinCoreExtensionBuilder {
-        self.titles = titles;
+    pub fn titles<V: Into<Vec<String>>>(mut self, titles: V) -> DublinCoreExtensionBuilder {
+        self.titles = titles.into();
         self
     }
 
     /// Set the resource_types that exists under `DublinCoreExtension`.
-    pub fn resource_types(mut self, resource_types: Vec<String>) -> DublinCoreExtensionBuilder {
-        self.resource_types = resource_types;
+    pub fn resource_types<V>(mut self, resource_types: V) -> DublinCoreExtensionBuilder
+        where V: Into<Vec<String>>
+    {
+        self.resource_types = resource_types.into();
         self
     }
 

--- a/src/extension/dublincore.rs
+++ b/src/extension/dublincore.rs
@@ -52,77 +52,77 @@ pub struct DublinCoreExtension {
 }
 
 impl DublinCoreExtension {
-    /// Get the contributors that exists under `DublinCoreExtension`.
+    /// Return the contributors for this `DublinCoreExtension`.
     pub fn contributors(&self) -> &[String] {
         &self.contributors
     }
 
-    /// Get the coverages that exists under `DublinCoreExtension`.
+    /// Return the coverages for this `DublinCoreExtension`.
     pub fn coverages(&self) -> &[String] {
         &self.coverages
     }
 
-    /// Get the creators that exists under `DublinCoreExtension`.
+    /// Return the creators for this `DublinCoreExtension`.
     pub fn creators(&self) -> &[String] {
         &self.creators
     }
 
-    /// Get the dates that exists under `DublinCoreExtension`.
+    /// Return the dates for this `DublinCoreExtension`.
     pub fn dates(&self) -> &[String] {
         &self.dates
     }
 
-    /// Get the descriptions that exists under `DublinCoreExtension`.
+    /// Return the descriptions for this `DublinCoreExtension`.
     pub fn descriptions(&self) -> &[String] {
         &self.descriptions
     }
 
-    /// Get the formats that exists under `DublinCoreExtension`.
+    /// Return the formats for this `DublinCoreExtension`.
     pub fn formats(&self) -> &[String] {
         &self.formats
     }
 
-    /// Get the identifiers that exists under `DublinCoreExtension`.
+    /// Return the identifiers for this `DublinCoreExtension`.
     pub fn identifiers(&self) -> &[String] {
         &self.identifiers
     }
 
-    /// Get the languages that exists under `DublinCoreExtension`.
+    /// Return the languages for this `DublinCoreExtension`.
     pub fn languages(&self) -> &[String] {
         &self.languages
     }
 
-    /// Get the publishers that exists under `DublinCoreExtension`.
+    /// Return the publishers for this `DublinCoreExtension`.
     pub fn publishers(&self) -> &[String] {
         &self.publishers
     }
 
-    /// Get the relations that exists under `DublinCoreExtension`.
+    /// Return the relations for this `DublinCoreExtension`.
     pub fn relations(&self) -> &[String] {
         &self.relations
     }
 
-    /// Get the rights that exists under `DublinCoreExtension`.
+    /// Return the rights for this `DublinCoreExtension`.
     pub fn rights(&self) -> &[String] {
         &self.rights
     }
 
-    /// Get the sources that exists under `DublinCoreExtension`.
+    /// Return the sources for this `DublinCoreExtension`.
     pub fn sources(&self) -> &[String] {
         &self.sources
     }
 
-    /// Get the subjects that exists under `DublinCoreExtension`.
+    /// Return the subjects for this `DublinCoreExtension`.
     pub fn subjects(&self) -> &[String] {
         &self.subjects
     }
 
-    /// Get the titles that exists under `DublinCoreExtension`.
+    /// Return the titles for this `DublinCoreExtension`.
     pub fn titles(&self) -> &[String] {
         &self.titles
     }
 
-    /// Get the resource_types that exists under `DublinCoreExtension`.
+    /// Return the resource_types for this `DublinCoreExtension`.
     pub fn resource_types(&self) -> &[String] {
         &self.resource_types
     }
@@ -175,7 +175,7 @@ impl ToXml for DublinCoreExtension {
     }
 }
 
-/// This `DublinCoreExtensionBuilder` struct creates the `DublinCoreExtension`.
+/// A builder used to create a `DublinCoreExtension`.
 #[derive(Debug, Default, Clone)]
 pub struct DublinCoreExtensionBuilder {
     /// An entity responsible for making contributions to the resource.
@@ -212,20 +212,7 @@ pub struct DublinCoreExtensionBuilder {
 }
 
 impl DublinCoreExtensionBuilder {
-    /// Construct a new `DublinCoreExtensionBuilder` and return default values.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rss::extension::dublincore::DublinCoreExtensionBuilder;
-    ///
-    /// let dublin_builder = DublinCoreExtensionBuilder::new();
-    /// ```
-    pub fn new() -> DublinCoreExtensionBuilder {
-        DublinCoreExtensionBuilder::default()
-    }
-
-    /// Set the contributors that exists under `DublinCoreExtension`.
+    /// Set the contributors for the `DublinCoreExtension`.
     pub fn contributors<V>(mut self, contributors: V) -> DublinCoreExtensionBuilder
         where V: Into<Vec<String>>
     {
@@ -233,25 +220,31 @@ impl DublinCoreExtensionBuilder {
         self
     }
 
-    /// Set the coverages that exists under `DublinCoreExtension`.
-    pub fn coverages<V: Into<Vec<String>>>(mut self, coverages: V) -> DublinCoreExtensionBuilder {
+    /// Set the coverages for the `DublinCoreExtension`.
+    pub fn coverages<V>(mut self, coverages: V) -> DublinCoreExtensionBuilder
+        where V: Into<Vec<String>>
+    {
         self.coverages = coverages.into();
         self
     }
 
-    /// Set the creators that exists under `DublinCoreExtension`.
-    pub fn creators<V: Into<Vec<String>>>(mut self, creators: V) -> DublinCoreExtensionBuilder {
+    /// Set the creators for the `DublinCoreExtension`.
+    pub fn creators<V>(mut self, creators: V) -> DublinCoreExtensionBuilder
+        where V: Into<Vec<String>>
+    {
         self.creators = creators.into();
         self
     }
 
-    /// Set the dates that exists under `DublinCoreExtension`.
-    pub fn dates<V: Into<Vec<String>>>(mut self, dates: V) -> DublinCoreExtensionBuilder {
+    /// Set the dates for the `DublinCoreExtension`.
+    pub fn dates<V>(mut self, dates: V) -> DublinCoreExtensionBuilder
+        where V: Into<Vec<String>>
+    {
         self.dates = dates.into();
         self
     }
 
-    /// Set the descriptions that exists under `DublinCoreExtension`.
+    /// Set the descriptions for the `DublinCoreExtension`.
     pub fn descriptions<V>(mut self, descriptions: V) -> DublinCoreExtensionBuilder
         where V: Into<Vec<String>>
     {
@@ -259,13 +252,15 @@ impl DublinCoreExtensionBuilder {
         self
     }
 
-    /// Get the formats that exists under `DublinCoreExtension`.
-    pub fn formats<V: Into<Vec<String>>>(mut self, formats: V) -> DublinCoreExtensionBuilder {
+    /// Set the formats for the `DublinCoreExtension`.
+    pub fn formats<V>(mut self, formats: V) -> DublinCoreExtensionBuilder
+        where V: Into<Vec<String>>
+    {
         self.formats = formats.into();
         self
     }
 
-    /// Set the identifiers that exists under `DublinCoreExtension`.
+    /// Set the identifiers for the `DublinCoreExtension`.
     pub fn identifiers<V>(mut self, identifiers: V) -> DublinCoreExtensionBuilder
         where V: Into<Vec<String>>
     {
@@ -273,49 +268,63 @@ impl DublinCoreExtensionBuilder {
         self
     }
 
-    /// Set the languages that exists under `DublinCoreExtension`.
-    pub fn languages<V: Into<Vec<String>>>(mut self, languages: V) -> DublinCoreExtensionBuilder {
+    /// Set the languages for the `DublinCoreExtension`.
+    pub fn languages<V>(mut self, languages: V) -> DublinCoreExtensionBuilder
+        where V: Into<Vec<String>>
+    {
         self.languages = languages.into();
         self
     }
 
-    /// Set the publishers that exists under `DublinCoreExtension`.
-    pub fn publishers<V: Into<Vec<String>>>(mut self, publishers: V) -> DublinCoreExtensionBuilder {
+    /// Set the publishers for the `DublinCoreExtension`.
+    pub fn publishers<V>(mut self, publishers: V) -> DublinCoreExtensionBuilder
+        where V: Into<Vec<String>>
+    {
         self.publishers = publishers.into();
         self
     }
 
-    /// Set the relations that exists under `DublinCoreExtension`.
-    pub fn relations<V: Into<Vec<String>>>(mut self, relations: V) -> DublinCoreExtensionBuilder {
+    /// Set the relations for the `DublinCoreExtension`.
+    pub fn relations<V>(mut self, relations: V) -> DublinCoreExtensionBuilder
+        where V: Into<Vec<String>>
+    {
         self.relations = relations.into();
         self
     }
 
-    /// Set the rights that exists under `DublinCoreExtension`.
-    pub fn rights<V: Into<Vec<String>>>(mut self, rights: V) -> DublinCoreExtensionBuilder {
+    /// Set the rights for the `DublinCoreExtension`.
+    pub fn rights<V>(mut self, rights: V) -> DublinCoreExtensionBuilder
+        where V: Into<Vec<String>>
+    {
         self.rights = rights.into();
         self
     }
 
-    /// Set the sources that exists under `DublinCoreExtension`.
-    pub fn sources<V: Into<Vec<String>>>(mut self, sources: V) -> DublinCoreExtensionBuilder {
+    /// Set the sources for the `DublinCoreExtension`.
+    pub fn sources<V>(mut self, sources: V) -> DublinCoreExtensionBuilder
+        where V: Into<Vec<String>>
+    {
         self.sources = sources.into();
         self
     }
 
-    /// Set the subjects that exists under `DublinCoreExtension`.
-    pub fn subjects<V: Into<Vec<String>>>(mut self, subjects: V) -> DublinCoreExtensionBuilder {
+    /// Set the subjects for the `DublinCoreExtension`.
+    pub fn subjects<V>(mut self, subjects: V) -> DublinCoreExtensionBuilder
+        where V: Into<Vec<String>>
+    {
         self.subjects = subjects.into();
         self
     }
 
-    /// Set the titles that exists under `DublinCoreExtension`.
-    pub fn titles<V: Into<Vec<String>>>(mut self, titles: V) -> DublinCoreExtensionBuilder {
+    /// Set the titles for the `DublinCoreExtension`.
+    pub fn titles<V>(mut self, titles: V) -> DublinCoreExtensionBuilder
+        where V: Into<Vec<String>>
+    {
         self.titles = titles.into();
         self
     }
 
-    /// Set the resource_types that exists under `DublinCoreExtension`.
+    /// Set the resource_types for the `DublinCoreExtension`.
     pub fn resource_types<V>(mut self, resource_types: V) -> DublinCoreExtensionBuilder
         where V: Into<Vec<String>>
     {
@@ -323,7 +332,7 @@ impl DublinCoreExtensionBuilder {
         self
     }
 
-    /// Construct the `DublinCoreExtension` from the `DublinCoreExtensionBuilder`.
+    /// Construct the `DublinCoreExtension` from this `DublinCoreExtensionBuilder`.
     pub fn finalize(self) -> DublinCoreExtension {
         DublinCoreExtension {
             contributors: self.contributors,

--- a/src/extension/dublincore.rs
+++ b/src/extension/dublincore.rs
@@ -5,7 +5,6 @@
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the MIT License and/or Apache 2.0 License.
 
-use error::Error;
 use extension::Extension;
 use extension::remove_extension_values;
 use quick_xml::Writer;
@@ -317,23 +316,23 @@ impl DublinCoreExtensionBuilder {
     }
 
     /// Construct the `DublinCoreExtension` from the `DublinCoreExtensionBuilder`.
-    pub fn finalize(self) -> Result<DublinCoreExtension, Error> {
-        Ok(DublinCoreExtension {
-               contributors: self.contributors,
-               coverages: self.coverages,
-               creators: self.creators,
-               dates: self.dates,
-               descriptions: self.descriptions,
-               formats: self.formats,
-               identifiers: self.identifiers,
-               languages: self.languages,
-               publishers: self.publishers,
-               relations: self.relations,
-               rights: self.rights,
-               sources: self.sources,
-               subjects: self.subjects,
-               titles: self.titles,
-               resource_types: self.resource_types,
-           })
+    pub fn finalize(self) -> DublinCoreExtension {
+        DublinCoreExtension {
+            contributors: self.contributors,
+            coverages: self.coverages,
+            creators: self.creators,
+            dates: self.dates,
+            descriptions: self.descriptions,
+            formats: self.formats,
+            identifiers: self.identifiers,
+            languages: self.languages,
+            publishers: self.publishers,
+            relations: self.relations,
+            rights: self.rights,
+            sources: self.sources,
+            subjects: self.subjects,
+            titles: self.titles,
+            resource_types: self.resource_types,
+        }
     }
 }

--- a/src/extension/itunes/itunes_category.rs
+++ b/src/extension/itunes/itunes_category.rs
@@ -22,16 +22,16 @@ pub struct ITunesCategory {
 }
 
 impl ITunesCategory {
-    /// Get the text that exists under `ITunesCategory`.
+    /// Return the name of this category.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesCategoryBuilder, ITunesCategory};
+    /// use rss::extension::itunes::ITunesCategoryBuilder;
     ///
-    /// let text = "text";
+    /// let text = "category";
     ///
-    /// let category = ITunesCategoryBuilder::new()
+    /// let category = ITunesCategoryBuilder::default()
     ///     .text(text)
     ///     .finalize();
     ///
@@ -41,20 +41,19 @@ impl ITunesCategory {
         self.text.as_str()
     }
 
-
-    /// Get the optional subcategory that exists under `ITunesCategory`.
+    /// Return the subcategory for this category.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesCategoryBuilder, ITunesCategory};
+    /// use rss::extension::itunes::ITunesCategoryBuilder;
     ///
-    /// let subcategory = ITunesCategoryBuilder::new()
-    ///     .text("text")
+    /// let subcategory = ITunesCategoryBuilder::default()
+    ///     .text("subcategory")
     ///     .finalize();
     ///
-    /// let category = ITunesCategoryBuilder::new()
-    ///     .text("text")
+    /// let category = ITunesCategoryBuilder::default()
+    ///     .text("category")
     ///     .subcategory(Box::new(subcategory))
     ///     .finalize();
     ///
@@ -62,10 +61,9 @@ impl ITunesCategory {
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesCategoryBuilder, ITunesCategory};
+    /// use rss::extension::itunes::ITunesCategoryBuilder;
     ///
-    /// let category = ITunesCategoryBuilder::new()
-    ///     .text("text")
+    /// let category = ITunesCategoryBuilder::default()
     ///     .subcategory(None)
     ///     .finalize();
     ///
@@ -92,7 +90,7 @@ impl ToXml for ITunesCategory {
     }
 }
 
-/// This `ITunesCategoryBuilder` struct creates the `ITunesCategory`.
+/// A builder used to create an `ITunesCategory`.
 #[derive(Debug, Clone, Default)]
 pub struct ITunesCategoryBuilder {
     text: String,
@@ -100,46 +98,36 @@ pub struct ITunesCategoryBuilder {
 }
 
 impl ITunesCategoryBuilder {
-    /// Construct a new `ITunesCategoryBuilder` and return default values.
+    /// Set the name of the category.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesCategoryBuilder;
     ///
-    /// let category_builder = ITunesCategoryBuilder::new();
+    /// let builder = ITunesCategoryBuilder::default()
+    ///     .text("category");
     /// ```
-    pub fn new() -> ITunesCategoryBuilder {
-        ITunesCategoryBuilder::default()
-    }
-
-    /// Set the text that exists uner `ITunesCategory`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rss::extension::itunes::ITunesCategoryBuilder;
-    ///
-    /// let category_builder = ITunesCategoryBuilder::new()
-    ///     .text("text");
-    /// ```
-    pub fn text<S: Into<String>>(mut self, text: S) -> ITunesCategoryBuilder {
+    pub fn text<S>(mut self, text: S) -> ITunesCategoryBuilder
+        where S: Into<String>
+    {
         self.text = text.into();
         self
     }
 
-    /// Set the optional subcategory that exists uner `ITunesCategory`.
+    /// Set the subcategory for the category.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesCategoryBuilder;
     ///
-    /// let subcategory = ITunesCategoryBuilder::new()
-    ///     .text("text")
+    /// let subcategory = ITunesCategoryBuilder::default()
+    ///     .text("subcategory")
     ///     .finalize();
     ///
-    /// let category_builder = ITunesCategoryBuilder::new()
+    /// let builder = ITunesCategoryBuilder::default()
+    ///     .text("category")
     ///     .subcategory(Box::new(subcategory));
     /// ```
     pub fn subcategory<V>(mut self, subcategory: V) -> ITunesCategoryBuilder
@@ -149,20 +137,15 @@ impl ITunesCategoryBuilder {
         self
     }
 
-    /// Construct the `ITunesCategory` from the `ITunesCategoryBuilder`.
+    /// Construct the `ITunesCategory` from this `ITunesCategoryBuilder`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesCategoryBuilder;
     ///
-    /// let subcategory = ITunesCategoryBuilder::new()
-    ///     .text("text")
-    ///     .finalize();
-    ///
-    /// let category = ITunesCategoryBuilder::new()
-    ///     .text("text")
-    ///     .subcategory(Box::new(subcategory))
+    /// let category = ITunesCategoryBuilder::default()
+    ///     .text("category")
     ///     .finalize();
     /// ```
     pub fn finalize(self) -> ITunesCategory {

--- a/src/extension/itunes/itunes_category.rs
+++ b/src/extension/itunes/itunes_category.rs
@@ -27,8 +27,7 @@ impl ITunesCategory {
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesCategoryBuilder,
-    /// ITunesCategory};
+    /// use rss::extension::itunes::{ITunesCategoryBuilder, ITunesCategory};
     ///
     /// let text = "text";
     ///
@@ -48,8 +47,7 @@ impl ITunesCategory {
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesCategoryBuilder,
-    /// ITunesCategory};
+    /// use rss::extension::itunes::{ITunesCategoryBuilder, ITunesCategory};
     ///
     /// let subcategory = ITunesCategoryBuilder::new()
     ///     .text("text")
@@ -64,8 +62,7 @@ impl ITunesCategory {
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesCategoryBuilder,
-    /// ITunesCategory};
+    /// use rss::extension::itunes::{ITunesCategoryBuilder, ITunesCategory};
     ///
     /// let category = ITunesCategoryBuilder::new()
     ///     .text("text")
@@ -123,11 +120,11 @@ impl ITunesCategoryBuilder {
     /// ```
     /// use rss::extension::itunes::ITunesCategoryBuilder;
     ///
-    /// let mut category_builder = ITunesCategoryBuilder::new();
-    /// category_builder.text("text");
+    /// let category_builder = ITunesCategoryBuilder::new()
+    ///     .text("text");
     /// ```
-    pub fn text(mut self, text: &str) -> ITunesCategoryBuilder {
-        self.text = text.to_string();
+    pub fn text<S: Into<String>>(mut self, text: S) -> ITunesCategoryBuilder {
+        self.text = text.into();
         self
     }
 
@@ -142,8 +139,8 @@ impl ITunesCategoryBuilder {
     ///     .text("text")
     ///     .finalize();
     ///
-    /// let mut category_builder = ITunesCategoryBuilder::new();
-    /// category_builder.subcategory(Some(Box::new(subcategory)));
+    /// let category_builder = ITunesCategoryBuilder::new()
+    ///     .subcategory(Some(Box::new(subcategory)));
     /// ```
     pub fn subcategory(mut self,
                        subcategory: Option<Box<ITunesCategory>>)

--- a/src/extension/itunes/itunes_category.rs
+++ b/src/extension/itunes/itunes_category.rs
@@ -55,7 +55,7 @@ impl ITunesCategory {
     ///
     /// let category = ITunesCategoryBuilder::new()
     ///     .text("text")
-    ///     .subcategory(Some(Box::new(subcategory)))
+    ///     .subcategory(Box::new(subcategory))
     ///     .finalize();
     ///
     /// assert!(category.subcategory().is_some());
@@ -140,12 +140,12 @@ impl ITunesCategoryBuilder {
     ///     .finalize();
     ///
     /// let category_builder = ITunesCategoryBuilder::new()
-    ///     .subcategory(Some(Box::new(subcategory)));
+    ///     .subcategory(Box::new(subcategory));
     /// ```
-    pub fn subcategory(mut self,
-                       subcategory: Option<Box<ITunesCategory>>)
-                       -> ITunesCategoryBuilder {
-        self.subcategory = subcategory;
+    pub fn subcategory<V>(mut self, subcategory: V) -> ITunesCategoryBuilder
+        where V: Into<Option<Box<ITunesCategory>>>
+    {
+        self.subcategory = subcategory.into();
         self
     }
 
@@ -162,7 +162,7 @@ impl ITunesCategoryBuilder {
     ///
     /// let category = ITunesCategoryBuilder::new()
     ///     .text("text")
-    ///     .subcategory(Some(Box::new(subcategory)))
+    ///     .subcategory(Box::new(subcategory))
     ///     .finalize();
     /// ```
     pub fn finalize(self) -> ITunesCategory {

--- a/src/extension/itunes/itunes_category.rs
+++ b/src/extension/itunes/itunes_category.rs
@@ -5,7 +5,6 @@
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the MIT License and/or Apache 2.0 License.
 
-use error::Error;
 use quick_xml::errors::Error as XmlError;
 use quick_xml::events::{Event, BytesStart, BytesEnd};
 use quick_xml::writer::Writer;
@@ -35,8 +34,7 @@ impl ITunesCategory {
     ///
     /// let category = ITunesCategoryBuilder::new()
     ///     .text(text)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(text, category.text())
     /// ```
@@ -55,14 +53,12 @@ impl ITunesCategory {
     ///
     /// let subcategory = ITunesCategoryBuilder::new()
     ///     .text("text")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let category = ITunesCategoryBuilder::new()
     ///     .text("text")
     ///     .subcategory(Some(Box::new(subcategory)))
-    ///     .finalize()
-    ///     .unwrap();;
+    ///     .finalize();
     ///
     /// assert!(category.subcategory().is_some());
     /// ```
@@ -74,8 +70,7 @@ impl ITunesCategory {
     /// let category = ITunesCategoryBuilder::new()
     ///     .text("text")
     ///     .subcategory(None)
-    ///     .finalize()
-    ///     .unwrap();;
+    ///     .finalize();
     ///
     /// assert!(category.subcategory().is_none());
     /// ```
@@ -145,8 +140,7 @@ impl ITunesCategoryBuilder {
     ///
     /// let subcategory = ITunesCategoryBuilder::new()
     ///     .text("text")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let mut category_builder = ITunesCategoryBuilder::new();
     /// category_builder.subcategory(Some(Box::new(subcategory)));
@@ -167,19 +161,17 @@ impl ITunesCategoryBuilder {
     ///
     /// let subcategory = ITunesCategoryBuilder::new()
     ///     .text("text")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let category = ITunesCategoryBuilder::new()
     ///     .text("text")
     ///     .subcategory(Some(Box::new(subcategory)))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     /// ```
-    pub fn finalize(self) -> Result<ITunesCategory, Error> {
-        Ok(ITunesCategory {
-               text: self.text,
-               subcategory: self.subcategory,
-           })
+    pub fn finalize(self) -> ITunesCategory {
+        ITunesCategory {
+            text: self.text,
+            subcategory: self.subcategory,
+        }
     }
 }

--- a/src/extension/itunes/itunes_channel_extension.rs
+++ b/src/extension/itunes/itunes_channel_extension.rs
@@ -50,374 +50,328 @@ pub struct ITunesChannelExtension {
 }
 
 impl ITunesChannelExtension {
-    /// Get the optional author that exists under `ITunesChannelExtension`.
+    /// Return the author of this podcast.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
+    /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let author = "author".to_string();
+    /// let author = "author";
     ///
-    /// let channel = ITunesChannelExtensionBuilder::new()
-    ///     .author(author.clone())
+    /// let ext = ITunesChannelExtensionBuilder::default()
+    ///     .author(author.to_string())
     ///     .finalize();
     ///
-    /// let author_opt = channel.author();
-    /// assert!(author_opt.is_some());
-    ///
-    /// assert_eq!(author.clone(), author_opt.unwrap());
+    /// assert_eq!(Some(author), ext.author());
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
+    /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let channel = ITunesChannelExtensionBuilder::new()
+    /// let ext = ITunesChannelExtensionBuilder::default()
     ///     .author(None)
     ///     .finalize();
     ///
-    /// let author_opt = channel.author();
-    /// assert!(author_opt.is_none());
+    /// assert!(ext.author().is_none());
     /// ```
     pub fn author(&self) -> Option<&str> {
         self.author.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the optional block that exists under `ITunesChannelExtension`.
+    /// Return whether the podcast should be blocked from appearing in the iTunes Store.
+    ///
+    /// A value of `Yes` indicates that the podcast should not show up in the iTunes Store. All
+    /// other values are ignored.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
+    /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let block = "block".to_string();
+    /// let block = "Yes";
     ///
-    /// let channel = ITunesChannelExtensionBuilder::new()
-    ///     .block(block.clone())
+    /// let ext = ITunesChannelExtensionBuilder::default()
+    ///     .block(block.to_string())
     ///     .finalize();
     ///
-    /// let block_opt = channel.block();
-    /// assert!(block_opt.is_some());
-    ///
-    /// assert_eq!(block.clone(), block_opt.unwrap());
+    /// assert_eq!(Some(block), ext.block());
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
+    /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let channel = ITunesChannelExtensionBuilder::new()
+    /// let ext = ITunesChannelExtensionBuilder::default()
     ///     .block(None)
     ///     .finalize();
     ///
-    /// let block_opt = channel.block();
-    /// assert!(block_opt.is_none());
+    /// assert!(ext.block().is_none());
     /// ```
     pub fn block(&self) -> Option<&str> {
         self.block.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the categories that exists under `ITunesChannelExtension`.
+    /// Return the iTunes categories that the podcast belongs to.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension,
-    ///     ITunesCategoryBuilder};
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesCategoryBuilder};
     ///
-    /// let subcategory = ITunesCategoryBuilder::new()
-    ///     .text("text")
+    /// let category = ITunesCategoryBuilder::default()
+    ///     .text("category")
     ///     .finalize();
     ///
-    /// let category = ITunesCategoryBuilder::new()
-    ///     .text("text")
-    ///     .subcategory(Box::new(subcategory))
+    /// let categories = vec![category];
+    ///
+    /// let ext = ITunesChannelExtensionBuilder::default()
+    ///     .categories(categories.clone())
     ///     .finalize();
     ///
-    /// let categories_vec = vec![category];
-    ///
-    /// let channel = ITunesChannelExtensionBuilder::new()
-    ///     .categories(categories_vec)
-    ///     .finalize();
-    ///
-    /// let categories = channel.categories();
-    /// assert!(!categories.is_empty());
+    /// assert_eq!(categories, ext.categories());
     /// ```
     pub fn categories(&self) -> &[ITunesCategory] {
         &self.categories
     }
 
-
-    /// Get the optional image that exists under `ITunesChannelExtension`.
+    /// Return the artwork URL for the podcast.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
+    /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let image = "image".to_string();
+    /// let image = "http://example.com/image.png";
     ///
-    /// let channel = ITunesChannelExtensionBuilder::new()
-    ///     .image(image.clone())
+    /// let ext = ITunesChannelExtensionBuilder::default()
+    ///     .image(image.to_string())
     ///     .finalize();
     ///
-    /// let image_opt = channel.image();
-    /// assert!(image_opt.is_some());
-    ///
-    /// assert_eq!(image, image_opt.unwrap());
+    /// assert_eq!(Some(image), ext.image());
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
+    /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let channel = ITunesChannelExtensionBuilder::new()
+    /// let ext = ITunesChannelExtensionBuilder::default()
     ///     .image(None)
     ///     .finalize();
     ///
-    /// let image_opt = channel.image();
-    /// assert!(image_opt.is_none());
+    /// assert!(ext.image().is_none());
     /// ```
     pub fn image(&self) -> Option<&str> {
         self.image.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the optional explicit that exists under `ITunesChannelExtension`.
+    /// Return whether the podcast contains explicit content.
+    ///
+    /// A value of `Yes`, `Explicit`, or `True` indicates that the podcast contains explicit
+    /// content. A value of `Clean`, `No`, `False` inidicates that none of the episodes contain
+    /// explicit content.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
+    /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let explicit = "explicit".to_string();
+    /// let explicit = "Yes";
     ///
-    /// let channel = ITunesChannelExtensionBuilder::new()
-    ///     .explicit(explicit.clone())
+    /// let ext = ITunesChannelExtensionBuilder::default()
+    ///     .explicit(explicit.to_string())
     ///     .finalize();
     ///
-    /// let explicit_opt = channel.explicit();
-    /// assert!(explicit_opt.is_some());
-    ///
-    /// assert_eq!(explicit.clone(), explicit_opt.unwrap());
+    /// assert_eq!(Some(explicit), ext.explicit());
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
+    /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let channel = ITunesChannelExtensionBuilder::new()
+    /// let ext = ITunesChannelExtensionBuilder::default()
     ///     .explicit(None)
     ///     .finalize();
     ///
-    /// let explicit_opt = channel.explicit();
-    /// assert!(explicit_opt.is_none());
+    /// assert!(ext.explicit().is_none());
     /// ```
     pub fn explicit(&self) -> Option<&str> {
         self.explicit.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the optional complete that exists under `ITunesChannelExtension`.
+    /// Return whether the podcast is complete and no new episodes will be posted.
+    ///
+    /// A value of `Yes` indicates that the podcast is complete.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
+    /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let complete = "complete".to_string();
+    /// let complete = "Yes";
     ///
-    /// let channel = ITunesChannelExtensionBuilder::new()
-    ///     .complete(complete.clone())
+    /// let ext = ITunesChannelExtensionBuilder::default()
+    ///     .complete(complete.to_string())
     ///     .finalize();
     ///
-    /// let complete_opt = channel.complete();
-    /// assert!(complete_opt.is_some());
-    ///
-    /// assert_eq!(complete.clone(), complete_opt.unwrap());
+    /// assert_eq!(Some(complete), ext.complete());
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
+    /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let channel = ITunesChannelExtensionBuilder::new()
+    /// let ext = ITunesChannelExtensionBuilder::default()
     ///     .complete(None)
     ///     .finalize();
     ///
-    /// let complete_opt = channel.complete();
-    /// assert!(complete_opt.is_none());
+    /// assert!(ext.complete().is_none());
     /// ```
     pub fn complete(&self) -> Option<&str> {
         self.complete.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the optional new_feed_url that exists under
-    /// `ITunesChannelExtension`.
+    /// Return the new feed URL for this podcast.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
+    /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let new_feed_url = "new_feed_url".to_string();
+    /// let url = "http://example.com/feed";
     ///
-    /// let channel = ITunesChannelExtensionBuilder::new()
-    ///     .new_feed_url(new_feed_url.clone())
+    /// let ext = ITunesChannelExtensionBuilder::default()
+    ///     .new_feed_url(url.to_string())
     ///     .finalize();
     ///
-    /// let new_feed_url_opt = channel.new_feed_url();
-    /// assert!(new_feed_url_opt.is_some());
-    ///
-    /// assert_eq!(new_feed_url.clone(), new_feed_url_opt.unwrap());
+    /// assert_eq!(Some(url), ext.new_feed_url());
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
+    /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let channel = ITunesChannelExtensionBuilder::new()
+    /// let ext = ITunesChannelExtensionBuilder::default()
     ///     .new_feed_url(None)
     ///     .finalize();
     ///
-    /// let new_feed_url_opt = channel.new_feed_url();
-    /// assert!(new_feed_url_opt.is_none());
+    /// assert!(ext.new_feed_url().is_none());
     /// ```
     pub fn new_feed_url(&self) -> Option<&str> {
         self.new_feed_url.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the optional owner that exists under `ITunesChannelExtension`.
+    /// Return the contact information for the owner of this podcast.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension,
-    ///     ITunesOwnerBuilder};
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesOwnerBuilder};
     ///
-    /// let owner = ITunesOwnerBuilder::new()
+    /// let owner = ITunesOwnerBuilder::default()
     ///     .email("email@example.com".to_string())
     ///     .name("name".to_string())
     ///     .finalize();
     ///
-    /// let channel = ITunesChannelExtensionBuilder::new()
+    /// let ext = ITunesChannelExtensionBuilder::default()
     ///     .owner(owner)
     ///     .finalize();
     ///
-    /// let owner_opt = channel.owner();
-    /// assert!(owner_opt.is_some());
+    /// assert!(ext.owner().is_some());
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
+    /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let channel = ITunesChannelExtensionBuilder::new()
+    /// let ext = ITunesChannelExtensionBuilder::default()
     ///     .owner(None)
     ///     .finalize();
     ///
-    /// let owner_opt = channel.owner();
-    /// assert!(owner_opt.is_none());
+    /// assert!(ext.owner().is_none());
     /// ```
     pub fn owner(&self) -> Option<&ITunesOwner> {
         self.owner.as_ref()
     }
 
-
-    /// Get the optional subtitle that exists under `ITunesChannelExtension`.
+    /// Return the description of this podcast.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
+    /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let subtitle = "subtitle".to_string();
+    /// let subtitle = "description";
     ///
-    /// let channel = ITunesChannelExtensionBuilder::new()
-    ///     .subtitle(subtitle.clone())
+    /// let ext = ITunesChannelExtensionBuilder::default()
+    ///     .subtitle(subtitle.to_string())
     ///     .finalize();
     ///
-    /// let subtitle_opt = channel.subtitle();
-    /// assert!(subtitle_opt.is_some());
-    ///
-    /// assert_eq!(subtitle.clone(), subtitle_opt.unwrap());
+    /// assert_eq!(Some(subtitle), ext.subtitle())
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
+    /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let channel = ITunesChannelExtensionBuilder::new()
+    /// let ext = ITunesChannelExtensionBuilder::default()
     ///     .subtitle(None)
     ///     .finalize();
     ///
-    /// let subtitle_opt = channel.subtitle();
-    /// assert!(subtitle_opt.is_none());
+    /// assert!(ext.subtitle().is_none());
     /// ```
     pub fn subtitle(&self) -> Option<&str> {
         self.subtitle.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the optional summary that exists under `ITunesChannelExtension`.
+    /// Return the summary for this podcast.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
+    /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let summary = "summary".to_string();
+    /// let summary = "summary";
     ///
-    /// let channel = ITunesChannelExtensionBuilder::new()
-    ///     .summary(summary.clone())
+    /// let ext = ITunesChannelExtensionBuilder::default()
+    ///     .summary(summary.to_string())
     ///     .finalize();
     ///
-    /// let summary_opt = channel.summary();
-    /// assert!(summary_opt.is_some());
-    ///
-    /// assert_eq!(summary.clone(), summary_opt.unwrap());
+    /// assert_eq!(Some(summary), ext.summary());
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
+    /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let channel = ITunesChannelExtensionBuilder::new()
+    /// let ext = ITunesChannelExtensionBuilder::default()
     ///     .summary(None)
     ///     .finalize();
     ///
-    /// let summary_opt = channel.summary();
-    /// assert!(summary_opt.is_none());
+    /// assert!(ext.summary().is_none());
     /// ```
     pub fn summary(&self) -> Option<&str> {
         self.summary.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the optional keywords that exists under `ITunesChannelExtension`.
+    /// Return the keywords for this podcast.
+    ///
+    /// The string contains a comma separated list of keywords.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
+    /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let keywords = "keywords".to_string();
+    /// let keywords = "keyword1,keyword2";
     ///
-    /// let channel = ITunesChannelExtensionBuilder::new()
-    ///     .keywords(keywords.clone())
+    /// let ext = ITunesChannelExtensionBuilder::default()
+    ///     .keywords(keywords.to_string())
     ///     .finalize();
     ///
-    /// let keywords_opt = channel.keywords();
-    /// assert!(keywords_opt.is_some());
-    ///
-    /// assert_eq!(keywords.clone(), keywords_opt.unwrap());
+    /// assert_eq!(Some(keywords), ext.keywords());
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
+    /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let channel = ITunesChannelExtensionBuilder::new()
+    /// let ext = ITunesChannelExtensionBuilder::default()
     ///     .keywords(None)
     ///     .finalize();
     ///
-    /// let keywords_opt = channel.keywords();
-    /// assert!(keywords_opt.is_none());
+    /// assert!(ext.keywords().is_none());
     /// ```
     pub fn keywords(&self) -> Option<&str> {
         self.keywords.as_ref().map(|s| s.as_str())
@@ -495,8 +449,7 @@ impl ToXml for ITunesChannelExtension {
     }
 }
 
-/// This `ITunesChannelExtensionBuilder` struct creates the
-/// `ITunesChannelExtension`.
+/// A builder used to create an `ITunesChannelExtension`.
 #[derive(Debug, Clone, Default)]
 pub struct ITunesChannelExtensionBuilder {
     author: Option<String>,
@@ -513,67 +466,50 @@ pub struct ITunesChannelExtensionBuilder {
 }
 
 impl ITunesChannelExtensionBuilder {
-    /// Construct a new `ITunesChannelExtension` and return default values.
-    ///
-    /// # Examples
+    /// Set the author of the podcast.
     ///
     /// ```
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let channel_builder = ITunesChannelExtensionBuilder::new();
-    /// ```
-    pub fn new() -> ITunesChannelExtensionBuilder {
-        ITunesChannelExtensionBuilder::default()
-    }
-
-
-    /// Set the optional author that exists under `ITunesChannelExtension`.
-    ///
-    /// ```
-    /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
-    ///
-    /// let channel_builder = ITunesChannelExtensionBuilder::new()
+    /// let builder = ITunesChannelExtensionBuilder::default()
     ///     .author("author".to_string());
     /// ```
-    pub fn author<V: Into<Option<String>>>(mut self, author: V) -> ITunesChannelExtensionBuilder {
+    pub fn author<V>(mut self, author: V) -> ITunesChannelExtensionBuilder
+        where V: Into<Option<String>>
+    {
         self.author = author.into();
         self
     }
 
-
-    /// Set the optional block that exists under `ITunesChannelExtension`.
+    /// Set whether the podcast should be blocked from appearing in the iTunes Store.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let channel_builder = ITunesChannelExtensionBuilder::new()
-    ///     .block("block".to_string());
+    /// let builder = ITunesChannelExtensionBuilder::default()
+    ///     .block("Yes".to_string());
     /// ```
-    pub fn block<V: Into<Option<String>>>(mut self, block: V) -> ITunesChannelExtensionBuilder {
+    pub fn block<V>(mut self, block: V) -> ITunesChannelExtensionBuilder
+        where V: Into<Option<String>>
+    {
         self.block = block.into();
         self
     }
 
-
-    /// Set the categories that exists under `ITunesChannelExtension`.
+    /// Set the iTunes categories that the podcast belongs to.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::{ITunesCategoryBuilder, ITunesChannelExtensionBuilder};
     ///
-    /// let subcategory = ITunesCategoryBuilder::new()
-    ///     .text("text")
+    /// let category = ITunesCategoryBuilder::default()
+    ///     .text("category")
     ///     .finalize();
     ///
-    /// let category = ITunesCategoryBuilder::new()
-    ///     .text("text")
-    ///     .subcategory(Box::new(subcategory))
-    ///     .finalize();
-    ///
-    /// let channel_builder = ITunesChannelExtensionBuilder::new()
+    /// let builder = ITunesChannelExtensionBuilder::default()
     ///     .categories(vec![category]);
     /// ```
     pub fn categories<V>(mut self, categories: V) -> ITunesChannelExtensionBuilder
@@ -583,32 +519,32 @@ impl ITunesChannelExtensionBuilder {
         self
     }
 
-
-    /// Set the optional image that exists under `ITunesChannelExtension`.
+    /// Set the artwork URL for the podcast.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let channel_builder = ITunesChannelExtensionBuilder::new()
-    ///     .image("image".to_string());
+    /// let builder = ITunesChannelExtensionBuilder::default()
+    ///     .image("http://example.com/image.png".to_string());
     /// ```
-    pub fn image<V: Into<Option<String>>>(mut self, image: V) -> ITunesChannelExtensionBuilder {
+    pub fn image<V>(mut self, image: V) -> ITunesChannelExtensionBuilder
+        where V: Into<Option<String>>
+    {
         self.image = image.into();
         self
     }
 
-
-    /// Set the optional explicit that exists under `ITunesChannelExtension`.
+    /// Set whether the podcast contains explicit content.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let channel_builder = ITunesChannelExtensionBuilder::new()
-    ///     .explicit("explicit".to_string());
+    /// let builder = ITunesChannelExtensionBuilder::default()
+    ///     .explicit("Yes".to_string());
     /// ```
     pub fn explicit<V>(mut self, explicit: V) -> ITunesChannelExtensionBuilder
         where V: Into<Option<String>>
@@ -617,16 +553,15 @@ impl ITunesChannelExtensionBuilder {
         self
     }
 
-
-    /// Set the optional complete that exists under `ITunesChannelExtension`.
+    /// Set whether the podcast is complete and no new episodes will be posted.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let channel_builder = ITunesChannelExtensionBuilder::new()
-    ///     .complete("complete".to_string());
+    /// let builder = ITunesChannelExtensionBuilder::default()
+    ///     .complete("Yes".to_string());
     /// ```
     pub fn complete<V>(mut self, complete: V) -> ITunesChannelExtensionBuilder
         where V: Into<Option<String>>
@@ -635,16 +570,15 @@ impl ITunesChannelExtensionBuilder {
         self
     }
 
-
-    /// Set the optional new_feed_url that exists under `ITunesChannelExtension`.
+    /// Set the new feed URL for the podcast.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let channel_builder = ITunesChannelExtensionBuilder::new()
-    ///     .new_feed_url("new_feed_url".to_string());
+    /// let builder = ITunesChannelExtensionBuilder::default()
+    ///     .new_feed_url("http://example.com/feed".to_string());
     /// ```
     pub fn new_feed_url<V>(mut self, new_feed_url: V) -> ITunesChannelExtensionBuilder
         where V: Into<Option<String>>
@@ -653,20 +587,19 @@ impl ITunesChannelExtensionBuilder {
         self
     }
 
-
-    /// Set the optional owner that exists under `ITunesChannelExtension`.
+    /// Set the contact information for the owner of the podcast.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesOwnerBuilder};
     ///
-    /// let owner = ITunesOwnerBuilder::new()
+    /// let owner = ITunesOwnerBuilder::default()
     ///     .email("email@example.com".to_string())
     ///     .name("name".to_string())
     ///     .finalize();
     ///
-    /// let channel_builder = ITunesChannelExtensionBuilder::new()
+    /// let builder = ITunesChannelExtensionBuilder::default()
     ///     .owner(owner);
     /// ```
     pub fn owner<V>(mut self, owner: V) -> ITunesChannelExtensionBuilder
@@ -676,16 +609,15 @@ impl ITunesChannelExtensionBuilder {
         self
     }
 
-
-    /// Set the optional subtitle that exists under `ITunesChannelExtension`.
+    /// Set the description of the podcast.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let channel_builder = ITunesChannelExtensionBuilder::new()
-    ///     .subtitle("subtitle".to_string());
+    /// let builder = ITunesChannelExtensionBuilder::default()
+    ///     .subtitle("description".to_string());
     /// ```
     pub fn subtitle<V>(mut self, subtitle: V) -> ITunesChannelExtensionBuilder
         where V: Into<Option<String>>
@@ -694,32 +626,34 @@ impl ITunesChannelExtensionBuilder {
         self
     }
 
-
-    /// Set the optional summary that exists under `ITunesChannelExtension`.
+    /// Set the summary for the podcast.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let channel_builder = ITunesChannelExtensionBuilder::new()
+    /// let builder = ITunesChannelExtensionBuilder::default()
     ///     .summary("summary".to_string());
     /// ```
-    pub fn summary<V: Into<Option<String>>>(mut self, summary: V) -> ITunesChannelExtensionBuilder {
+    pub fn summary<V>(mut self, summary: V) -> ITunesChannelExtensionBuilder
+        where V: Into<Option<String>>
+    {
         self.summary = summary.into();
         self
     }
 
-
-    /// Set the optional keywords that exists under `ITunesChannelExtension`.
+    /// Set the keywords for the podcast.
+    ///
+    /// The string should be a comma separated list of keywords.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let channel_builder = ITunesChannelExtensionBuilder::new()
-    ///     .keywords("keywords".to_string());
+    /// let builder = ITunesChannelExtensionBuilder::default()
+    ///     .keywords("keyword1,keyword2".to_string());
     /// ```
     pub fn keywords<V>(mut self, keywords: V) -> ITunesChannelExtensionBuilder
         where V: Into<Option<String>>
@@ -728,8 +662,7 @@ impl ITunesChannelExtensionBuilder {
         self
     }
 
-
-    /// Construct the `ITunesChannelExtension` from the `ITunesChannelExtensionBuilder`.
+    /// Construct the `ITunesChannelExtension` from this `ITunesChannelExtensionBuilder`.
     ///
     /// # Examples
     ///
@@ -737,34 +670,13 @@ impl ITunesChannelExtensionBuilder {
     /// use rss::extension::itunes::{ITunesCategoryBuilder, ITunesChannelExtensionBuilder,
     ///     ITunesOwnerBuilder};
     ///
-    /// let owner = ITunesOwnerBuilder::new()
+    /// let owner = ITunesOwnerBuilder::default()
     ///     .email("email@example.com".to_string())
     ///     .name("name".to_string())
     ///     .finalize();
     ///
-    /// let subcategory = ITunesCategoryBuilder::new()
-    ///     .text("text")
-    ///     .finalize();
-    ///
-    /// let category = ITunesCategoryBuilder::new()
-    ///     .text("text")
-    ///     .subcategory(Box::new(subcategory))
-    ///     .finalize();
-    ///
-    /// let categories = vec![category];
-    ///
-    /// let channel = ITunesChannelExtensionBuilder::new()
-    ///     .author("author".to_string())
-    ///     .block("block".to_string())
-    ///     .image("image".to_string())
-    ///     .explicit("explicit".to_string())
-    ///     .subtitle("subtitle".to_string())
-    ///     .summary("summary".to_string())
-    ///     .keywords("keywords".to_string())
-    ///     .new_feed_url("new_feed_url".to_string())
-    ///     .complete("complete".to_string())
+    /// let ext = ITunesChannelExtensionBuilder::default()
     ///     .owner(owner)
-    ///     .categories(categories)
     ///     .finalize();
     /// ```
     pub fn finalize(self) -> ITunesChannelExtension {

--- a/src/extension/itunes/itunes_channel_extension.rs
+++ b/src/extension/itunes/itunes_channel_extension.rs
@@ -62,8 +62,7 @@ impl ITunesChannelExtension {
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .author(Some(author.clone()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let author_opt = channel.author();
     /// assert!(author_opt.is_some());
@@ -77,8 +76,7 @@ impl ITunesChannelExtension {
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .author(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let author_opt = channel.author();
     /// assert!(author_opt.is_none());
@@ -100,8 +98,7 @@ impl ITunesChannelExtension {
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .block(Some(block.clone()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let block_opt = channel.block();
     /// assert!(block_opt.is_some());
@@ -115,8 +112,7 @@ impl ITunesChannelExtension {
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .block(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let block_opt = channel.block();
     /// assert!(block_opt.is_none());
@@ -136,21 +132,18 @@ impl ITunesChannelExtension {
     ///
     /// let subcategory = ITunesCategoryBuilder::new()
     ///     .text("text")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let category = ITunesCategoryBuilder::new()
     ///     .text("text")
     ///     .subcategory(Some(Box::new(subcategory)))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let categories_vec = vec![category];
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .categories(categories_vec)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let categories = channel.categories();
     /// assert!(!categories.is_empty());
@@ -172,8 +165,7 @@ impl ITunesChannelExtension {
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .image(Some(image.clone()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let image_opt = channel.image();
     /// assert!(image_opt.is_some());
@@ -187,8 +179,7 @@ impl ITunesChannelExtension {
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .image(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let image_opt = channel.image();
     /// assert!(image_opt.is_none());
@@ -210,8 +201,7 @@ impl ITunesChannelExtension {
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .explicit(Some(explicit.clone()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let explicit_opt = channel.explicit();
     /// assert!(explicit_opt.is_some());
@@ -225,8 +215,7 @@ impl ITunesChannelExtension {
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .explicit(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let explicit_opt = channel.explicit();
     /// assert!(explicit_opt.is_none());
@@ -248,8 +237,7 @@ impl ITunesChannelExtension {
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .complete(Some(complete.clone()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let complete_opt = channel.complete();
     /// assert!(complete_opt.is_some());
@@ -263,8 +251,7 @@ impl ITunesChannelExtension {
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .complete(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let complete_opt = channel.complete();
     /// assert!(complete_opt.is_none());
@@ -287,8 +274,7 @@ impl ITunesChannelExtension {
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .new_feed_url(Some(new_feed_url.clone()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let new_feed_url_opt = channel.new_feed_url();
     /// assert!(new_feed_url_opt.is_some());
@@ -302,8 +288,7 @@ impl ITunesChannelExtension {
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .new_feed_url(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let new_feed_url_opt = channel.new_feed_url();
     /// assert!(new_feed_url_opt.is_none());
@@ -324,13 +309,11 @@ impl ITunesChannelExtension {
     /// let owner = ITunesOwnerBuilder::new()
     ///     .email(Some("email@example.com".to_string()))
     ///     .name(Some("name".to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .owner(Some(owner))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let owner_opt = channel.owner();
     /// assert!(owner_opt.is_some());
@@ -342,8 +325,7 @@ impl ITunesChannelExtension {
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .owner(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let owner_opt = channel.owner();
     /// assert!(owner_opt.is_none());
@@ -365,8 +347,7 @@ impl ITunesChannelExtension {
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .subtitle(Some(subtitle.clone()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let subtitle_opt = channel.subtitle();
     /// assert!(subtitle_opt.is_some());
@@ -380,8 +361,7 @@ impl ITunesChannelExtension {
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .subtitle(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let subtitle_opt = channel.subtitle();
     /// assert!(subtitle_opt.is_none());
@@ -403,8 +383,7 @@ impl ITunesChannelExtension {
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .summary(Some(summary.clone()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let summary_opt = channel.summary();
     /// assert!(summary_opt.is_some());
@@ -418,8 +397,7 @@ impl ITunesChannelExtension {
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .summary(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let summary_opt = channel.summary();
     /// assert!(summary_opt.is_none());
@@ -441,8 +419,7 @@ impl ITunesChannelExtension {
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .keywords(Some(keywords.clone()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let keywords_opt = channel.keywords();
     /// assert!(keywords_opt.is_some());
@@ -456,8 +433,7 @@ impl ITunesChannelExtension {
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .keywords(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let keywords_opt = channel.keywords();
     /// assert!(keywords_opt.is_none());
@@ -610,14 +586,12 @@ impl ITunesChannelExtensionBuilder {
     ///
     /// let subcategory = ITunesCategoryBuilder::new()
     ///     .text("text")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let category = ITunesCategoryBuilder::new()
     ///     .text("text")
     ///     .subcategory(Some(Box::new(subcategory)))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let categories = vec![category];
     ///
@@ -706,8 +680,7 @@ impl ITunesChannelExtensionBuilder {
     /// let owner = ITunesOwnerBuilder::new()
     ///     .email(Some("email@example.com".to_string()))
     ///     .name(Some("name".to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let mut channel_builder = ITunesChannelExtensionBuilder::new();
     /// channel_builder.owner(Some(owner));
@@ -778,19 +751,16 @@ impl ITunesChannelExtensionBuilder {
     /// let owner = ITunesOwnerBuilder::new()
     ///     .email(Some("email@example.com".to_string()))
     ///     .name(Some("name".to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let subcategory = ITunesCategoryBuilder::new()
     ///     .text("text")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let category = ITunesCategoryBuilder::new()
     ///     .text("text")
     ///     .subcategory(Some(Box::new(subcategory)))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let categories = vec![category];
     ///
@@ -806,22 +776,21 @@ impl ITunesChannelExtensionBuilder {
     ///     .complete(Some("complete".to_string()))
     ///     .owner(Some(owner))
     ///     .categories(categories)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     /// ```
-    pub fn finalize(self) -> Result<ITunesChannelExtension, Error> {
-        Ok(ITunesChannelExtension {
-               author: self.author,
-               block: self.block,
-               categories: self.categories,
-               image: self.image,
-               explicit: self.explicit,
-               complete: self.complete,
-               new_feed_url: self.new_feed_url,
-               owner: self.owner,
-               subtitle: self.subtitle,
-               summary: self.summary,
-               keywords: self.keywords,
-           })
+    pub fn finalize(self) -> ITunesChannelExtension {
+        ITunesChannelExtension {
+            author: self.author,
+            block: self.block,
+            categories: self.categories,
+            image: self.image,
+            explicit: self.explicit,
+            complete: self.complete,
+            new_feed_url: self.new_feed_url,
+            owner: self.owner,
+            subtitle: self.subtitle,
+            summary: self.summary,
+            keywords: self.keywords,
+        }
     }
 }

--- a/src/extension/itunes/itunes_channel_extension.rs
+++ b/src/extension/itunes/itunes_channel_extension.rs
@@ -60,7 +60,7 @@ impl ITunesChannelExtension {
     /// let author = "author".to_string();
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
-    ///     .author(Some(author.clone()))
+    ///     .author(author.clone())
     ///     .finalize();
     ///
     /// let author_opt = channel.author();
@@ -94,7 +94,7 @@ impl ITunesChannelExtension {
     /// let block = "block".to_string();
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
-    ///     .block(Some(block.clone()))
+    ///     .block(block.clone())
     ///     .finalize();
     ///
     /// let block_opt = channel.block();
@@ -132,7 +132,7 @@ impl ITunesChannelExtension {
     ///
     /// let category = ITunesCategoryBuilder::new()
     ///     .text("text")
-    ///     .subcategory(Some(Box::new(subcategory)))
+    ///     .subcategory(Box::new(subcategory))
     ///     .finalize();
     ///
     /// let categories_vec = vec![category];
@@ -159,13 +159,13 @@ impl ITunesChannelExtension {
     /// let image = "image".to_string();
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
-    ///     .image(Some(image.clone()))
+    ///     .image(image.clone())
     ///     .finalize();
     ///
     /// let image_opt = channel.image();
     /// assert!(image_opt.is_some());
     ///
-    /// assert_eq!(image.clone(), image_opt.unwrap());
+    /// assert_eq!(image, image_opt.unwrap());
     /// ```
     ///
     /// ```
@@ -193,7 +193,7 @@ impl ITunesChannelExtension {
     /// let explicit = "explicit".to_string();
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
-    ///     .explicit(Some(explicit.clone()))
+    ///     .explicit(explicit.clone())
     ///     .finalize();
     ///
     /// let explicit_opt = channel.explicit();
@@ -227,7 +227,7 @@ impl ITunesChannelExtension {
     /// let complete = "complete".to_string();
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
-    ///     .complete(Some(complete.clone()))
+    ///     .complete(complete.clone())
     ///     .finalize();
     ///
     /// let complete_opt = channel.complete();
@@ -262,7 +262,7 @@ impl ITunesChannelExtension {
     /// let new_feed_url = "new_feed_url".to_string();
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
-    ///     .new_feed_url(Some(new_feed_url.clone()))
+    ///     .new_feed_url(new_feed_url.clone())
     ///     .finalize();
     ///
     /// let new_feed_url_opt = channel.new_feed_url();
@@ -295,12 +295,12 @@ impl ITunesChannelExtension {
     ///     ITunesOwnerBuilder};
     ///
     /// let owner = ITunesOwnerBuilder::new()
-    ///     .email(Some("email@example.com".to_string()))
-    ///     .name(Some("name".to_string()))
+    ///     .email("email@example.com".to_string())
+    ///     .name("name".to_string())
     ///     .finalize();
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
-    ///     .owner(Some(owner))
+    ///     .owner(owner)
     ///     .finalize();
     ///
     /// let owner_opt = channel.owner();
@@ -332,7 +332,7 @@ impl ITunesChannelExtension {
     /// let subtitle = "subtitle".to_string();
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
-    ///     .subtitle(Some(subtitle.clone()))
+    ///     .subtitle(subtitle.clone())
     ///     .finalize();
     ///
     /// let subtitle_opt = channel.subtitle();
@@ -366,7 +366,7 @@ impl ITunesChannelExtension {
     /// let summary = "summary".to_string();
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
-    ///     .summary(Some(summary.clone()))
+    ///     .summary(summary.clone())
     ///     .finalize();
     ///
     /// let summary_opt = channel.summary();
@@ -400,7 +400,7 @@ impl ITunesChannelExtension {
     /// let keywords = "keywords".to_string();
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
-    ///     .keywords(Some(keywords.clone()))
+    ///     .keywords(keywords.clone())
     ///     .finalize();
     ///
     /// let keywords_opt = channel.keywords();
@@ -533,10 +533,10 @@ impl ITunesChannelExtensionBuilder {
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
     /// let channel_builder = ITunesChannelExtensionBuilder::new()
-    ///     .author(Some("author".to_string()));
+    ///     .author("author".to_string());
     /// ```
-    pub fn author(mut self, author: Option<String>) -> ITunesChannelExtensionBuilder {
-        self.author = author;
+    pub fn author<V: Into<Option<String>>>(mut self, author: V) -> ITunesChannelExtensionBuilder {
+        self.author = author.into();
         self
     }
 
@@ -549,10 +549,10 @@ impl ITunesChannelExtensionBuilder {
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
     /// let channel_builder = ITunesChannelExtensionBuilder::new()
-    ///     .block(Some("block".to_string()));
+    ///     .block("block".to_string());
     /// ```
-    pub fn block(mut self, block: Option<String>) -> ITunesChannelExtensionBuilder {
-        self.block = block;
+    pub fn block<V: Into<Option<String>>>(mut self, block: V) -> ITunesChannelExtensionBuilder {
+        self.block = block.into();
         self
     }
 
@@ -570,16 +570,16 @@ impl ITunesChannelExtensionBuilder {
     ///
     /// let category = ITunesCategoryBuilder::new()
     ///     .text("text")
-    ///     .subcategory(Some(Box::new(subcategory)))
+    ///     .subcategory(Box::new(subcategory))
     ///     .finalize();
     ///
-    /// let categories = vec![category];
-    ///
     /// let channel_builder = ITunesChannelExtensionBuilder::new()
-    ///     .categories(categories);
+    ///     .categories(vec![category]);
     /// ```
-    pub fn categories(mut self, categories: Vec<ITunesCategory>) -> ITunesChannelExtensionBuilder {
-        self.categories = categories;
+    pub fn categories<V>(mut self, categories: V) -> ITunesChannelExtensionBuilder
+        where V: Into<Vec<ITunesCategory>>
+    {
+        self.categories = categories.into();
         self
     }
 
@@ -592,10 +592,10 @@ impl ITunesChannelExtensionBuilder {
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
     /// let channel_builder = ITunesChannelExtensionBuilder::new()
-    ///     .image(Some("image".to_string()));
+    ///     .image("image".to_string());
     /// ```
-    pub fn image(mut self, image: Option<String>) -> ITunesChannelExtensionBuilder {
-        self.image = image;
+    pub fn image<V: Into<Option<String>>>(mut self, image: V) -> ITunesChannelExtensionBuilder {
+        self.image = image.into();
         self
     }
 
@@ -608,10 +608,12 @@ impl ITunesChannelExtensionBuilder {
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
     /// let channel_builder = ITunesChannelExtensionBuilder::new()
-    ///     .explicit(Some("explicit".to_string()));
+    ///     .explicit("explicit".to_string());
     /// ```
-    pub fn explicit(mut self, explicit: Option<String>) -> ITunesChannelExtensionBuilder {
-        self.explicit = explicit;
+    pub fn explicit<V>(mut self, explicit: V) -> ITunesChannelExtensionBuilder
+        where V: Into<Option<String>>
+    {
+        self.explicit = explicit.into();
         self
     }
 
@@ -624,10 +626,12 @@ impl ITunesChannelExtensionBuilder {
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
     /// let channel_builder = ITunesChannelExtensionBuilder::new()
-    ///     .complete(Some("complete".to_string()));
+    ///     .complete("complete".to_string());
     /// ```
-    pub fn complete(mut self, complete: Option<String>) -> ITunesChannelExtensionBuilder {
-        self.complete = complete;
+    pub fn complete<V>(mut self, complete: V) -> ITunesChannelExtensionBuilder
+        where V: Into<Option<String>>
+    {
+        self.complete = complete.into();
         self
     }
 
@@ -640,10 +644,12 @@ impl ITunesChannelExtensionBuilder {
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
     /// let channel_builder = ITunesChannelExtensionBuilder::new()
-    ///     .new_feed_url(Some("new_feed_url".to_string()));
+    ///     .new_feed_url("new_feed_url".to_string());
     /// ```
-    pub fn new_feed_url(mut self, new_feed_url: Option<String>) -> ITunesChannelExtensionBuilder {
-        self.new_feed_url = new_feed_url;
+    pub fn new_feed_url<V>(mut self, new_feed_url: V) -> ITunesChannelExtensionBuilder
+        where V: Into<Option<String>>
+    {
+        self.new_feed_url = new_feed_url.into();
         self
     }
 
@@ -656,15 +662,17 @@ impl ITunesChannelExtensionBuilder {
     /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesOwnerBuilder};
     ///
     /// let owner = ITunesOwnerBuilder::new()
-    ///     .email(Some("email@example.com".to_string()))
-    ///     .name(Some("name".to_string()))
+    ///     .email("email@example.com".to_string())
+    ///     .name("name".to_string())
     ///     .finalize();
     ///
     /// let channel_builder = ITunesChannelExtensionBuilder::new()
-    ///     .owner(Some(owner));
+    ///     .owner(owner);
     /// ```
-    pub fn owner(mut self, owner: Option<ITunesOwner>) -> ITunesChannelExtensionBuilder {
-        self.owner = owner;
+    pub fn owner<V>(mut self, owner: V) -> ITunesChannelExtensionBuilder
+        where V: Into<Option<ITunesOwner>>
+    {
+        self.owner = owner.into();
         self
     }
 
@@ -677,10 +685,12 @@ impl ITunesChannelExtensionBuilder {
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
     /// let channel_builder = ITunesChannelExtensionBuilder::new()
-    ///     .subtitle(Some("subtitle".to_string()));
+    ///     .subtitle("subtitle".to_string());
     /// ```
-    pub fn subtitle(mut self, subtitle: Option<String>) -> ITunesChannelExtensionBuilder {
-        self.subtitle = subtitle;
+    pub fn subtitle<V>(mut self, subtitle: V) -> ITunesChannelExtensionBuilder
+        where V: Into<Option<String>>
+    {
+        self.subtitle = subtitle.into();
         self
     }
 
@@ -693,10 +703,10 @@ impl ITunesChannelExtensionBuilder {
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
     /// let channel_builder = ITunesChannelExtensionBuilder::new()
-    ///     .summary(Some("summary".to_string()));
+    ///     .summary("summary".to_string());
     /// ```
-    pub fn summary(mut self, summary: Option<String>) -> ITunesChannelExtensionBuilder {
-        self.summary = summary;
+    pub fn summary<V: Into<Option<String>>>(mut self, summary: V) -> ITunesChannelExtensionBuilder {
+        self.summary = summary.into();
         self
     }
 
@@ -709,10 +719,12 @@ impl ITunesChannelExtensionBuilder {
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
     /// let channel_builder = ITunesChannelExtensionBuilder::new()
-    ///     .keywords(Some("keywords".to_string()));
+    ///     .keywords("keywords".to_string());
     /// ```
-    pub fn keywords(mut self, keywords: Option<String>) -> ITunesChannelExtensionBuilder {
-        self.keywords = keywords;
+    pub fn keywords<V>(mut self, keywords: V) -> ITunesChannelExtensionBuilder
+        where V: Into<Option<String>>
+    {
+        self.keywords = keywords.into();
         self
     }
 
@@ -726,8 +738,8 @@ impl ITunesChannelExtensionBuilder {
     ///     ITunesOwnerBuilder};
     ///
     /// let owner = ITunesOwnerBuilder::new()
-    ///     .email(Some("email@example.com".to_string()))
-    ///     .name(Some("name".to_string()))
+    ///     .email("email@example.com".to_string())
+    ///     .name("name".to_string())
     ///     .finalize();
     ///
     /// let subcategory = ITunesCategoryBuilder::new()
@@ -736,22 +748,22 @@ impl ITunesChannelExtensionBuilder {
     ///
     /// let category = ITunesCategoryBuilder::new()
     ///     .text("text")
-    ///     .subcategory(Some(Box::new(subcategory)))
+    ///     .subcategory(Box::new(subcategory))
     ///     .finalize();
     ///
     /// let categories = vec![category];
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
-    ///     .author(Some("author".to_string()))
-    ///     .block(Some("block".to_string()))
-    ///     .image(Some("image".to_string()))
-    ///     .explicit(Some("explicit".to_string()))
-    ///     .subtitle(Some("subtitle".to_string()))
-    ///     .summary(Some("summary".to_string()))
-    ///     .keywords(Some("keywords".to_string()))
-    ///     .new_feed_url(Some("new_feed_url".to_string()))
-    ///     .complete(Some("complete".to_string()))
-    ///     .owner(Some(owner))
+    ///     .author("author".to_string())
+    ///     .block("block".to_string())
+    ///     .image("image".to_string())
+    ///     .explicit("explicit".to_string())
+    ///     .subtitle("subtitle".to_string())
+    ///     .summary("summary".to_string())
+    ///     .keywords("keywords".to_string())
+    ///     .new_feed_url("new_feed_url".to_string())
+    ///     .complete("complete".to_string())
+    ///     .owner(owner)
     ///     .categories(categories)
     ///     .finalize();
     /// ```

--- a/src/extension/itunes/itunes_channel_extension.rs
+++ b/src/extension/itunes/itunes_channel_extension.rs
@@ -55,8 +55,7 @@ impl ITunesChannelExtension {
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder,
-    /// ITunesChannelExtension};
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
     ///
     /// let author = "author".to_string();
     ///
@@ -71,8 +70,7 @@ impl ITunesChannelExtension {
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder,
-    /// ITunesChannelExtension};
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .author(None)
@@ -91,8 +89,7 @@ impl ITunesChannelExtension {
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder,
-    /// ITunesChannelExtension};
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
     ///
     /// let block = "block".to_string();
     ///
@@ -107,8 +104,7 @@ impl ITunesChannelExtension {
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder,
-    /// ITunesChannelExtension};
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .block(None)
@@ -127,8 +123,8 @@ impl ITunesChannelExtension {
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder,
-    /// ITunesChannelExtension, ITunesCategoryBuilder};
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension,
+    ///     ITunesCategoryBuilder};
     ///
     /// let subcategory = ITunesCategoryBuilder::new()
     ///     .text("text")
@@ -158,8 +154,7 @@ impl ITunesChannelExtension {
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder,
-    /// ITunesChannelExtension};
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
     ///
     /// let image = "image".to_string();
     ///
@@ -174,8 +169,7 @@ impl ITunesChannelExtension {
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder,
-    /// ITunesChannelExtension};
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .image(None)
@@ -194,8 +188,7 @@ impl ITunesChannelExtension {
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder,
-    /// ITunesChannelExtension};
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
     ///
     /// let explicit = "explicit".to_string();
     ///
@@ -210,8 +203,7 @@ impl ITunesChannelExtension {
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder,
-    /// ITunesChannelExtension};
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .explicit(None)
@@ -230,8 +222,7 @@ impl ITunesChannelExtension {
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder,
-    /// ITunesChannelExtension};
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
     ///
     /// let complete = "complete".to_string();
     ///
@@ -246,8 +237,7 @@ impl ITunesChannelExtension {
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder,
-    /// ITunesChannelExtension};
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .complete(None)
@@ -267,8 +257,7 @@ impl ITunesChannelExtension {
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder,
-    /// ITunesChannelExtension};
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
     ///
     /// let new_feed_url = "new_feed_url".to_string();
     ///
@@ -283,8 +272,7 @@ impl ITunesChannelExtension {
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder,
-    /// ITunesChannelExtension};
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .new_feed_url(None)
@@ -303,8 +291,8 @@ impl ITunesChannelExtension {
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder,
-    /// ITunesChannelExtension, ITunesOwnerBuilder};
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension,
+    ///     ITunesOwnerBuilder};
     ///
     /// let owner = ITunesOwnerBuilder::new()
     ///     .email(Some("email@example.com".to_string()))
@@ -320,8 +308,7 @@ impl ITunesChannelExtension {
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder,
-    /// ITunesChannelExtension};
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .owner(None)
@@ -340,8 +327,7 @@ impl ITunesChannelExtension {
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder,
-    /// ITunesChannelExtension};
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
     ///
     /// let subtitle = "subtitle".to_string();
     ///
@@ -356,8 +342,7 @@ impl ITunesChannelExtension {
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder,
-    /// ITunesChannelExtension};
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .subtitle(None)
@@ -376,8 +361,7 @@ impl ITunesChannelExtension {
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder,
-    /// ITunesChannelExtension};
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
     ///
     /// let summary = "summary".to_string();
     ///
@@ -392,8 +376,7 @@ impl ITunesChannelExtension {
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder,
-    /// ITunesChannelExtension};
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .summary(None)
@@ -412,8 +395,7 @@ impl ITunesChannelExtension {
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder,
-    /// ITunesChannelExtension};
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
     ///
     /// let keywords = "keywords".to_string();
     ///
@@ -428,8 +410,7 @@ impl ITunesChannelExtension {
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder,
-    /// ITunesChannelExtension};
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesChannelExtension};
     ///
     /// let channel = ITunesChannelExtensionBuilder::new()
     ///     .keywords(None)
@@ -551,8 +532,8 @@ impl ITunesChannelExtensionBuilder {
     /// ```
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let mut channel_builder = ITunesChannelExtensionBuilder::new();
-    /// channel_builder.author(Some("author".to_string()));
+    /// let channel_builder = ITunesChannelExtensionBuilder::new()
+    ///     .author(Some("author".to_string()));
     /// ```
     pub fn author(mut self, author: Option<String>) -> ITunesChannelExtensionBuilder {
         self.author = author;
@@ -567,8 +548,8 @@ impl ITunesChannelExtensionBuilder {
     /// ```
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let mut channel_builder = ITunesChannelExtensionBuilder::new();
-    /// channel_builder.block(Some("block".to_string()));
+    /// let channel_builder = ITunesChannelExtensionBuilder::new()
+    ///     .block(Some("block".to_string()));
     /// ```
     pub fn block(mut self, block: Option<String>) -> ITunesChannelExtensionBuilder {
         self.block = block;
@@ -581,8 +562,7 @@ impl ITunesChannelExtensionBuilder {
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesCategoryBuilder,
-    /// ITunesChannelExtensionBuilder};
+    /// use rss::extension::itunes::{ITunesCategoryBuilder, ITunesChannelExtensionBuilder};
     ///
     /// let subcategory = ITunesCategoryBuilder::new()
     ///     .text("text")
@@ -595,8 +575,8 @@ impl ITunesChannelExtensionBuilder {
     ///
     /// let categories = vec![category];
     ///
-    /// let mut channel_builder = ITunesChannelExtensionBuilder::new();
-    /// channel_builder.categories(categories);
+    /// let channel_builder = ITunesChannelExtensionBuilder::new()
+    ///     .categories(categories);
     /// ```
     pub fn categories(mut self, categories: Vec<ITunesCategory>) -> ITunesChannelExtensionBuilder {
         self.categories = categories;
@@ -611,8 +591,8 @@ impl ITunesChannelExtensionBuilder {
     /// ```
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let mut channel_builder = ITunesChannelExtensionBuilder::new();
-    /// channel_builder.image(Some("image".to_string()));
+    /// let channel_builder = ITunesChannelExtensionBuilder::new()
+    ///     .image(Some("image".to_string()));
     /// ```
     pub fn image(mut self, image: Option<String>) -> ITunesChannelExtensionBuilder {
         self.image = image;
@@ -627,8 +607,8 @@ impl ITunesChannelExtensionBuilder {
     /// ```
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let mut channel_builder = ITunesChannelExtensionBuilder::new();
-    /// channel_builder.explicit(Some("explicit".to_string()));
+    /// let channel_builder = ITunesChannelExtensionBuilder::new()
+    ///     .explicit(Some("explicit".to_string()));
     /// ```
     pub fn explicit(mut self, explicit: Option<String>) -> ITunesChannelExtensionBuilder {
         self.explicit = explicit;
@@ -643,8 +623,8 @@ impl ITunesChannelExtensionBuilder {
     /// ```
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let mut channel_builder = ITunesChannelExtensionBuilder::new();
-    /// channel_builder.complete(Some("complete".to_string()));
+    /// let channel_builder = ITunesChannelExtensionBuilder::new()
+    ///     .complete(Some("complete".to_string()));
     /// ```
     pub fn complete(mut self, complete: Option<String>) -> ITunesChannelExtensionBuilder {
         self.complete = complete;
@@ -652,16 +632,15 @@ impl ITunesChannelExtensionBuilder {
     }
 
 
-    /// Set the optional new_feed_url that exists under
-    /// `ITunesChannelExtension`.
+    /// Set the optional new_feed_url that exists under `ITunesChannelExtension`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let mut channel_builder = ITunesChannelExtensionBuilder::new();
-    /// channel_builder.new_feed_url(Some("new_feed_url".to_string()));
+    /// let channel_builder = ITunesChannelExtensionBuilder::new()
+    ///     .new_feed_url(Some("new_feed_url".to_string()));
     /// ```
     pub fn new_feed_url(mut self, new_feed_url: Option<String>) -> ITunesChannelExtensionBuilder {
         self.new_feed_url = new_feed_url;
@@ -674,16 +653,15 @@ impl ITunesChannelExtensionBuilder {
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder,
-    /// ITunesOwnerBuilder};
+    /// use rss::extension::itunes::{ITunesChannelExtensionBuilder, ITunesOwnerBuilder};
     ///
     /// let owner = ITunesOwnerBuilder::new()
     ///     .email(Some("email@example.com".to_string()))
     ///     .name(Some("name".to_string()))
     ///     .finalize();
     ///
-    /// let mut channel_builder = ITunesChannelExtensionBuilder::new();
-    /// channel_builder.owner(Some(owner));
+    /// let channel_builder = ITunesChannelExtensionBuilder::new()
+    ///     .owner(Some(owner));
     /// ```
     pub fn owner(mut self, owner: Option<ITunesOwner>) -> ITunesChannelExtensionBuilder {
         self.owner = owner;
@@ -698,8 +676,8 @@ impl ITunesChannelExtensionBuilder {
     /// ```
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let mut channel_builder = ITunesChannelExtensionBuilder::new();
-    /// channel_builder.subtitle(Some("subtitle".to_string()));
+    /// let channel_builder = ITunesChannelExtensionBuilder::new()
+    ///     .subtitle(Some("subtitle".to_string()));
     /// ```
     pub fn subtitle(mut self, subtitle: Option<String>) -> ITunesChannelExtensionBuilder {
         self.subtitle = subtitle;
@@ -714,8 +692,8 @@ impl ITunesChannelExtensionBuilder {
     /// ```
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let mut channel_builder = ITunesChannelExtensionBuilder::new();
-    /// channel_builder.summary(Some("summary".to_string()));
+    /// let channel_builder = ITunesChannelExtensionBuilder::new()
+    ///     .summary(Some("summary".to_string()));
     /// ```
     pub fn summary(mut self, summary: Option<String>) -> ITunesChannelExtensionBuilder {
         self.summary = summary;
@@ -730,8 +708,8 @@ impl ITunesChannelExtensionBuilder {
     /// ```
     /// use rss::extension::itunes::ITunesChannelExtensionBuilder;
     ///
-    /// let mut channel_builder = ITunesChannelExtensionBuilder::new();
-    /// channel_builder.keywords(Some("keywords".to_string()));
+    /// let channel_builder = ITunesChannelExtensionBuilder::new()
+    ///     .keywords(Some("keywords".to_string()));
     /// ```
     pub fn keywords(mut self, keywords: Option<String>) -> ITunesChannelExtensionBuilder {
         self.keywords = keywords;
@@ -739,14 +717,13 @@ impl ITunesChannelExtensionBuilder {
     }
 
 
-    /// Construct the `ITunesChannelExtension` from the
-    /// `ITunesChannelExtensionBuilder`.
+    /// Construct the `ITunesChannelExtension` from the `ITunesChannelExtensionBuilder`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesCategoryBuilder,
-    /// ITunesChannelExtensionBuilder, ITunesOwnerBuilder};
+    /// use rss::extension::itunes::{ITunesCategoryBuilder, ITunesChannelExtensionBuilder,
+    ///     ITunesOwnerBuilder};
     ///
     /// let owner = ITunesOwnerBuilder::new()
     ///     .email(Some("email@example.com".to_string()))

--- a/src/extension/itunes/itunes_item_extension.rs
+++ b/src/extension/itunes/itunes_item_extension.rs
@@ -56,7 +56,7 @@ impl ITunesItemExtension {
     /// let author = "author";
     ///
     /// let item = ITunesItemExtensionBuilder::new()
-    ///     .author(Some(author.to_string()))
+    ///     .author(author.to_string())
     ///     .finalize();
     ///
     /// assert_eq!(Some(author), item.author());
@@ -87,7 +87,7 @@ impl ITunesItemExtension {
     /// let block = "block";
     ///
     /// let item = ITunesItemExtensionBuilder::new()
-    ///     .block(Some(block.to_string()))
+    ///     .block(block.to_string())
     ///     .finalize();
     ///
     ///
@@ -119,7 +119,7 @@ impl ITunesItemExtension {
     /// let image = "image";
     ///
     /// let item = ITunesItemExtensionBuilder::new()
-    ///     .image(Some(image.to_string()))
+    ///     .image(image.to_string())
     ///     .finalize();
     ///
     /// assert_eq!(Some(image), item.image());
@@ -150,7 +150,7 @@ impl ITunesItemExtension {
     /// let duration = "duration";
     ///
     /// let item = ITunesItemExtensionBuilder::new()
-    ///     .duration(Some(duration.to_string()))
+    ///     .duration(duration.to_string())
     ///     .finalize();
     ///
     /// assert_eq!(Some(duration), item.duration());
@@ -181,7 +181,7 @@ impl ITunesItemExtension {
     /// let explicit = "explicit";
     ///
     /// let item = ITunesItemExtensionBuilder::new()
-    ///     .explicit(Some(explicit.to_string()))
+    ///     .explicit(explicit.to_string())
     ///     .finalize();
     ///
     /// assert_eq!(Some(explicit), item.explicit());
@@ -213,7 +213,7 @@ impl ITunesItemExtension {
     /// let closed_captioned = "closed_captioned";
     ///
     /// let item = ITunesItemExtensionBuilder::new()
-    ///     .closed_captioned(Some(closed_captioned.to_string()))
+    ///     .closed_captioned(closed_captioned.to_string())
     ///     .finalize();
     ///
     /// assert_eq!(Some(closed_captioned), item.closed_captioned());
@@ -244,7 +244,7 @@ impl ITunesItemExtension {
     /// let order = "order";
     ///
     /// let item = ITunesItemExtensionBuilder::new()
-    ///     .order(Some(order.to_string()))
+    ///     .order(order.to_string())
     ///     .finalize();
     ///
     /// assert_eq!(Some(order), item.order());
@@ -275,7 +275,7 @@ impl ITunesItemExtension {
     /// let subtitle = "subtitle";
     ///
     /// let item = ITunesItemExtensionBuilder::new()
-    ///     .subtitle(Some(subtitle.to_string()))
+    ///     .subtitle(subtitle.to_string())
     ///     .finalize();
     ///
     /// assert_eq!(Some(subtitle), item.subtitle());
@@ -306,7 +306,7 @@ impl ITunesItemExtension {
     /// let summary = "summary";
     ///
     /// let item = ITunesItemExtensionBuilder::new()
-    ///     .summary(Some(summary.to_string()))
+    ///     .summary(summary.to_string())
     ///     .finalize();
     ///
     /// assert_eq!(Some(summary), item.summary());
@@ -337,7 +337,7 @@ impl ITunesItemExtension {
     /// let keywords = "keywords";
     ///
     /// let item = ITunesItemExtensionBuilder::new()
-    ///     .keywords(Some(keywords.to_string()))
+    ///     .keywords(keywords.to_string())
     ///     .finalize();
     ///
     /// assert_eq!(Some(keywords), item.keywords());
@@ -467,10 +467,10 @@ impl ITunesItemExtensionBuilder {
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
     /// let item_builder = ITunesItemExtensionBuilder::new()
-    ///     .author(Some("author".to_string()));
+    ///     .author("author".to_string());
     /// ```
-    pub fn author(mut self, author: Option<String>) -> ITunesItemExtensionBuilder {
-        self.author = author;
+    pub fn author<V: Into<Option<String>>>(mut self, author: V) -> ITunesItemExtensionBuilder {
+        self.author = author.into();
         self
     }
 
@@ -483,10 +483,10 @@ impl ITunesItemExtensionBuilder {
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
     /// let item_builder = ITunesItemExtensionBuilder::new()
-    ///     .block(Some("block".to_string()));
+    ///     .block("block".to_string());
     /// ```
-    pub fn block(mut self, block: Option<String>) -> ITunesItemExtensionBuilder {
-        self.block = block;
+    pub fn block<V: Into<Option<String>>>(mut self, block: V) -> ITunesItemExtensionBuilder {
+        self.block = block.into();
         self
     }
 
@@ -499,10 +499,10 @@ impl ITunesItemExtensionBuilder {
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
     /// let item_builder = ITunesItemExtensionBuilder::new()
-    ///     .image(Some("image".to_string()));
+    ///     .image("image".to_string());
     /// ```
-    pub fn image(mut self, image: Option<String>) -> ITunesItemExtensionBuilder {
-        self.image = image;
+    pub fn image<V: Into<Option<String>>>(mut self, image: V) -> ITunesItemExtensionBuilder {
+        self.image = image.into();
         self
     }
 
@@ -515,10 +515,10 @@ impl ITunesItemExtensionBuilder {
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
     /// let item_builder = ITunesItemExtensionBuilder::new()
-    ///     .duration(Some("duration".to_string()));
+    ///     .duration("duration".to_string());
     /// ```
-    pub fn duration(mut self, duration: Option<String>) -> ITunesItemExtensionBuilder {
-        self.duration = duration;
+    pub fn duration<V: Into<Option<String>>>(mut self, duration: V) -> ITunesItemExtensionBuilder {
+        self.duration = duration.into();
         self
     }
 
@@ -531,10 +531,10 @@ impl ITunesItemExtensionBuilder {
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
     /// let item_builder = ITunesItemExtensionBuilder::new()
-    ///     .explicit(Some("explicit".to_string()));
+    ///     .explicit("explicit".to_string());
     /// ```
-    pub fn explicit(mut self, explicit: Option<String>) -> ITunesItemExtensionBuilder {
-        self.explicit = explicit;
+    pub fn explicit<V: Into<Option<String>>>(mut self, explicit: V) -> ITunesItemExtensionBuilder {
+        self.explicit = explicit.into();
         self
     }
 
@@ -548,12 +548,12 @@ impl ITunesItemExtensionBuilder {
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
     /// let item_builder = ITunesItemExtensionBuilder::new()
-    ///     .closed_captioned(Some("closed_captioned".to_string()));
+    ///     .closed_captioned("closed_captioned".to_string());
     /// ```
-    pub fn closed_captioned(mut self,
-                            closed_captioned: Option<String>)
-                            -> ITunesItemExtensionBuilder {
-        self.closed_captioned = closed_captioned;
+    pub fn closed_captioned<V>(mut self, closed_captioned: V) -> ITunesItemExtensionBuilder
+        where V: Into<Option<String>>
+    {
+        self.closed_captioned = closed_captioned.into();
         self
     }
 
@@ -566,10 +566,10 @@ impl ITunesItemExtensionBuilder {
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
     /// let item_builder = ITunesItemExtensionBuilder::new()
-    ///     .order(Some("order".to_string()));
+    ///     .order("order".to_string());
     /// ```
-    pub fn order(mut self, order: Option<String>) -> ITunesItemExtensionBuilder {
-        self.order = order;
+    pub fn order<V: Into<Option<String>>>(mut self, order: V) -> ITunesItemExtensionBuilder {
+        self.order = order.into();
         self
     }
 
@@ -582,10 +582,10 @@ impl ITunesItemExtensionBuilder {
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
     /// let item_builder = ITunesItemExtensionBuilder::new()
-    ///     .subtitle(Some("subtitle".to_string()));
+    ///     .subtitle("subtitle".to_string());
     /// ```
-    pub fn subtitle(mut self, subtitle: Option<String>) -> ITunesItemExtensionBuilder {
-        self.subtitle = subtitle;
+    pub fn subtitle<V: Into<Option<String>>>(mut self, subtitle: V) -> ITunesItemExtensionBuilder {
+        self.subtitle = subtitle.into();
         self
     }
 
@@ -598,10 +598,10 @@ impl ITunesItemExtensionBuilder {
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
     /// let item_builder = ITunesItemExtensionBuilder::new()
-    ///     .summary(Some("summary".to_string()));
+    ///     .summary("summary".to_string());
     /// ```
-    pub fn summary(mut self, summary: Option<String>) -> ITunesItemExtensionBuilder {
-        self.summary = summary;
+    pub fn summary<V: Into<Option<String>>>(mut self, summary: V) -> ITunesItemExtensionBuilder {
+        self.summary = summary.into();
         self
     }
 
@@ -614,10 +614,10 @@ impl ITunesItemExtensionBuilder {
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
     /// let item_builder = ITunesItemExtensionBuilder::new()
-    ///     .keywords(Some("keywords".to_string()));
+    ///     .keywords("keywords".to_string());
     /// ```
-    pub fn keywords(mut self, keywords: Option<String>) -> ITunesItemExtensionBuilder {
-        self.keywords = keywords;
+    pub fn keywords<V: Into<Option<String>>>(mut self, keywords: V) -> ITunesItemExtensionBuilder {
+        self.keywords = keywords.into();
         self
     }
 
@@ -630,16 +630,16 @@ impl ITunesItemExtensionBuilder {
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
     /// let item = ITunesItemExtensionBuilder::new()
-    ///     .author(Some("author".to_string()))
-    ///     .block(Some("block".to_string()))
-    ///     .image(Some("image".to_string()))
-    ///     .duration(Some("duration".to_string()))
-    ///     .explicit(Some("explicit".to_string()))
-    ///     .closed_captioned(Some("closed_captioned".to_string()))
-    ///     .order(Some("order".to_string()))
-    ///     .subtitle(Some("subtitle".to_string()))
-    ///     .summary(Some("summary".to_string()))
-    ///     .keywords(Some("keywords".to_string()))
+    ///     .author("author".to_string())
+    ///     .block("block".to_string())
+    ///     .image("image".to_string())
+    ///     .duration("duration".to_string())
+    ///     .explicit("explicit".to_string())
+    ///     .closed_captioned("closed_captioned".to_string())
+    ///     .order("order".to_string())
+    ///     .subtitle("subtitle".to_string())
+    ///     .summary("summary".to_string())
+    ///     .keywords("keywords".to_string())
     ///     .finalize();
     /// ```
     pub fn finalize(self) -> ITunesItemExtension {

--- a/src/extension/itunes/itunes_item_extension.rs
+++ b/src/extension/itunes/itunes_item_extension.rs
@@ -466,8 +466,8 @@ impl ITunesItemExtensionBuilder {
     /// ```
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let mut item_builder = ITunesItemExtensionBuilder::new();
-    /// item_builder.author(Some("author".to_string()));
+    /// let item_builder = ITunesItemExtensionBuilder::new()
+    ///     .author(Some("author".to_string()));
     /// ```
     pub fn author(mut self, author: Option<String>) -> ITunesItemExtensionBuilder {
         self.author = author;
@@ -482,8 +482,8 @@ impl ITunesItemExtensionBuilder {
     /// ```
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let mut item_builder = ITunesItemExtensionBuilder::new();
-    /// item_builder.block(Some("block".to_string()));
+    /// let item_builder = ITunesItemExtensionBuilder::new()
+    ///     .block(Some("block".to_string()));
     /// ```
     pub fn block(mut self, block: Option<String>) -> ITunesItemExtensionBuilder {
         self.block = block;
@@ -498,8 +498,8 @@ impl ITunesItemExtensionBuilder {
     /// ```
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let mut item_builder = ITunesItemExtensionBuilder::new();
-    /// item_builder.image(Some("image".to_string()));
+    /// let item_builder = ITunesItemExtensionBuilder::new()
+    ///     .image(Some("image".to_string()));
     /// ```
     pub fn image(mut self, image: Option<String>) -> ITunesItemExtensionBuilder {
         self.image = image;
@@ -514,8 +514,8 @@ impl ITunesItemExtensionBuilder {
     /// ```
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let mut item_builder = ITunesItemExtensionBuilder::new();
-    /// item_builder.duration(Some("duration".to_string()));
+    /// let item_builder = ITunesItemExtensionBuilder::new()
+    ///     .duration(Some("duration".to_string()));
     /// ```
     pub fn duration(mut self, duration: Option<String>) -> ITunesItemExtensionBuilder {
         self.duration = duration;
@@ -530,8 +530,8 @@ impl ITunesItemExtensionBuilder {
     /// ```
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let mut item_builder = ITunesItemExtensionBuilder::new();
-    /// item_builder.explicit(Some("explicit".to_string()));
+    /// let item_builder = ITunesItemExtensionBuilder::new()
+    ///     .explicit(Some("explicit".to_string()));
     /// ```
     pub fn explicit(mut self, explicit: Option<String>) -> ITunesItemExtensionBuilder {
         self.explicit = explicit;
@@ -547,8 +547,8 @@ impl ITunesItemExtensionBuilder {
     /// ```
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let mut item_builder = ITunesItemExtensionBuilder::new();
-    /// item_builder.closed_captioned(Some("closed_captioned".to_string()));
+    /// let item_builder = ITunesItemExtensionBuilder::new()
+    ///     .closed_captioned(Some("closed_captioned".to_string()));
     /// ```
     pub fn closed_captioned(mut self,
                             closed_captioned: Option<String>)
@@ -565,8 +565,8 @@ impl ITunesItemExtensionBuilder {
     /// ```
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let mut item_builder = ITunesItemExtensionBuilder::new();
-    /// item_builder.order(Some("order".to_string()));
+    /// let item_builder = ITunesItemExtensionBuilder::new()
+    ///     .order(Some("order".to_string()));
     /// ```
     pub fn order(mut self, order: Option<String>) -> ITunesItemExtensionBuilder {
         self.order = order;
@@ -581,8 +581,8 @@ impl ITunesItemExtensionBuilder {
     /// ```
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let mut item_builder = ITunesItemExtensionBuilder::new();
-    /// item_builder.subtitle(Some("subtitle".to_string()));
+    /// let item_builder = ITunesItemExtensionBuilder::new()
+    ///     .subtitle(Some("subtitle".to_string()));
     /// ```
     pub fn subtitle(mut self, subtitle: Option<String>) -> ITunesItemExtensionBuilder {
         self.subtitle = subtitle;
@@ -597,8 +597,8 @@ impl ITunesItemExtensionBuilder {
     /// ```
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let mut item_builder = ITunesItemExtensionBuilder::new();
-    /// item_builder.summary(Some("summary".to_string()));
+    /// let item_builder = ITunesItemExtensionBuilder::new()
+    ///     .summary(Some("summary".to_string()));
     /// ```
     pub fn summary(mut self, summary: Option<String>) -> ITunesItemExtensionBuilder {
         self.summary = summary;
@@ -613,8 +613,8 @@ impl ITunesItemExtensionBuilder {
     /// ```
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let mut item_builder = ITunesItemExtensionBuilder::new();
-    /// item_builder.keywords(Some("keywords".to_string()));
+    /// let item_builder = ITunesItemExtensionBuilder::new()
+    ///     .keywords(Some("keywords".to_string()));
     /// ```
     pub fn keywords(mut self, keywords: Option<String>) -> ITunesItemExtensionBuilder {
         self.keywords = keywords;
@@ -622,8 +622,7 @@ impl ITunesItemExtensionBuilder {
     }
 
 
-    /// Construct the `ITunesItemExtension` from the
-    /// `ITunesItemExtensionBuilder`.
+    /// Construct the `ITunesItemExtension` from the `ITunesItemExtensionBuilder`.
     ///
     /// # Examples
     ///

--- a/src/extension/itunes/itunes_item_extension.rs
+++ b/src/extension/itunes/itunes_item_extension.rs
@@ -6,7 +6,6 @@
 // it under the terms of the MIT License and/or Apache 2.0 License.
 
 use super::parse_image;
-use error::Error;
 use extension::Extension;
 use extension::remove_extension_value;
 use quick_xml::errors::Error as XmlError;
@@ -58,8 +57,7 @@ impl ITunesItemExtension {
     ///
     /// let item = ITunesItemExtensionBuilder::new()
     ///     .author(Some(author.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(author), item.author());
     /// ```
@@ -70,8 +68,7 @@ impl ITunesItemExtension {
     ///
     /// let item = ITunesItemExtensionBuilder::new()
     ///     .author(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let author_opt = item.author();
     /// assert!(author_opt.is_none());
@@ -91,8 +88,7 @@ impl ITunesItemExtension {
     ///
     /// let item = ITunesItemExtensionBuilder::new()
     ///     .block(Some(block.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     ///
     /// assert_eq!(Some(block), item.block());
@@ -104,8 +100,7 @@ impl ITunesItemExtension {
     ///
     /// let item = ITunesItemExtensionBuilder::new()
     ///     .block(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let block_opt = item.block();
     /// assert!(block_opt.is_none());
@@ -125,8 +120,7 @@ impl ITunesItemExtension {
     ///
     /// let item = ITunesItemExtensionBuilder::new()
     ///     .image(Some(image.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(image), item.image());
     /// ```
@@ -137,8 +131,7 @@ impl ITunesItemExtension {
     ///
     /// let item = ITunesItemExtensionBuilder::new()
     ///     .image(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let image_opt = item.image();
     /// assert!(image_opt.is_none());
@@ -158,8 +151,7 @@ impl ITunesItemExtension {
     ///
     /// let item = ITunesItemExtensionBuilder::new()
     ///     .duration(Some(duration.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(duration), item.duration());
     /// ```
@@ -170,8 +162,7 @@ impl ITunesItemExtension {
     ///
     /// let item = ITunesItemExtensionBuilder::new()
     ///     .duration(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let duration_opt = item.duration();
     /// assert!(duration_opt.is_none());
@@ -191,8 +182,7 @@ impl ITunesItemExtension {
     ///
     /// let item = ITunesItemExtensionBuilder::new()
     ///     .explicit(Some(explicit.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(explicit), item.explicit());
     /// ```
@@ -203,8 +193,7 @@ impl ITunesItemExtension {
     ///
     /// let item = ITunesItemExtensionBuilder::new()
     ///     .explicit(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let explicit_opt = item.explicit();
     /// assert!(explicit_opt.is_none());
@@ -225,8 +214,7 @@ impl ITunesItemExtension {
     ///
     /// let item = ITunesItemExtensionBuilder::new()
     ///     .closed_captioned(Some(closed_captioned.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(closed_captioned), item.closed_captioned());
     /// ```
@@ -237,8 +225,7 @@ impl ITunesItemExtension {
     ///
     /// let item = ITunesItemExtensionBuilder::new()
     ///     .closed_captioned(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let closed_captioned_opt = item.closed_captioned();
     /// assert!(closed_captioned_opt.is_none());
@@ -258,8 +245,7 @@ impl ITunesItemExtension {
     ///
     /// let item = ITunesItemExtensionBuilder::new()
     ///     .order(Some(order.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(order), item.order());
     /// ```
@@ -270,8 +256,7 @@ impl ITunesItemExtension {
     ///
     /// let item = ITunesItemExtensionBuilder::new()
     ///     .order(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let order_opt = item.order();
     /// assert!(order_opt.is_none());
@@ -291,8 +276,7 @@ impl ITunesItemExtension {
     ///
     /// let item = ITunesItemExtensionBuilder::new()
     ///     .subtitle(Some(subtitle.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(subtitle), item.subtitle());
     /// ```
@@ -303,8 +287,7 @@ impl ITunesItemExtension {
     ///
     /// let item = ITunesItemExtensionBuilder::new()
     ///     .subtitle(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let subtitle_opt = item.subtitle();
     /// assert!(subtitle_opt.is_none());
@@ -324,8 +307,7 @@ impl ITunesItemExtension {
     ///
     /// let item = ITunesItemExtensionBuilder::new()
     ///     .summary(Some(summary.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(summary), item.summary());
     /// ```
@@ -336,8 +318,7 @@ impl ITunesItemExtension {
     ///
     /// let item = ITunesItemExtensionBuilder::new()
     ///     .summary(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let summary_opt = item.summary();
     /// assert!(summary_opt.is_none());
@@ -357,8 +338,7 @@ impl ITunesItemExtension {
     ///
     /// let item = ITunesItemExtensionBuilder::new()
     ///     .keywords(Some(keywords.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(keywords), item.keywords());
     /// ```
@@ -369,8 +349,7 @@ impl ITunesItemExtension {
     ///
     /// let item = ITunesItemExtensionBuilder::new()
     ///     .keywords(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let keywords_opt = item.keywords();
     /// assert!(keywords_opt.is_none());
@@ -662,21 +641,20 @@ impl ITunesItemExtensionBuilder {
     ///     .subtitle(Some("subtitle".to_string()))
     ///     .summary(Some("summary".to_string()))
     ///     .keywords(Some("keywords".to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     /// ```
-    pub fn finalize(self) -> Result<ITunesItemExtension, Error> {
-        Ok(ITunesItemExtension {
-               author: self.author,
-               block: self.block,
-               image: self.image,
-               duration: self.duration,
-               explicit: self.explicit,
-               closed_captioned: self.closed_captioned,
-               order: self.order,
-               subtitle: self.subtitle,
-               summary: self.summary,
-               keywords: self.keywords,
-           })
+    pub fn finalize(self) -> ITunesItemExtension {
+        ITunesItemExtension {
+            author: self.author,
+            block: self.block,
+            image: self.image,
+            duration: self.duration,
+            explicit: self.explicit,
+            closed_captioned: self.closed_captioned,
+            order: self.order,
+            subtitle: self.subtitle,
+            summary: self.summary,
+            keywords: self.keywords,
+        }
     }
 }

--- a/src/extension/itunes/itunes_item_extension.rs
+++ b/src/extension/itunes/itunes_item_extension.rs
@@ -46,313 +46,286 @@ pub struct ITunesItemExtension {
 }
 
 impl ITunesItemExtension {
-    /// Get the optional author that exists under `ITunesItemExtension`.
+    /// Return the author of this podcast episode.
+    ///
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesItemExtensionBuilder,
-    /// ITunesItemExtension};
+    /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
     /// let author = "author";
     ///
-    /// let item = ITunesItemExtensionBuilder::new()
+    /// let ext = ITunesItemExtensionBuilder::default()
     ///     .author(author.to_string())
     ///     .finalize();
     ///
-    /// assert_eq!(Some(author), item.author());
+    /// assert_eq!(Some(author), ext.author());
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesItemExtensionBuilder,
-    /// ITunesItemExtension};
+    /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let item = ITunesItemExtensionBuilder::new()
+    /// let ext = ITunesItemExtensionBuilder::default()
     ///     .author(None)
     ///     .finalize();
     ///
-    /// let author_opt = item.author();
-    /// assert!(author_opt.is_none());
+    /// assert!(ext.author().is_none());
     /// ```
     pub fn author(&self) -> Option<&str> {
         self.author.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the optional block that exists under `ITunesItemExtension`.
+    /// Return whether this podcast episode should be blocked from appearing in the iTunes Store.
+    ///
+    /// A value of `Yes` indicates that the podcast should not show up in the iTunes Store. All
+    /// other values are ignored.
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesItemExtensionBuilder,
-    /// ITunesItemExtension};
+    /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let block = "block";
+    /// let block = "Yes";
     ///
-    /// let item = ITunesItemExtensionBuilder::new()
+    /// let ext = ITunesItemExtensionBuilder::default()
     ///     .block(block.to_string())
     ///     .finalize();
     ///
-    ///
-    /// assert_eq!(Some(block), item.block());
+    /// assert_eq!(Some(block), ext.block());
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesItemExtensionBuilder,
-    /// ITunesItemExtension};
+    /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let item = ITunesItemExtensionBuilder::new()
+    /// let ext = ITunesItemExtensionBuilder::default()
     ///     .block(None)
     ///     .finalize();
     ///
-    /// let block_opt = item.block();
-    /// assert!(block_opt.is_none());
+    /// assert!(ext.block().is_none());
     /// ```
     pub fn block(&self) -> Option<&str> {
         self.block.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the optional image that exists under `ITunesItemExtension`.
+    /// Return the artwork URL for this podcast episode.
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesItemExtensionBuilder,
-    /// ITunesItemExtension};
+    /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let image = "image";
+    /// let image = "http://example.com/image.png";
     ///
-    /// let item = ITunesItemExtensionBuilder::new()
+    /// let ext = ITunesItemExtensionBuilder::default()
     ///     .image(image.to_string())
     ///     .finalize();
     ///
-    /// assert_eq!(Some(image), item.image());
+    /// assert_eq!(Some(image), ext.image());
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesItemExtensionBuilder,
-    /// ITunesItemExtension};
+    /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let item = ITunesItemExtensionBuilder::new()
+    /// let ext = ITunesItemExtensionBuilder::default()
     ///     .image(None)
     ///     .finalize();
     ///
-    /// let image_opt = item.image();
-    /// assert!(image_opt.is_none());
+    /// assert!(ext.image().is_none());
     /// ```
     pub fn image(&self) -> Option<&str> {
         self.image.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the optional duration that exists under `ITunesItemExtension`.
+    /// Return the duration of this podcast episode.
+    ///
+    /// The duration should be in one of the following formats: HH:MM:SS, H:MM:SS, MM:SS, M:SS.
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesItemExtensionBuilder,
-    /// ITunesItemExtension};
+    /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let duration = "duration";
+    /// let duration = "50:03";
     ///
-    /// let item = ITunesItemExtensionBuilder::new()
+    /// let ext = ITunesItemExtensionBuilder::default()
     ///     .duration(duration.to_string())
     ///     .finalize();
     ///
-    /// assert_eq!(Some(duration), item.duration());
+    /// assert_eq!(Some(duration), ext.duration());
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesItemExtensionBuilder,
-    /// ITunesItemExtension};
+    /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let item = ITunesItemExtensionBuilder::new()
+    /// let ext = ITunesItemExtensionBuilder::default()
     ///     .duration(None)
     ///     .finalize();
     ///
-    /// let duration_opt = item.duration();
-    /// assert!(duration_opt.is_none());
+    /// assert!(ext.duration().is_none());
     /// ```
     pub fn duration(&self) -> Option<&str> {
         self.duration.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the optional explicit that exists under `ITunesItemExtension`.
+    /// Return whether this podcast episode contains explicit content.
+    ///
+    /// A value of `Yes`, `Explicit`, or `True` indicates that the episode contains explicit
+    /// content. A value of `Clean`, `No`, `False` inidicates that episode does not contain
+    /// explicit content.
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesItemExtensionBuilder,
-    /// ITunesItemExtension};
+    /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let explicit = "explicit";
+    /// let explicit = "Yes";
     ///
-    /// let item = ITunesItemExtensionBuilder::new()
+    /// let ext = ITunesItemExtensionBuilder::default()
     ///     .explicit(explicit.to_string())
     ///     .finalize();
     ///
-    /// assert_eq!(Some(explicit), item.explicit());
+    /// assert_eq!(Some(explicit), ext.explicit());
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesItemExtensionBuilder,
-    /// ITunesItemExtension};
+    /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let item = ITunesItemExtensionBuilder::new()
+    /// let ext = ITunesItemExtensionBuilder::default()
     ///     .explicit(None)
     ///     .finalize();
     ///
-    /// let explicit_opt = item.explicit();
-    /// assert!(explicit_opt.is_none());
+    /// assert!(ext.explicit().is_none());
     /// ```
     pub fn explicit(&self) -> Option<&str> {
         self.explicit.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the optional closed_captioned that exists under
-    /// `ITunesItemExtension`.
+    /// Return whether this podcast episode contains embedded closed captioning.
+    ///
+    /// A value of `Yes` indicates that it does. Any other value indicates that it does not.
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesItemExtensionBuilder,
-    /// ITunesItemExtension};
+    /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let closed_captioned = "closed_captioned";
+    /// let closed_captioned = "Yes";
     ///
-    /// let item = ITunesItemExtensionBuilder::new()
+    /// let ext = ITunesItemExtensionBuilder::default()
     ///     .closed_captioned(closed_captioned.to_string())
     ///     .finalize();
     ///
-    /// assert_eq!(Some(closed_captioned), item.closed_captioned());
+    /// assert_eq!(Some(closed_captioned), ext.closed_captioned());
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesItemExtensionBuilder,
-    /// ITunesItemExtension};
+    /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let item = ITunesItemExtensionBuilder::new()
+    /// let ext = ITunesItemExtensionBuilder::default()
     ///     .closed_captioned(None)
     ///     .finalize();
     ///
-    /// let closed_captioned_opt = item.closed_captioned();
-    /// assert!(closed_captioned_opt.is_none());
+    /// assert!(ext.closed_captioned().is_none());
     /// ```
     pub fn closed_captioned(&self) -> Option<&str> {
         self.closed_captioned.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the optional order that exists under `ITunesItemExtension`.
+    /// Return the value used to override the default sorting order for episodes.
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesItemExtensionBuilder,
-    /// ITunesItemExtension};
+    /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let order = "order";
+    /// let order = "0";
     ///
-    /// let item = ITunesItemExtensionBuilder::new()
+    /// let ext = ITunesItemExtensionBuilder::default()
     ///     .order(order.to_string())
     ///     .finalize();
     ///
-    /// assert_eq!(Some(order), item.order());
+    /// assert_eq!(Some(order), ext.order());
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesItemExtensionBuilder,
-    /// ITunesItemExtension};
+    /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let item = ITunesItemExtensionBuilder::new()
+    /// let ext = ITunesItemExtensionBuilder::default()
     ///     .order(None)
     ///     .finalize();
     ///
-    /// let order_opt = item.order();
-    /// assert!(order_opt.is_none());
+    /// assert!(ext.order().is_none());
     /// ```
     pub fn order(&self) -> Option<&str> {
         self.order.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the optional subtitle that exists under `ITunesItemExtension`.
+    /// Return the description of this podcast episode.
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesItemExtensionBuilder,
-    /// ITunesItemExtension};
+    /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let subtitle = "subtitle";
+    /// let subtitle = "description";
     ///
-    /// let item = ITunesItemExtensionBuilder::new()
+    /// let ext = ITunesItemExtensionBuilder::default()
     ///     .subtitle(subtitle.to_string())
     ///     .finalize();
     ///
-    /// assert_eq!(Some(subtitle), item.subtitle());
+    /// assert_eq!(Some(subtitle), ext.subtitle());
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesItemExtensionBuilder,
-    /// ITunesItemExtension};
+    /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let item = ITunesItemExtensionBuilder::new()
+    /// let ext = ITunesItemExtensionBuilder::default()
     ///     .subtitle(None)
     ///     .finalize();
     ///
-    /// let subtitle_opt = item.subtitle();
-    /// assert!(subtitle_opt.is_none());
+    /// assert!(ext.subtitle().is_none());
     /// ```
     pub fn subtitle(&self) -> Option<&str> {
         self.subtitle.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the optional summary that exists under `ITunesItemExtension`.
+    /// Return the summary for this podcast episode.
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesItemExtensionBuilder,
-    /// ITunesItemExtension};
+    /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
     /// let summary = "summary";
     ///
-    /// let item = ITunesItemExtensionBuilder::new()
+    /// let ext = ITunesItemExtensionBuilder::default()
     ///     .summary(summary.to_string())
     ///     .finalize();
     ///
-    /// assert_eq!(Some(summary), item.summary());
+    /// assert_eq!(Some(summary), ext.summary());
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesItemExtensionBuilder,
-    /// ITunesItemExtension};
+    /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let item = ITunesItemExtensionBuilder::new()
+    /// let ext = ITunesItemExtensionBuilder::default()
     ///     .summary(None)
     ///     .finalize();
     ///
-    /// let summary_opt = item.summary();
-    /// assert!(summary_opt.is_none());
+    /// assert!(ext.summary().is_none());
     /// ```
     pub fn summary(&self) -> Option<&str> {
         self.summary.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the optional keywords that exists under `ITunesItemExtension`.
+    /// Return the keywords for this podcast episode.
+    ///
+    /// The string contains a comma separated list of keywords.
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesItemExtensionBuilder,
-    /// ITunesItemExtension};
+    /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let keywords = "keywords";
+    /// let keywords = "keyword1,keyword2";
     ///
-    /// let item = ITunesItemExtensionBuilder::new()
+    /// let ext = ITunesItemExtensionBuilder::default()
     ///     .keywords(keywords.to_string())
     ///     .finalize();
     ///
-    /// assert_eq!(Some(keywords), item.keywords());
+    /// assert_eq!(Some(keywords), ext.keywords());
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesItemExtensionBuilder,
-    /// ITunesItemExtension};
+    /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let item = ITunesItemExtensionBuilder::new()
+    /// let ext = ITunesItemExtensionBuilder::default()
     ///     .keywords(None)
     ///     .finalize();
     ///
-    /// let keywords_opt = item.keywords();
-    /// assert!(keywords_opt.is_none());
+    /// assert!(ext.keywords().is_none());
     /// ```
     pub fn keywords(&self) -> Option<&str> {
         self.keywords.as_ref().map(|s| s.as_str())
@@ -428,8 +401,7 @@ impl ToXml for ITunesItemExtension {
     }
 }
 
-/// This `ITunesItemExtensionBuilder` struct creates the
-/// `ITunesChannelExtension`.
+/// A builder used to create an `ITunesItemExtension`.
 #[derive(Debug, Clone, Default)]
 pub struct ITunesItemExtensionBuilder {
     author: Option<String>,
@@ -445,110 +417,100 @@ pub struct ITunesItemExtensionBuilder {
 }
 
 impl ITunesItemExtensionBuilder {
-    /// Construct a new `ITunesItemExtensionBuilder` and return default values.
+    /// Set the author of the podcast episode.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let item_builder = ITunesItemExtensionBuilder::new();
-    /// ```
-    pub fn new() -> ITunesItemExtensionBuilder {
-        ITunesItemExtensionBuilder::default()
-    }
-
-
-    /// Set the optional author that exists under `ITunesItemExtension`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rss::extension::itunes::ITunesItemExtensionBuilder;
-    ///
-    /// let item_builder = ITunesItemExtensionBuilder::new()
+    /// let builder = ITunesItemExtensionBuilder::default()
     ///     .author("author".to_string());
     /// ```
-    pub fn author<V: Into<Option<String>>>(mut self, author: V) -> ITunesItemExtensionBuilder {
+    pub fn author<V>(mut self, author: V) -> ITunesItemExtensionBuilder
+        where V: Into<Option<String>>
+    {
         self.author = author.into();
         self
     }
 
-
-    /// Set the optional block that exists under `ITunesItemExtension`.
+    /// Set whether the podcast episode should be blocked from appearing in the iTunes Store.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let item_builder = ITunesItemExtensionBuilder::new()
-    ///     .block("block".to_string());
+    /// let builder = ITunesItemExtensionBuilder::default()
+    ///     .block("Yes".to_string());
     /// ```
-    pub fn block<V: Into<Option<String>>>(mut self, block: V) -> ITunesItemExtensionBuilder {
+    pub fn block<V>(mut self, block: V) -> ITunesItemExtensionBuilder
+        where V: Into<Option<String>>
+    {
         self.block = block.into();
         self
     }
 
-
-    /// Set the optional image that exists under `ITunesItemExtension`.
+    /// Set the artwork URL for the podcast episode.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let item_builder = ITunesItemExtensionBuilder::new()
-    ///     .image("image".to_string());
+    /// let builder = ITunesItemExtensionBuilder::default()
+    ///     .image("http://example.com/image.png".to_string());
     /// ```
-    pub fn image<V: Into<Option<String>>>(mut self, image: V) -> ITunesItemExtensionBuilder {
+    pub fn image<V>(mut self, image: V) -> ITunesItemExtensionBuilder
+        where V: Into<Option<String>>
+    {
         self.image = image.into();
         self
     }
 
-
-    /// Set the optional duration that exists under `ITunesItemExtension`.
+    /// Set the duration of the podcast episode.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let item_builder = ITunesItemExtensionBuilder::new()
-    ///     .duration("duration".to_string());
+    /// let builder = ITunesItemExtensionBuilder::default()
+    ///     .duration("50:03".to_string());
     /// ```
-    pub fn duration<V: Into<Option<String>>>(mut self, duration: V) -> ITunesItemExtensionBuilder {
+    pub fn duration<V>(mut self, duration: V) -> ITunesItemExtensionBuilder
+        where V: Into<Option<String>>
+    {
         self.duration = duration.into();
         self
     }
 
-
-    /// Set the optional explicit that exists under `ITunesItemExtension`.
+    /// Set whether the podcast episode contains explicit content.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let item_builder = ITunesItemExtensionBuilder::new()
-    ///     .explicit("explicit".to_string());
+    /// let builder = ITunesItemExtensionBuilder::default()
+    ///     .explicit("Yes".to_string());
     /// ```
-    pub fn explicit<V: Into<Option<String>>>(mut self, explicit: V) -> ITunesItemExtensionBuilder {
+    pub fn explicit<V>(mut self, explicit: V) -> ITunesItemExtensionBuilder
+        where V: Into<Option<String>>
+    {
         self.explicit = explicit.into();
         self
     }
 
-
-    /// Set the optional closed_captioned that exists under
-    /// `ITunesItemExtension`.
+    /// Set whether the podcast episode contains embedded closed captioning.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let item_builder = ITunesItemExtensionBuilder::new()
-    ///     .closed_captioned("closed_captioned".to_string());
+    /// let builder = ITunesItemExtensionBuilder::default()
+    ///     .closed_captioned("Yes".to_string());
     /// ```
     pub fn closed_captioned<V>(mut self, closed_captioned: V) -> ITunesItemExtensionBuilder
         where V: Into<Option<String>>
@@ -557,89 +519,85 @@ impl ITunesItemExtensionBuilder {
         self
     }
 
-
-    /// Set the optional order that exists under `ITunesItemExtension`.
+    /// Set the value used to override the default sorting order for episodes.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let item_builder = ITunesItemExtensionBuilder::new()
-    ///     .order("order".to_string());
+    /// let builder = ITunesItemExtensionBuilder::default()
+    ///     .order("0".to_string());
     /// ```
-    pub fn order<V: Into<Option<String>>>(mut self, order: V) -> ITunesItemExtensionBuilder {
+    pub fn order<V>(mut self, order: V) -> ITunesItemExtensionBuilder
+        where V: Into<Option<String>>
+    {
         self.order = order.into();
         self
     }
 
-
-    /// Set the optional subtitle that exists under `ITunesItemExtension`.
+    /// Set the description of the podcast episode.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let item_builder = ITunesItemExtensionBuilder::new()
-    ///     .subtitle("subtitle".to_string());
+    /// let builder = ITunesItemExtensionBuilder::default()
+    ///     .subtitle("description".to_string());
     /// ```
-    pub fn subtitle<V: Into<Option<String>>>(mut self, subtitle: V) -> ITunesItemExtensionBuilder {
+    pub fn subtitle<V>(mut self, subtitle: V) -> ITunesItemExtensionBuilder
+        where V: Into<Option<String>>
+    {
         self.subtitle = subtitle.into();
         self
     }
 
-
-    /// Set the optional summary that exists under `ITunesItemExtension`.
+    /// Set the summary for the podcast episode.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let item_builder = ITunesItemExtensionBuilder::new()
+    /// let builder = ITunesItemExtensionBuilder::default()
     ///     .summary("summary".to_string());
     /// ```
-    pub fn summary<V: Into<Option<String>>>(mut self, summary: V) -> ITunesItemExtensionBuilder {
+    pub fn summary<V>(mut self, summary: V) -> ITunesItemExtensionBuilder
+        where V: Into<Option<String>>
+    {
         self.summary = summary.into();
         self
     }
 
-
-    /// Set the optional keywords that exists under `ITunesItemExtension`.
+    /// Set the keywords for the podcast episode.
+    ///
+    /// The string should be a comma separated list of keywords.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let item_builder = ITunesItemExtensionBuilder::new()
-    ///     .keywords("keywords".to_string());
+    /// let builder = ITunesItemExtensionBuilder::default()
+    ///     .keywords("keyword1,keyword2".to_string());
     /// ```
-    pub fn keywords<V: Into<Option<String>>>(mut self, keywords: V) -> ITunesItemExtensionBuilder {
+    pub fn keywords<V>(mut self, keywords: V) -> ITunesItemExtensionBuilder
+        where V: Into<Option<String>>
+    {
         self.keywords = keywords.into();
         self
     }
 
-
-    /// Construct the `ITunesItemExtension` from the `ITunesItemExtensionBuilder`.
+    /// Construct the `ITunesItemExtension` from this `ITunesItemExtensionBuilder`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let item = ITunesItemExtensionBuilder::new()
+    /// let ext = ITunesItemExtensionBuilder::default()
     ///     .author("author".to_string())
-    ///     .block("block".to_string())
-    ///     .image("image".to_string())
-    ///     .duration("duration".to_string())
-    ///     .explicit("explicit".to_string())
-    ///     .closed_captioned("closed_captioned".to_string())
-    ///     .order("order".to_string())
-    ///     .subtitle("subtitle".to_string())
-    ///     .summary("summary".to_string())
-    ///     .keywords("keywords".to_string())
     ///     .finalize();
     /// ```
     pub fn finalize(self) -> ITunesItemExtension {

--- a/src/extension/itunes/itunes_owner.rs
+++ b/src/extension/itunes/itunes_owner.rs
@@ -30,7 +30,7 @@ impl ITunesOwner {
     /// let name = "name";
     ///
     /// let owner = ITunesOwnerBuilder::new()
-    ///     .name(Some(name.to_string()))
+    ///     .name(name.to_string())
     ///     .finalize();
     ///
     /// assert_eq!(Some(name), owner.name());
@@ -61,7 +61,7 @@ impl ITunesOwner {
     /// let email = "email@example.com";
     ///
     /// let owner = ITunesOwnerBuilder::new()
-    ///     .email(Some(email.to_string()))
+    ///     .email(email.to_string())
     ///     .finalize();
     ///
     /// assert_eq!(Some(email), owner.email());
@@ -131,10 +131,10 @@ impl ITunesOwnerBuilder {
     /// use rss::extension::itunes::ITunesOwnerBuilder;
     ///
     /// let owner_builder = ITunesOwnerBuilder::new()
-    ///     .name(Some("name".to_string()));
+    ///     .name("name".to_string());
     /// ```
-    pub fn name(mut self, name: Option<String>) -> ITunesOwnerBuilder {
-        self.name = name;
+    pub fn name<V: Into<Option<String>>>(mut self, name: V) -> ITunesOwnerBuilder {
+        self.name = name.into();
         self
     }
 
@@ -146,10 +146,10 @@ impl ITunesOwnerBuilder {
     /// use rss::extension::itunes::ITunesOwnerBuilder;
     ///
     /// let owner_builder = ITunesOwnerBuilder::new()
-    ///     .email(Some("email@example.com".to_string()));
+    ///     .email("email@example.com".to_string());
     /// ```
-    pub fn email(mut self, email: Option<String>) -> ITunesOwnerBuilder {
-        self.email = email;
+    pub fn email<V: Into<Option<String>>>(mut self, email: V) -> ITunesOwnerBuilder {
+        self.email = email.into();
         self
     }
 
@@ -161,8 +161,8 @@ impl ITunesOwnerBuilder {
     /// use rss::extension::itunes::ITunesOwnerBuilder;
     ///
     /// let owner = ITunesOwnerBuilder::new()
-    ///     .email(Some("email@example.com".to_string()))
-    ///     .name(Some("name".to_string()))
+    ///     .email("email@example.com".to_string())
+    ///     .name("name".to_string())
     ///     .finalize();
     /// ```
     pub fn finalize(self) -> ITunesOwner {

--- a/src/extension/itunes/itunes_owner.rs
+++ b/src/extension/itunes/itunes_owner.rs
@@ -5,7 +5,6 @@
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the MIT License and/or Apache 2.0 License.
 
-use error::Error;
 use quick_xml::errors::Error as XmlError;
 use quick_xml::events::{Event, BytesStart, BytesEnd};
 use quick_xml::writer::Writer;
@@ -32,19 +31,17 @@ impl ITunesOwner {
     ///
     /// let owner = ITunesOwnerBuilder::new()
     ///     .name(Some(name.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(name), owner.name());
     /// ```
     ///
-    // ```
-    /// use feed::extension::itunes::{ITunesOwnerBuilder, ITunesOwner};
+    /// ```
+    /// use rss::extension::itunes::{ITunesOwnerBuilder, ITunesOwner};
     ///
     /// let owner = ITunesOwnerBuilder::new()
     ///     .name(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let name_opt = owner.name();
     /// assert!(name_opt.is_none());
@@ -65,19 +62,17 @@ impl ITunesOwner {
     ///
     /// let owner = ITunesOwnerBuilder::new()
     ///     .email(Some(email.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(email), owner.email());
     /// ```
     ///
-    // ```
-    /// use feed::extension::itunes::{ITunesOwnerBuilder, ITunesOwner};
+    /// ```
+    /// use rss::extension::itunes::{ITunesOwnerBuilder, ITunesOwner};
     ///
     /// let owner = ITunesOwnerBuilder::new()
     ///     .email(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let email_opt = owner.email();
     /// assert!(email_opt.is_none());
@@ -168,13 +163,12 @@ impl ITunesOwnerBuilder {
     /// let owner = ITunesOwnerBuilder::new()
     ///     .email(Some("email@example.com".to_string()))
     ///     .name(Some("name".to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     /// ```
-    pub fn finalize(self) -> Result<ITunesOwner, Error> {
-        Ok(ITunesOwner {
-               name: self.name,
-               email: self.email,
-           })
+    pub fn finalize(self) -> ITunesOwner {
+        ITunesOwner {
+            name: self.name,
+            email: self.email,
+        }
     }
 }

--- a/src/extension/itunes/itunes_owner.rs
+++ b/src/extension/itunes/itunes_owner.rs
@@ -15,21 +15,21 @@ use toxml::{ToXml, WriterExt};
 pub struct ITunesOwner {
     /// The name of the owner.
     name: Option<String>,
-    /// The email of the email.
+    /// The email of the owner.
     email: Option<String>,
 }
 
 impl ITunesOwner {
-    /// Get the optional name that exists under `ITunesOwner`.
+    /// Return the name of this owner.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesOwnerBuilder, ITunesOwner};
+    /// use rss::extension::itunes::ITunesOwnerBuilder;
     ///
     /// let name = "name";
     ///
-    /// let owner = ITunesOwnerBuilder::new()
+    /// let owner = ITunesOwnerBuilder::default()
     ///     .name(name.to_string())
     ///     .finalize();
     ///
@@ -37,30 +37,28 @@ impl ITunesOwner {
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesOwnerBuilder, ITunesOwner};
+    /// use rss::extension::itunes::ITunesOwnerBuilder;
     ///
-    /// let owner = ITunesOwnerBuilder::new()
+    /// let owner = ITunesOwnerBuilder::default()
     ///     .name(None)
     ///     .finalize();
     ///
-    /// let name_opt = owner.name();
-    /// assert!(name_opt.is_none());
+    /// assert!(owner.name().is_none());
     /// ```
     pub fn name(&self) -> Option<&str> {
         self.name.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the optional email that exists under `ITunesOwner`.
+    /// Return the email of this owner.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesOwnerBuilder, ITunesOwner};
+    /// use rss::extension::itunes::ITunesOwnerBuilder;
     ///
     /// let email = "email@example.com";
     ///
-    /// let owner = ITunesOwnerBuilder::new()
+    /// let owner = ITunesOwnerBuilder::default()
     ///     .email(email.to_string())
     ///     .finalize();
     ///
@@ -68,14 +66,13 @@ impl ITunesOwner {
     /// ```
     ///
     /// ```
-    /// use rss::extension::itunes::{ITunesOwnerBuilder, ITunesOwner};
+    /// use rss::extension::itunes::ITunesOwnerBuilder;
     ///
-    /// let owner = ITunesOwnerBuilder::new()
+    /// let owner = ITunesOwnerBuilder::default()
     ///     .email(None)
     ///     .finalize();
     ///
-    /// let email_opt = owner.email();
-    /// assert!(email_opt.is_none());
+    /// assert!(owner.email().is_none());
     /// ```
     pub fn email(&self) -> Option<&str> {
         self.email.as_ref().map(|s| s.as_str())
@@ -102,7 +99,7 @@ impl ToXml for ITunesOwner {
     }
 }
 
-/// This `ITunesOwnerBuilder` struct creates the `ITunesOwner`.
+/// A builder used to create an `ITunesOwner`.
 #[derive(Debug, Clone, Default)]
 pub struct ITunesOwnerBuilder {
     name: Option<String>,
@@ -110,27 +107,14 @@ pub struct ITunesOwnerBuilder {
 }
 
 impl ITunesOwnerBuilder {
-    /// Construct a new `ITunesOwnerBuilder` and return default values.
+    /// Set the name of the owner.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesOwnerBuilder;
     ///
-    /// let owner_builder = ITunesOwnerBuilder::new();
-    /// ```
-    pub fn new() -> ITunesOwnerBuilder {
-        ITunesOwnerBuilder::default()
-    }
-
-    /// Set the optional name that exists under `ITunesOwner`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rss::extension::itunes::ITunesOwnerBuilder;
-    ///
-    /// let owner_builder = ITunesOwnerBuilder::new()
+    /// let builder = ITunesOwnerBuilder::default()
     ///     .name("name".to_string());
     /// ```
     pub fn name<V: Into<Option<String>>>(mut self, name: V) -> ITunesOwnerBuilder {
@@ -138,14 +122,14 @@ impl ITunesOwnerBuilder {
         self
     }
 
-    /// Set the optional email that exists under `ITunesOwner`.
+    /// Set the email of the owner.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesOwnerBuilder;
     ///
-    /// let owner_builder = ITunesOwnerBuilder::new()
+    /// let builder = ITunesOwnerBuilder::default()
     ///     .email("email@example.com".to_string());
     /// ```
     pub fn email<V: Into<Option<String>>>(mut self, email: V) -> ITunesOwnerBuilder {
@@ -153,16 +137,16 @@ impl ITunesOwnerBuilder {
         self
     }
 
-    /// Construct the `ITunesOwner` from the `ITunesOwnerBuilder`.
+    /// Construct the `ITunesOwner` from this `ITunesOwnerBuilder`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::extension::itunes::ITunesOwnerBuilder;
     ///
-    /// let owner = ITunesOwnerBuilder::new()
-    ///     .email("email@example.com".to_string())
+    /// let owner = ITunesOwnerBuilder::default()
     ///     .name("name".to_string())
+    ///     .email("email@example.com".to_string())
     ///     .finalize();
     /// ```
     pub fn finalize(self) -> ITunesOwner {

--- a/src/extension/itunes/itunes_owner.rs
+++ b/src/extension/itunes/itunes_owner.rs
@@ -130,8 +130,8 @@ impl ITunesOwnerBuilder {
     /// ```
     /// use rss::extension::itunes::ITunesOwnerBuilder;
     ///
-    /// let mut owner_builder = ITunesOwnerBuilder::new();
-    /// owner_builder.name(Some("name".to_string()));
+    /// let owner_builder = ITunesOwnerBuilder::new()
+    ///     .name(Some("name".to_string()));
     /// ```
     pub fn name(mut self, name: Option<String>) -> ITunesOwnerBuilder {
         self.name = name;
@@ -145,8 +145,8 @@ impl ITunesOwnerBuilder {
     /// ```
     /// use rss::extension::itunes::ITunesOwnerBuilder;
     ///
-    /// let mut owner_builder = ITunesOwnerBuilder::new();
-    /// owner_builder.email(Some("email@example.com".to_string()));
+    /// let owner_builder = ITunesOwnerBuilder::new()
+    ///     .email(Some("email@example.com".to_string()));
     /// ```
     pub fn email(mut self, email: Option<String>) -> ITunesOwnerBuilder {
         self.email = email;

--- a/src/extension/itunes/mod.rs
+++ b/src/extension/itunes/mod.rs
@@ -52,7 +52,7 @@ fn parse_categories(map: &mut HashMap<String, Vec<Extension>>)
         let child = {
             if let Some(mut child) = elem.children.remove("category").map(|mut v| v.remove(0)) {
                 let text = child.attrs.remove("text").unwrap_or_default();
-                Some(Box::new(ITunesCategoryBuilder::new()
+                Some(Box::new(ITunesCategoryBuilder::default()
                                   .text(text.as_str())
                                   .subcategory(None)
                                   .finalize()))
@@ -61,7 +61,7 @@ fn parse_categories(map: &mut HashMap<String, Vec<Extension>>)
             }
         };
 
-        categories.push(ITunesCategoryBuilder::new()
+        categories.push(ITunesCategoryBuilder::default()
                             .text(text.as_str())
                             .subcategory(child)
                             .finalize());
@@ -85,5 +85,8 @@ fn parse_owner(map: &mut HashMap<String, Vec<Extension>>) -> Result<Option<ITune
         .remove("email")
         .and_then(|mut v| v.remove(0).value);
 
-    Ok(Some(ITunesOwnerBuilder::new().name(name).email(email).finalize()))
+    Ok(Some(ITunesOwnerBuilder::default()
+                .name(name)
+                .email(email)
+                .finalize()))
 }

--- a/src/extension/itunes/mod.rs
+++ b/src/extension/itunes/mod.rs
@@ -55,7 +55,7 @@ fn parse_categories(map: &mut HashMap<String, Vec<Extension>>)
                 Some(Box::new(ITunesCategoryBuilder::new()
                                   .text(text.as_str())
                                   .subcategory(None)
-                                  .finalize()?))
+                                  .finalize()))
             } else {
                 None
             }
@@ -64,7 +64,7 @@ fn parse_categories(map: &mut HashMap<String, Vec<Extension>>)
         categories.push(ITunesCategoryBuilder::new()
                             .text(text.as_str())
                             .subcategory(child)
-                            .finalize()?);
+                            .finalize());
     }
 
     Ok(categories)
@@ -85,8 +85,5 @@ fn parse_owner(map: &mut HashMap<String, Vec<Extension>>) -> Result<Option<ITune
         .remove("email")
         .and_then(|mut v| v.remove(0).value);
 
-    Ok(Some(ITunesOwnerBuilder::new()
-                .name(name)
-                .email(email)
-                .finalize()?))
+    Ok(Some(ITunesOwnerBuilder::new().name(name).email(email).finalize()))
 }

--- a/src/extension/mod.rs
+++ b/src/extension/mod.rs
@@ -37,22 +37,24 @@ pub struct Extension {
 }
 
 impl Extension {
-    /// Get the name that exists under `Extension`.
+    /// Return the qualified name of the extension element.
     pub fn name(&self) -> &str {
         self.name.as_str()
     }
 
-    /// Get the value that exists under `Extension`.
+    /// Return the content of the extension element.
     pub fn value(&self) -> Option<&str> {
         self.value.as_ref().map(|s| s.as_str())
     }
 
-    /// Get the attrs that exists under `Extension`.
+    /// Return the attributes for the extension element.
     pub fn attrs(&self) -> &HashMap<String, String> {
         &self.attrs
     }
 
-    /// Get the children that exists under `Extension`.
+    /// Return the children of the extension element.
+    ///
+    /// This is a map of local names to child elements.
     pub fn children(&self) -> &HashMap<String, Vec<Extension>> {
         &self.children
     }
@@ -96,38 +98,31 @@ pub struct ExtensionBuilder {
 }
 
 impl ExtensionBuilder {
-    /// Construct a new `ExtensionBuilder` and return default values.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rss::extension::ExtensionBuilder;
-    ///
-    /// let extension_builder = ExtensionBuilder::new();
-    /// ```
-    pub fn new() -> ExtensionBuilder {
-        ExtensionBuilder::default()
-    }
-
-    /// Get the name that exists under `Extension`.
-    pub fn name<S: Into<String>>(mut self, name: S) -> ExtensionBuilder {
+    /// Set the qualified name of the extension element.
+    pub fn name<S>(mut self, name: S) -> ExtensionBuilder
+        where S: Into<String>
+    {
         self.name = name.into();
         self
     }
 
-    /// Get the value that exists under `Extension`.
-    pub fn value<V: Into<Option<String>>>(mut self, value: V) -> ExtensionBuilder {
+    /// Set the content of the extension element.
+    pub fn value<V>(mut self, value: V) -> ExtensionBuilder
+        where V: Into<Option<String>>
+    {
         self.value = value.into();
         self
     }
 
-    /// Get the attrs that exists under `Extension`.
-    pub fn attrs<V: Into<HashMap<String, String>>>(mut self, attrs: V) -> ExtensionBuilder {
+    /// Set the attributes for the extension element.
+    pub fn attrs<V>(mut self, attrs: V) -> ExtensionBuilder
+        where V: Into<HashMap<String, String>>
+    {
         self.attrs = attrs.into();
         self
     }
 
-    /// Get the children that exists under `Extension`.
+    /// Set the children of the extension element.
     pub fn children<V>(mut self, children: V) -> ExtensionBuilder
         where V: Into<HashMap<String, Vec<Extension>>>
     {
@@ -135,7 +130,7 @@ impl ExtensionBuilder {
         self
     }
 
-    /// Construct the `ExtensionBuilder` from the `ExtensionBuilderBuilder`.
+    /// Construct the `ExtensionBuilder` from this `ExtensionBuilderBuilder`.
     pub fn finalize(self) -> Extension {
         Extension {
             name: self.name,

--- a/src/extension/mod.rs
+++ b/src/extension/mod.rs
@@ -96,7 +96,7 @@ pub struct ExtensionBuilder {
 }
 
 impl ExtensionBuilder {
-    // Construct a new `DublinCoreExtensionBuilder` and return default values.
+    /// Construct a new `ExtensionBuilder` and return default values.
     ///
     /// # Examples
     ///
@@ -110,8 +110,8 @@ impl ExtensionBuilder {
     }
 
     /// Get the name that exists under `Extension`.
-    pub fn name(mut self, name: &str) -> ExtensionBuilder {
-        self.name = name.to_string();
+    pub fn name<S: Into<String>>(mut self, name: S) -> ExtensionBuilder {
+        self.name = name.into();
         self
     }
 

--- a/src/extension/mod.rs
+++ b/src/extension/mod.rs
@@ -116,20 +116,22 @@ impl ExtensionBuilder {
     }
 
     /// Get the value that exists under `Extension`.
-    pub fn value(mut self, value: Option<String>) -> ExtensionBuilder {
-        self.value = value;
+    pub fn value<V: Into<Option<String>>>(mut self, value: V) -> ExtensionBuilder {
+        self.value = value.into();
         self
     }
 
     /// Get the attrs that exists under `Extension`.
-    pub fn attrs(mut self, attrs: HashMap<String, String>) -> ExtensionBuilder {
-        self.attrs = attrs;
+    pub fn attrs<V: Into<HashMap<String, String>>>(mut self, attrs: V) -> ExtensionBuilder {
+        self.attrs = attrs.into();
         self
     }
 
     /// Get the children that exists under `Extension`.
-    pub fn children(mut self, children: HashMap<String, Vec<Extension>>) -> ExtensionBuilder {
-        self.children = children;
+    pub fn children<V>(mut self, children: V) -> ExtensionBuilder
+        where V: Into<HashMap<String, Vec<Extension>>>
+    {
+        self.children = children.into();
         self
     }
 

--- a/src/extension/mod.rs
+++ b/src/extension/mod.rs
@@ -5,8 +5,6 @@
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the MIT License and/or Apache 2.0 License.
 
-use error::Error;
-
 use quick_xml::errors::Error as XmlError;
 use quick_xml::events::{Event, BytesStart, BytesEnd, BytesText};
 use quick_xml::writer::Writer;
@@ -136,13 +134,13 @@ impl ExtensionBuilder {
     }
 
     /// Construct the `ExtensionBuilder` from the `ExtensionBuilderBuilder`.
-    pub fn finalize(self) -> Result<Extension, Error> {
-        Ok(Extension {
-               name: self.name,
-               value: self.value,
-               attrs: self.attrs,
-               children: self.children,
-           })
+    pub fn finalize(self) -> Extension {
+        Extension {
+            name: self.name,
+            value: self.value,
+            attrs: self.attrs,
+            children: self.children,
+        }
     }
 }
 

--- a/src/fromxml.rs
+++ b/src/fromxml.rs
@@ -124,12 +124,12 @@ fn parse_extension_element<R: BufRead>(reader: &mut Reader<R>,
                 }
             }
             Event::End(element) => {
-                return ExtensionBuilder::new()
-                           .name(&*reader.decode(element.name()))
-                           .value(content)
-                           .attrs(attrs)
-                           .children(children)
-                           .finalize();
+                return Ok(ExtensionBuilder::new()
+                              .name(&*reader.decode(element.name()))
+                              .value(content)
+                              .attrs(attrs)
+                              .children(children)
+                              .finalize());
             }
             Event::CData(element) => {
                 content = Some(reader.decode(&element).into_owned());

--- a/src/fromxml.rs
+++ b/src/fromxml.rs
@@ -124,7 +124,7 @@ fn parse_extension_element<R: BufRead>(reader: &mut Reader<R>,
                 }
             }
             Event::End(element) => {
-                return Ok(ExtensionBuilder::new()
+                return Ok(ExtensionBuilder::default()
                               .name(&*reader.decode(element.name()))
                               .value(content)
                               .attrs(attrs)

--- a/src/fromxml.rs
+++ b/src/fromxml.rs
@@ -33,7 +33,7 @@ pub fn element_text<R: BufRead>(reader: &mut Reader<R>) -> Result<Option<String>
                 content = Some(text);
             }
             Event::Text(element) => {
-                let text = element.unescape_and_decode(&reader)?;
+                let text = element.unescape_and_decode(reader)?;
                 content = Some(text);
             }
             Event::End(_) | Event::Eof => break,
@@ -99,7 +99,7 @@ fn parse_extension_element<R: BufRead>(reader: &mut Reader<R>,
     for attr in atts.with_checks(false) {
         if let Ok(attr) = attr {
             let key = str::from_utf8(attr.key)?;
-            let value = attr.unescape_and_decode_value(&reader)?;
+            let value = attr.unescape_and_decode_value(reader)?;
             attrs.insert(key.to_string(), value);
         }
     }
@@ -135,7 +135,7 @@ fn parse_extension_element<R: BufRead>(reader: &mut Reader<R>,
                 content = Some(reader.decode(&element).into_owned());
             }
             Event::Text(element) => {
-                content = Some(element.unescape_and_decode(&reader)?);
+                content = Some(element.unescape_and_decode(reader)?);
             }
             Event::Eof => break,
             _ => {}

--- a/src/guid.rs
+++ b/src/guid.rs
@@ -44,7 +44,7 @@ impl Guid {
     /// let permalink = true;
     ///
     /// let guid = GuidBuilder::new()
-    ///     .is_permalink(Some(permalink))
+    ///     .is_permalink(permalink)
     ///     .finalize();
     ///
     /// assert_eq!(permalink, guid.is_permalink());
@@ -56,7 +56,7 @@ impl Guid {
     /// let permalink = false;
     ///
     /// let guid = GuidBuilder::new()
-    ///     .is_permalink(Some(permalink))
+    ///     .is_permalink(permalink)
     ///     .finalize();
     ///
     /// assert_eq!(permalink, guid.is_permalink());
@@ -165,10 +165,10 @@ impl GuidBuilder {
     /// use rss::GuidBuilder;
     ///
     /// let guid_builder = GuidBuilder::new()
-    ///     .is_permalink(Some(false));
+    ///     .is_permalink(false);
     /// ```
-    pub fn is_permalink(mut self, is_permalink: Option<bool>) -> GuidBuilder {
-        self.is_permalink = is_permalink;
+    pub fn is_permalink<V: Into<Option<bool>>>(mut self, is_permalink: V) -> GuidBuilder {
+        self.is_permalink = is_permalink.into();
         self
     }
 
@@ -196,7 +196,7 @@ impl GuidBuilder {
     ///
     /// let guid = GuidBuilder::new()
     ///         .value("9DE46946-2F90-4D5D-9047-7E9165C16E7C")
-    ///         .is_permalink(Some(true))
+    ///         .is_permalink(true)
     ///         .finalize();
     /// ```
     pub fn finalize(self) -> Guid {

--- a/src/guid.rs
+++ b/src/guid.rs
@@ -33,8 +33,7 @@ impl Guid {
     ///
     /// let guid = GuidBuilder::new()
     ///     .is_permalink(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(guid.is_permalink());
     /// ```
@@ -46,8 +45,7 @@ impl Guid {
     ///
     /// let guid = GuidBuilder::new()
     ///     .is_permalink(Some(permalink))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(permalink, guid.is_permalink());
     /// ```
@@ -59,8 +57,7 @@ impl Guid {
     ///
     /// let guid = GuidBuilder::new()
     ///     .is_permalink(Some(permalink))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(permalink, guid.is_permalink());
     /// ```
@@ -78,8 +75,7 @@ impl Guid {
     /// let guid = "9DE46946-2F90-4D5D-9047-7E9165C16E7C";
     /// let guid_obj = GuidBuilder::new()
     ///     .value(guid)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(guid, guid_obj.value());
     /// ```
@@ -203,15 +199,10 @@ impl GuidBuilder {
     ///         .is_permalink(Some(true))
     ///         .finalize();
     /// ```
-    pub fn finalize(self) -> Result<Guid, Error> {
-        let is_permalink = match self.is_permalink {
-            Some(val) => val,
-            None => true,
-        };
-
-        Ok(Guid {
-               is_permalink: is_permalink,
-               value: self.value,
-           })
+    pub fn finalize(self) -> Guid {
+        Guid {
+            is_permalink: self.is_permalink.unwrap_or(true),
+            value: self.value,
+        }
     }
 }

--- a/src/guid.rs
+++ b/src/guid.rs
@@ -24,26 +24,25 @@ pub struct Guid {
 }
 
 impl Guid {
-    /// Get the permalink that exists under `Guid`.
+    /// Return whether this `Guid` is a permalink.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{GuidBuilder, Guid};
+    /// use rss::GuidBuilder;
     ///
-    /// let guid = GuidBuilder::new()
-    ///     .is_permalink(None)
+    /// let guid = GuidBuilder::default()
     ///     .finalize();
     ///
     /// assert!(guid.is_permalink());
     /// ```
     ///
     /// ```
-    /// use rss::{GuidBuilder, Guid};
+    /// use rss::GuidBuilder;
     ///
     /// let permalink = true;
     ///
-    /// let guid = GuidBuilder::new()
+    /// let guid = GuidBuilder::default()
     ///     .is_permalink(permalink)
     ///     .finalize();
     ///
@@ -51,11 +50,11 @@ impl Guid {
     /// ```
     ///
     /// ```
-    /// use rss::{GuidBuilder, Guid};
+    /// use rss::GuidBuilder;
     ///
     /// let permalink = false;
     ///
-    /// let guid = GuidBuilder::new()
+    /// let guid = GuidBuilder::default()
     ///     .is_permalink(permalink)
     ///     .finalize();
     ///
@@ -65,19 +64,20 @@ impl Guid {
         self.is_permalink
     }
 
-    /// Get the guid that exists under `Guid`.
+    /// Return the value of this `Guid`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{GuidBuilder, Guid};
+    /// use rss::GuidBuilder;
     ///
-    /// let guid = "9DE46946-2F90-4D5D-9047-7E9165C16E7C";
-    /// let guid_obj = GuidBuilder::new()
-    ///     .value(guid)
+    /// let value = "9DE46946-2F90-4D5D-9047-7E9165C16E7C";
+    ///
+    /// let guid = GuidBuilder::default()
+    ///     .value(value)
     ///     .finalize();
     ///
-    /// assert_eq!(guid, guid_obj.value());
+    /// assert_eq!(value, guid.value());
     /// ```
     pub fn value(&self) -> &str {
         self.value.as_str()
@@ -136,7 +136,7 @@ impl ToXml for Guid {
     }
 }
 
-/// This `GuidBuilder` struct creates the `Guid`.
+/// A builder used to create an `Guid`.
 #[derive(Debug, Clone, Default)]
 pub struct GuidBuilder {
     is_permalink: Option<bool>,
@@ -144,59 +144,48 @@ pub struct GuidBuilder {
 }
 
 impl GuidBuilder {
-    /// Construct a new `GuidBuilder` and return default values.
+    /// Set whether this `Guid` is a permalink.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::GuidBuilder;
     ///
-    /// let guid_builder = GuidBuilder::new();
-    /// ```
-    pub fn new() -> GuidBuilder {
-        GuidBuilder::default()
-    }
-
-    /// Set the optional permalink that exists under `Guid`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rss::GuidBuilder;
-    ///
-    /// let guid_builder = GuidBuilder::new()
+    /// let builder = GuidBuilder::default()
     ///     .is_permalink(false);
     /// ```
-    pub fn is_permalink<V: Into<Option<bool>>>(mut self, is_permalink: V) -> GuidBuilder {
-        self.is_permalink = is_permalink.into();
+    pub fn is_permalink(mut self, is_permalink: bool) -> GuidBuilder {
+        self.is_permalink = Some(is_permalink);
         self
     }
 
-    /// Set the guid that exists under `Guid`.
+    /// Set the value of this `Guid`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::GuidBuilder;
     ///
-    /// let guid_builder = GuidBuilder::new()
+    /// let builder = GuidBuilder::default()
     ///     .value("9DE46946-2F90-4D5D-9047-7E9165C16E7C");
     /// ```
-    pub fn value<S: Into<String>>(mut self, value: S) -> GuidBuilder {
+    pub fn value<S>(mut self, value: S) -> GuidBuilder
+        where S: Into<String>
+    {
         self.value = value.into();
         self
     }
 
-    /// Construct the `Guid` from the `GuidBuilder`.
+    /// Construct the `Guid` from this `GuidBuilder`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::GuidBuilder;
     ///
-    /// let guid = GuidBuilder::new()
-    ///         .value("9DE46946-2F90-4D5D-9047-7E9165C16E7C")
+    /// let guid = GuidBuilder::default()
     ///         .is_permalink(true)
+    ///         .value("9DE46946-2F90-4D5D-9047-7E9165C16E7C")
     ///         .finalize();
     /// ```
     pub fn finalize(self) -> Guid {

--- a/src/guid.rs
+++ b/src/guid.rs
@@ -164,8 +164,8 @@ impl GuidBuilder {
     /// ```
     /// use rss::GuidBuilder;
     ///
-    /// let mut guid_builder = GuidBuilder::new();
-    /// guid_builder.is_permalink(Some(false));
+    /// let guid_builder = GuidBuilder::new()
+    ///     .is_permalink(Some(false));
     /// ```
     pub fn is_permalink(mut self, is_permalink: Option<bool>) -> GuidBuilder {
         self.is_permalink = is_permalink;
@@ -179,11 +179,11 @@ impl GuidBuilder {
     /// ```
     /// use rss::GuidBuilder;
     ///
-    /// let mut guid_builder = GuidBuilder::new();
-    /// guid_builder.value("9DE46946-2F90-4D5D-9047-7E9165C16E7C");
+    /// let guid_builder = GuidBuilder::new()
+    ///     .value("9DE46946-2F90-4D5D-9047-7E9165C16E7C");
     /// ```
-    pub fn value(mut self, value: &str) -> GuidBuilder {
-        self.value = value.to_string();
+    pub fn value<S: Into<String>>(mut self, value: S) -> GuidBuilder {
+        self.value = value.into();
         self
     }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -263,8 +263,8 @@ impl FromXml for Image {
         let mut skip_buf = Vec::new();
 
         loop {
-            match reader.read_event(&mut buf) {
-                Ok(Event::Start(element)) => {
+            match reader.read_event(&mut buf)? {
+                Event::Start(element) => {
                     match element.name() {
                         b"url" => url = element_text(reader)?,
                         b"title" => title = element_text(reader)?,
@@ -275,7 +275,7 @@ impl FromXml for Image {
                         n => reader.read_to_end(n, &mut skip_buf)?,
                     }
                 }
-                Ok(Event::End(_)) => {
+                Event::End(_) => {
                     let url = url.unwrap_or_default();
                     let title = title.unwrap_or_default();
                     let link = link.unwrap_or_default();
@@ -289,8 +289,7 @@ impl FromXml for Image {
                                   description: description,
                               });
                 }
-                Ok(Event::Eof) => break,
-                Err(err) => return Err(err.into()),
+                Event::Eof => break,
                 _ => {}
             }
             buf.clear();

--- a/src/image.rs
+++ b/src/image.rs
@@ -267,14 +267,10 @@ impl FromXml for Image {
                     }
                 }
                 Event::End(_) => {
-                    let url = url.unwrap_or_default();
-                    let title = title.unwrap_or_default();
-                    let link = link.unwrap_or_default();
-
                     return Ok(Image {
-                                  url: url,
-                                  title: title,
-                                  link: link,
+                                  url: url.unwrap_or_default(),
+                                  title: title.unwrap_or_default(),
+                                  link: link.unwrap_or_default(),
                                   width: width,
                                   height: height,
                                   description: description,
@@ -351,12 +347,11 @@ impl ImageBuilder {
     /// ```
     /// use rss::ImageBuilder;
     ///
-    /// let mut image_builder = ImageBuilder::new();
-    /// image_builder.url("http://jupiterbroadcasting.com/images/LAS-300-Badge.
-    /// jpg");
+    /// let image_builder = ImageBuilder::new()
+    ///     .url("http://jupiterbroadcasting.com/images/LAS-300-Badge.jpg");
     /// ```
-    pub fn url(mut self, url: &str) -> ImageBuilder {
-        self.url = url.to_string();
+    pub fn url<S: Into<String>>(mut self, url: S) -> ImageBuilder {
+        self.url = url.into();
         self
     }
 
@@ -368,11 +363,11 @@ impl ImageBuilder {
     /// ```
     /// use rss::ImageBuilder;
     ///
-    /// let mut image_builder = ImageBuilder::new();
-    /// image_builder.title("LAS 300 Logo");
+    /// let image_builder = ImageBuilder::new()
+    ///     .title("LAS 300 Logo");
     /// ```
-    pub fn title(mut self, title: &str) -> ImageBuilder {
-        self.title = title.to_string();
+    pub fn title<S: Into<String>>(mut self, title: S) -> ImageBuilder {
+        self.title = title.into();
         self
     }
 
@@ -384,11 +379,11 @@ impl ImageBuilder {
     /// ```
     /// use rss::ImageBuilder;
     ///
-    /// let mut image_builder = ImageBuilder::new();
-    /// image_builder.link("http://www.jupiterbroadcasting.com/");
+    /// let image_builder = ImageBuilder::new()
+    ///     .link("http://www.jupiterbroadcasting.com/");
     /// ```
-    pub fn link(mut self, link: &str) -> ImageBuilder {
-        self.link = link.to_string();
+    pub fn link<S: Into<String>>(mut self, link: S) -> ImageBuilder {
+        self.link = link.into();
         self
     }
 
@@ -400,8 +395,8 @@ impl ImageBuilder {
     /// ```
     /// use rss::ImageBuilder;
     ///
-    /// let mut image_builder = ImageBuilder::new();
-    /// image_builder.width(Some(88));
+    /// let image_builder = ImageBuilder::new()
+    ///     .width(Some(88));
     /// ```
     pub fn width(mut self, width: Option<i64>) -> ImageBuilder {
         self.width = width;
@@ -416,8 +411,8 @@ impl ImageBuilder {
     /// ```
     /// use rss::ImageBuilder;
     ///
-    /// let mut image_builder = ImageBuilder::new();
-    /// image_builder.height(Some(88));
+    /// let image_builder = ImageBuilder::new()
+    ///     .height(Some(88));
     /// ```
     pub fn height(mut self, height: Option<i64>) -> ImageBuilder {
         self.height = height;
@@ -432,8 +427,8 @@ impl ImageBuilder {
     /// ```
     /// use rss::ImageBuilder;
     ///
-    /// let mut image_builder = ImageBuilder::new();
-    /// image_builder.description(Some("This is a test".to_string()));
+    /// let image_builder = ImageBuilder::new()
+    ///     .description(Some("This is a test".to_string()));
     /// ```
     pub fn description(mut self, description: Option<String>) -> ImageBuilder {
         self.description = description;

--- a/src/image.rs
+++ b/src/image.rs
@@ -47,8 +47,7 @@ impl Image {
     /// let image = ImageBuilder::new()
     ///     .url(url)
     ///     .link(link)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(url, image.url());
     /// ```
@@ -74,8 +73,7 @@ impl Image {
     ///     .title(title)
     ///     .url(url)
     ///     .link(link)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(title, image.title());
     /// ```
@@ -98,8 +96,7 @@ impl Image {
     /// let image = ImageBuilder::new()
     ///     .url(url)
     ///     .link(link)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(link, image.link());
     /// ```
@@ -125,8 +122,7 @@ impl Image {
     ///     .width(None)
     ///     .url(url)
     ///     .link(link)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(default.to_string(), image.width().unwrap());
     /// ```
@@ -144,8 +140,7 @@ impl Image {
     ///     .width(Some(width))
     ///     .url(url)
     ///     .link(link)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(width.to_string().as_str()), image.width());
     /// ```
@@ -173,8 +168,7 @@ impl Image {
     ///     .height(None)
     ///     .url(url)
     ///     .link(link)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(default.to_string(), image.height().unwrap());
     /// ```
@@ -192,8 +186,7 @@ impl Image {
     ///     .height(Some(height))
     ///     .url(url)
     ///     .link(link)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(height.to_string().as_str()), image.height());
     /// ```
@@ -217,8 +210,7 @@ impl Image {
     ///     .description(None)
     ///     .url(url)
     ///     .link(link)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(image.description().is_none());
     /// ```
@@ -236,8 +228,7 @@ impl Image {
     ///     .description(Some(description_string.to_string()))
     ///     .url(url)
     ///     .link(link)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let description_option = image.description();
     /// assert!(description_option.is_some());
@@ -464,8 +455,9 @@ impl ImageBuilder {
     ///         .width(Some(88))
     ///         .height(Some(88))
     ///         .description(Some("This is a test".to_string()))
-    ///         .validate().unwrap()
-    ///         .finalize().unwrap();
+    ///         .validate()
+    ///         .unwrap()
+    ///         .finalize();
     /// ```
     pub fn validate(self) -> Result<ImageBuilder, Error> {
         if !self.url.ends_with(".jpeg") && !self.url.ends_with(".jpg") &&
@@ -517,25 +509,14 @@ impl ImageBuilder {
     ///         .description(Some("This is a test".to_string()))
     ///         .finalize();
     /// ```
-    pub fn finalize(self) -> Result<Image, Error> {
-
-        let width = match self.width {
-            Some(val) => Some(val.to_string()),
-            None => Some(88.to_string()),
-        };
-
-        let height = match self.height {
-            Some(val) => Some(val.to_string()),
-            None => Some(31.to_string()),
-        };
-
-        Ok(Image {
-               url: self.url,
-               title: self.title,
-               link: self.link,
-               width: width,
-               height: height,
-               description: self.description,
-           })
+    pub fn finalize(self) -> Image {
+        Image {
+            url: self.url,
+            title: self.title,
+            link: self.link,
+            width: Some(self.width.unwrap_or(88).to_string()),
+            height: Some(self.height.unwrap_or(31).to_string()),
+            description: self.description,
+        }
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -137,7 +137,7 @@ impl Image {
     /// let link = "http://www.jupiterbroadcasting.com";
     ///
     /// let image = ImageBuilder::new()
-    ///     .width(Some(width))
+    ///     .width(width)
     ///     .url(url)
     ///     .link(link)
     ///     .finalize();
@@ -183,7 +183,7 @@ impl Image {
     /// let link = "http://www.jupiterbroadcasting.com";
     ///
     /// let image = ImageBuilder::new()
-    ///     .height(Some(height))
+    ///     .height(height)
     ///     .url(url)
     ///     .link(link)
     ///     .finalize();
@@ -225,7 +225,7 @@ impl Image {
     /// let link = "http://www.jupiterbroadcasting.com";
     ///
     /// let image = ImageBuilder::new()
-    ///     .description(Some(description_string.to_string()))
+    ///     .description(description_string.to_string())
     ///     .url(url)
     ///     .link(link)
     ///     .finalize();
@@ -396,10 +396,10 @@ impl ImageBuilder {
     /// use rss::ImageBuilder;
     ///
     /// let image_builder = ImageBuilder::new()
-    ///     .width(Some(88));
+    ///     .width(88);
     /// ```
-    pub fn width(mut self, width: Option<i64>) -> ImageBuilder {
-        self.width = width;
+    pub fn width<V: Into<Option<i64>>>(mut self, width: V) -> ImageBuilder {
+        self.width = width.into();
         self
     }
 
@@ -412,10 +412,10 @@ impl ImageBuilder {
     /// use rss::ImageBuilder;
     ///
     /// let image_builder = ImageBuilder::new()
-    ///     .height(Some(88));
+    ///     .height(88);
     /// ```
-    pub fn height(mut self, height: Option<i64>) -> ImageBuilder {
-        self.height = height;
+    pub fn height<V: Into<Option<i64>>>(mut self, height: V) -> ImageBuilder {
+        self.height = height.into();
         self
     }
 
@@ -428,10 +428,10 @@ impl ImageBuilder {
     /// use rss::ImageBuilder;
     ///
     /// let image_builder = ImageBuilder::new()
-    ///     .description(Some("This is a test".to_string()));
+    ///     .description("This is a test".to_string());
     /// ```
-    pub fn description(mut self, description: Option<String>) -> ImageBuilder {
-        self.description = description;
+    pub fn description<V: Into<Option<String>>>(mut self, description: V) -> ImageBuilder {
+        self.description = description.into();
         self
     }
 
@@ -447,9 +447,9 @@ impl ImageBuilder {
     ///         .url("http://jupiterbroadcasting.com/images/LAS-300-Badge.jpg")
     ///         .title("LAS 300 Logo")
     ///         .link("http://www.jupiterbroadcasting.com")
-    ///         .width(Some(88))
-    ///         .height(Some(88))
-    ///         .description(Some("This is a test".to_string()))
+    ///         .width(88)
+    ///         .height(88)
+    ///         .description("This is a test".to_string())
     ///         .validate()
     ///         .unwrap()
     ///         .finalize();
@@ -499,9 +499,9 @@ impl ImageBuilder {
     ///         .url("http://jupiterbroadcasting.com/images/LAS-300-Badge.jpg")
     ///         .title("LAS 300 Logo")
     ///         .link("http://www.jupiterbroadcasting.com")
-    ///         .width(Some(88))
-    ///         .height(Some(88))
-    ///         .description(Some("This is a test".to_string()))
+    ///         .width(88)
+    ///         .height(88)
+    ///         .description("This is a test".to_string())
     ///         .finalize();
     /// ```
     pub fn finalize(self) -> Image {

--- a/src/image.rs
+++ b/src/image.rs
@@ -33,20 +33,17 @@ pub struct Image {
 }
 
 impl Image {
-    /// Get the url that exists under `Image`.
+    /// Return the URL for this `Image`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ImageBuilder, Image};
+    /// use rss::ImageBuilder;
     ///
     /// let url = "http://jupiterbroadcasting.com/images/LAS-300-Badge.jpg";
     ///
-    /// let link = "http://www.jupiterbroadcasting.com";
-    ///
-    /// let image = ImageBuilder::new()
+    /// let image = ImageBuilder::default()
     ///     .url(url)
-    ///     .link(link)
     ///     .finalize();
     ///
     /// assert_eq!(url, image.url());
@@ -55,24 +52,17 @@ impl Image {
         self.url.as_str()
     }
 
-
-    /// Get the title that exists under `Image`.
+    /// Return the title for this `Image`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ImageBuilder, Image};
+    /// use rss::ImageBuilder;
     ///
     /// let title = "LAS 300 Logo";
     ///
-    /// let url = "http://jupiterbroadcasting.com/images/LAS-300-Badge.jpg";
-    ///
-    /// let link = "http://www.jupiterbroadcasting.com";
-    ///
-    /// let image = ImageBuilder::new()
+    /// let image = ImageBuilder::default()
     ///     .title(title)
-    ///     .url(url)
-    ///     .link(link)
     ///     .finalize();
     ///
     /// assert_eq!(title, image.title());
@@ -81,20 +71,16 @@ impl Image {
         self.title.as_str()
     }
 
-
-    /// Get the link that exists under `Image`.
+    /// Return the link that this `Image` directs to.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ImageBuilder, Image};
-    ///
-    /// let url = "http://jupiterbroadcasting.com/images/LAS-300-Badge.jpg";
+    /// use rss::ImageBuilder;
     ///
     /// let link = "http://www.jupiterbroadcasting.com/";
     ///
-    /// let image = ImageBuilder::new()
-    ///     .url(url)
+    /// let image = ImageBuilder::default()
     ///     .link(link)
     ///     .finalize();
     ///
@@ -104,88 +90,40 @@ impl Image {
         self.link.as_str()
     }
 
-
-    /// Get the width that exists under `Image`.
+    /// Return the width of this `Image`.
+    ///
+    /// If this is `None` the default value should be considered to be `80`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ImageBuilder, Image};
+    /// use rss::ImageBuilder;
     ///
-    /// let default: i64 = 88;
+    /// let width = 60;
     ///
-    /// let url = "http://jupiterbroadcasting.com/images/LAS-300-Badge.jpg";
-    ///
-    /// let link = "http://www.jupiterbroadcasting.com";
-    ///
-    /// let image = ImageBuilder::new()
-    ///     .width(None)
-    ///     .url(url)
-    ///     .link(link)
-    ///     .finalize();
-    ///
-    /// assert_eq!(default.to_string(), image.width().unwrap());
-    /// ```
-    ///
-    /// ```
-    /// use rss::{ImageBuilder, Image};
-    ///
-    /// let width: i64 = 60;
-    ///
-    /// let url = "http://jupiterbroadcasting.com/images/LAS-300-Badge.jpg";
-    ///
-    /// let link = "http://www.jupiterbroadcasting.com";
-    ///
-    /// let image = ImageBuilder::new()
+    /// let image = ImageBuilder::default()
     ///     .width(width)
-    ///     .url(url)
-    ///     .link(link)
     ///     .finalize();
     ///
     /// assert_eq!(Some(width.to_string().as_str()), image.width());
-    /// ```
-    ///
     /// ```
     pub fn width(&self) -> Option<&str> {
         self.width.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the height that exists under `Image`.
+    /// Return the height of this `Image`.
+    ///
+    /// If this is `None` the default value should be considered to be `31`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ImageBuilder, Image};
+    /// use rss::ImageBuilder;
     ///
-    /// let default: i64 = 31;
+    /// let height = 60;
     ///
-    /// let url = "http://jupiterbroadcasting.com/images/LAS-300-Badge.jpg";
-    ///
-    /// let link = "http://www.jupiterbroadcasting.com";
-    ///
-    /// let image = ImageBuilder::new()
-    ///     .height(None)
-    ///     .url(url)
-    ///     .link(link)
-    ///     .finalize();
-    ///
-    /// assert_eq!(default.to_string(), image.height().unwrap());
-    /// ```
-    ///
-    /// ```
-    /// use rss::{ImageBuilder, Image};
-    ///
-    /// let height: i64 = 60;
-    ///
-    /// let url = "http://jupiterbroadcasting.com/images/LAS-300-Badge.jpg";
-    ///
-    /// let link = "http://www.jupiterbroadcasting.com";
-    ///
-    /// let image = ImageBuilder::new()
+    /// let image = ImageBuilder::default()
     ///     .height(height)
-    ///     .url(url)
-    ///     .link(link)
     ///     .finalize();
     ///
     /// assert_eq!(Some(height.to_string().as_str()), image.height());
@@ -194,46 +132,30 @@ impl Image {
         self.height.as_ref().map(|s| s.as_str())
     }
 
-
-    /// Get the description that exists under `Image`.
+    /// Return the description of this `Image`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ImageBuilder, Image};
+    /// use rss::ImageBuilder;
     ///
-    /// let url = "http://jupiterbroadcasting.com/images/LAS-300-Badge.jpg";
-    ///
-    /// let link = "http://www.jupiterbroadcasting.com";
-    ///
-    /// let image = ImageBuilder::new()
+    /// let image = ImageBuilder::default()
     ///     .description(None)
-    ///     .url(url)
-    ///     .link(link)
     ///     .finalize();
     ///
     /// assert!(image.description().is_none());
     /// ```
     ///
     /// ```
-    /// use rss::{ImageBuilder, Image};
+    /// use rss::ImageBuilder;
     ///
-    /// let description_string = "This is a test";
+    /// let description = "This is a test";
     ///
-    /// let url = "http://jupiterbroadcasting.com/images/LAS-300-Badge.jpg";
-    ///
-    /// let link = "http://www.jupiterbroadcasting.com";
-    ///
-    /// let image = ImageBuilder::new()
-    ///     .description(description_string.to_string())
-    ///     .url(url)
-    ///     .link(link)
+    /// let image = ImageBuilder::default()
+    ///     .description(description.to_string())
     ///     .finalize();
     ///
-    /// let description_option = image.description();
-    /// assert!(description_option.is_some());
-    ///
-    /// assert_eq!(Some(description_string), image.description());
+    /// assert_eq!(Some(description), image.description());
     /// ```
     pub fn description(&self) -> Option<&str> {
         self.description.as_ref().map(|s| s.as_str())
@@ -314,8 +236,8 @@ impl ToXml for Image {
     }
 }
 
-/// This `ImageBuilder` struct creates the `Image`.
-#[derive(Debug, Clone, Default)]
+/// A builder used to create an `Image`.
+#[derive(Debug, Default, Clone)]
 pub struct ImageBuilder {
     url: String,
     title: String,
@@ -326,133 +248,122 @@ pub struct ImageBuilder {
 }
 
 impl ImageBuilder {
-    /// Construct a new `ImageBuilder` and return default values.
+    /// Set URL for the `Image`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ImageBuilder;
     ///
-    /// let image_builder = ImageBuilder::new();
-    /// ```
-    pub fn new() -> ImageBuilder {
-        ImageBuilder::default()
-    }
-
-
-    /// Set the url that exists under `Image`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rss::ImageBuilder;
-    ///
-    /// let image_builder = ImageBuilder::new()
+    /// let builder = ImageBuilder::default()
     ///     .url("http://jupiterbroadcasting.com/images/LAS-300-Badge.jpg");
     /// ```
-    pub fn url<S: Into<String>>(mut self, url: S) -> ImageBuilder {
+    pub fn url<S>(mut self, url: S) -> ImageBuilder
+        where S: Into<String>
+    {
         self.url = url.into();
         self
     }
 
-
-    /// Set the title that exists under `Image`.
+    /// Set the title for the `Image`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ImageBuilder;
     ///
-    /// let image_builder = ImageBuilder::new()
+    /// let builder = ImageBuilder::default()
     ///     .title("LAS 300 Logo");
     /// ```
-    pub fn title<S: Into<String>>(mut self, title: S) -> ImageBuilder {
+    pub fn title<S>(mut self, title: S) -> ImageBuilder
+        where S: Into<String>
+    {
         self.title = title.into();
         self
     }
 
-
-    /// Set the link that exists under `Image`.
+    /// Set the link that the `Image` directs to.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ImageBuilder;
     ///
-    /// let image_builder = ImageBuilder::new()
+    /// let builder = ImageBuilder::default()
     ///     .link("http://www.jupiterbroadcasting.com/");
     /// ```
-    pub fn link<S: Into<String>>(mut self, link: S) -> ImageBuilder {
+    pub fn link<S>(mut self, link: S) -> ImageBuilder
+        where S: Into<String>
+    {
         self.link = link.into();
         self
     }
 
-
-    /// Set the width that exists under `Image`.
+    /// Set width of the `Image`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ImageBuilder;
     ///
-    /// let image_builder = ImageBuilder::new()
+    /// let builder = ImageBuilder::default()
     ///     .width(88);
     /// ```
-    pub fn width<V: Into<Option<i64>>>(mut self, width: V) -> ImageBuilder {
+    pub fn width<V>(mut self, width: V) -> ImageBuilder
+        where V: Into<Option<i64>>
+    {
         self.width = width.into();
         self
     }
 
-
-    /// Set the height that exists under `Image`.
+    /// Set the height of the `Image`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ImageBuilder;
     ///
-    /// let image_builder = ImageBuilder::new()
+    /// let builder = ImageBuilder::default()
     ///     .height(88);
     /// ```
-    pub fn height<V: Into<Option<i64>>>(mut self, height: V) -> ImageBuilder {
+    pub fn height<V>(mut self, height: V) -> ImageBuilder
+        where V: Into<Option<i64>>
+    {
         self.height = height.into();
         self
     }
 
-
-    /// Set the description that exists under `Image`.
+    /// Set the description of the `Image`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ImageBuilder;
     ///
-    /// let image_builder = ImageBuilder::new()
+    /// let builder = ImageBuilder::default()
     ///     .description("This is a test".to_string());
     /// ```
-    pub fn description<V: Into<Option<String>>>(mut self, description: V) -> ImageBuilder {
+    pub fn description<V>(mut self, description: V) -> ImageBuilder
+        where V: Into<Option<String>>
+    {
         self.description = description.into();
         self
     }
 
 
-    /// Validate the contents of `Image`.
+    /// Validate the contents of this `ImageBuilder`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ImageBuilder;
     ///
-    /// let image = ImageBuilder::new()
+    /// let image = ImageBuilder::default()
     ///         .url("http://jupiterbroadcasting.com/images/LAS-300-Badge.jpg")
     ///         .title("LAS 300 Logo")
     ///         .link("http://www.jupiterbroadcasting.com")
-    ///         .width(88)
-    ///         .height(88)
-    ///         .description("This is a test".to_string())
     ///         .validate()
-    ///         .unwrap()
-    ///         .finalize();
+    ///         .unwrap();
     /// ```
     pub fn validate(self) -> Result<ImageBuilder, Error> {
         if !self.url.ends_with(".jpeg") && !self.url.ends_with(".jpg") &&
@@ -488,20 +399,17 @@ impl ImageBuilder {
     }
 
 
-    /// Construct the `Image` from the `ImageBuilder`.
+    /// Construct the `Image` from this `ImageBuilder`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ImageBuilder;
     ///
-    /// let image = ImageBuilder::new()
+    /// let image = ImageBuilder::default()
     ///         .url("http://jupiterbroadcasting.com/images/LAS-300-Badge.jpg")
     ///         .title("LAS 300 Logo")
     ///         .link("http://www.jupiterbroadcasting.com")
-    ///         .width(88)
-    ///         .height(88)
-    ///         .description("This is a test".to_string())
     ///         .finalize();
     /// ```
     pub fn finalize(self) -> Image {
@@ -509,8 +417,8 @@ impl ImageBuilder {
             url: self.url,
             title: self.title,
             link: self.link,
-            width: Some(self.width.unwrap_or(88).to_string()),
-            height: Some(self.height.unwrap_or(31).to_string()),
+            width: self.width.map(|n| n.to_string()),
+            height: self.height.map(|n| n.to_string()),
             description: self.description,
         }
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -477,26 +477,22 @@ impl ImageBuilder {
         Url::parse(self.url.as_str())?;
         Url::parse(self.link.as_str())?;
 
-        let width_opt = self.width;
-        if width_opt.is_some() {
-            let width = width_opt.unwrap();
+        if let Some(width) = self.width {
             if width > 144 {
-                return Err(Error::Validation("Image width cannot be greater than 144."
+                return Err(Error::Validation("Image Width cannot be greater than 144."
                                                  .to_string()));
             } else if width < 0 {
-                return Err(Error::Validation("Image width cannot be a negative value."
+                return Err(Error::Validation("Image Width cannot be a negative value."
                                                  .to_string()));
             }
         }
 
-        let height_opt = self.height;
-        if height_opt.is_some() {
-            let height = height_opt.unwrap();
+        if let Some(height) = self.height {
             if height > 144 {
-                return Err(Error::Validation("Image height cannot be greater than 400."
+                return Err(Error::Validation("Image Height cannot be greater than 400."
                                                  .to_string()));
             } else if height < 0 {
-                return Err(Error::Validation("Image height cannot be a negative value."
+                return Err(Error::Validation("Image Height cannot be a negative value."
                                                  .to_string()));
             }
         }

--- a/src/item.rs
+++ b/src/item.rs
@@ -57,26 +57,26 @@ pub struct Item {
 }
 
 impl Item {
-    /// Get the optional title that exists under `Item`.
+    /// Return the title of this `Item`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ItemBuilder, Item};
+    /// use rss::ItemBuilder;
     ///
-    /// let title_string = "Making Music with Linux | LAS 408";
+    /// let title = "Making Music with Linux | LAS 408";
     ///
-    /// let item = ItemBuilder::new()
-    ///     .title(title_string.to_string())
+    /// let item = ItemBuilder::default()
+    ///     .title(title.to_string())
     ///     .finalize();
     ///
-    /// assert_eq!(Some(title_string), item.title());
+    /// assert_eq!(Some(title), item.title());
     /// ```
     ///
     /// ```
-    /// use rss::{ItemBuilder, Item};
+    /// use rss::ItemBuilder;
     ///
-    /// let item = ItemBuilder::new()
+    /// let item = ItemBuilder::default()
     ///     .title(None)
     ///     .finalize();
     ///
@@ -86,25 +86,26 @@ impl Item {
         self.title.as_ref().map(|s| s.as_str())
     }
 
-    /// Get the optional link that exists under `Item`.
+    /// Return the URL for this `Item`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ItemBuilder, Item};
+    /// use rss::ItemBuilder;
     ///
-    /// let link_string = "http://www.jupiterbroadcasting.com/";
-    /// let item = ItemBuilder::new()
-    ///     .link(link_string.to_string())
+    /// let link = "http://www.jupiterbroadcasting.com/";
+    ///
+    /// let item = ItemBuilder::default()
+    ///     .link(link.to_string())
     ///     .finalize();
     ///
-    /// assert_eq!(Some(link_string), item.link());
+    /// assert_eq!(Some(link), item.link());
     /// ```
     ///
     /// ```
-    /// use rss::{ItemBuilder, Item};
+    /// use rss::ItemBuilder;
     ///
-    /// let item = ItemBuilder::new()
+    /// let item = ItemBuilder::default()
     ///     .link(None)
     ///     .finalize();
     ///
@@ -114,26 +115,26 @@ impl Item {
         self.link.as_ref().map(|s| s.as_str())
     }
 
-    /// Get the optional description that exists under `Item`.
+    /// Return the description of this `Item`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ItemBuilder, Item};
+    /// use rss::ItemBuilder;
     ///
-    /// let description_string = "This is a test description";
+    /// let description = "This is a test description";
     ///
-    /// let item = ItemBuilder::new()
-    ///     .description(description_string.to_string())
+    /// let item = ItemBuilder::default()
+    ///     .description(description.to_string())
     ///     .finalize();
     ///
-    /// assert_eq!(Some(description_string), item.description());
+    /// assert_eq!(Some(description), item.description());
     /// ```
     ///
     /// ```
-    /// use rss::{ItemBuilder, Item};
+    /// use rss::ItemBuilder;
     ///
-    /// let item = ItemBuilder::new()
+    /// let item = ItemBuilder::default()
     ///     .description(None)
     ///     .finalize();
     ///
@@ -143,26 +144,26 @@ impl Item {
         self.description.as_ref().map(|s| s.as_str())
     }
 
-    /// Get the optional author that exists under `Item`.
+    /// Return the author of this `Item`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ItemBuilder, Item};
+    /// use rss::ItemBuilder;
     ///
-    /// let author_string = "Chris Fisher";
+    /// let author = "Chris Fisher";
     ///
-    /// let item = ItemBuilder::new()
-    ///     .author(author_string.to_string())
+    /// let item = ItemBuilder::default()
+    ///     .author(author.to_string())
     ///     .finalize();
     ///
-    /// assert_eq!(Some(author_string), item.author());
+    /// assert_eq!(Some(author), item.author());
     /// ```
     ///
     /// ```
-    /// use rss::{ItemBuilder, Item};
+    /// use rss::ItemBuilder;
     ///
-    /// let item = ItemBuilder::new()
+    /// let item = ItemBuilder::default()
     ///     .author(None)
     ///     .finalize();
     ///
@@ -172,58 +173,49 @@ impl Item {
         self.author.as_ref().map(|s| s.as_str())
     }
 
-    /// Get the categories that exists under `Item`.
+    /// Return the categories that this `Item` belongs to.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{CategoryBuilder, ItemBuilder, Item};
+    /// use rss::{CategoryBuilder, ItemBuilder};
     ///
-    /// let category_1 = CategoryBuilder::new()
-    ///     .domain(None)
+    /// let category = CategoryBuilder::default()
     ///     .name("Media")
     ///     .finalize();
     ///
-    /// let category_2 = CategoryBuilder::new()
-    ///     .domain("http://jupiterbroadcasting.com".to_string())
-    ///     .name("Podcast")
+    /// let categories = vec![category];
+    ///
+    /// let item = ItemBuilder::default()
+    ///     .categories(categories.clone())
     ///     .finalize();
     ///
-    /// let categories_vec = vec![category_1, category_2];
-    ///
-    /// let item = ItemBuilder::new()
-    ///     .categories(categories_vec.clone())
-    ///     .finalize();
-    ///
-    /// assert_eq!(categories_vec.clone().len(), item.categories().len());
+    /// assert_eq!(categories, item.categories());
     /// ```
     pub fn categories(&self) -> &[Category] {
         &self.categories
     }
 
-    /// Get the optional comments that exists under `Item`.
+    /// Return the URL for comments about this `Item`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ItemBuilder, Item};
+    /// use rss::ItemBuilder;
     ///
-    /// let comments_string = "http://example.com/comments";
+    /// let comments = "http://example.com/comments";
     ///
-    /// let item = ItemBuilder::new()
-    ///     .comments(comments_string.to_string())
+    /// let item = ItemBuilder::default()
+    ///     .comments(comments.to_string())
     ///     .finalize();
     ///
-    /// let comments_option =  item.comments();
-    /// assert!(comments_option.is_some());
-    ///
-    /// assert_eq!(Some(comments_string), item.comments());
+    /// assert_eq!(Some(comments), item.comments());
     /// ```
     ///
     /// ```
-    /// use rss::{ItemBuilder, Item};
+    /// use rss::ItemBuilder;
     ///
-    /// let item = ItemBuilder::new()
+    /// let item = ItemBuilder::default()
     ///     .comments(None)
     ///     .finalize();
     ///
@@ -233,23 +225,23 @@ impl Item {
         self.comments.as_ref().map(|s| s.as_str())
     }
 
-    /// Get the optional enclosure that exists under `Item`.
+    /// Return the enclosure information for this `Item`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{EnclosureBuilder, ItemBuilder, Item};
+    /// use rss::{EnclosureBuilder, ItemBuilder};
     ///
-    /// let url = "http://www.podtrac.com/pts/redirect.ogg/".to_string()
-    /// + "traffic.libsyn.com/jnite/linuxactionshowep408.ogg";
+    /// let url = "http://www.podtrac.com/pts/redirect.ogg/traffic.libsyn.com/jnite/\
+    ///     linuxactionshowep408.ogg";
     ///
-    /// let enclosure = EnclosureBuilder::new()
-    ///     .url(url.as_ref())
+    /// let enclosure = EnclosureBuilder::default()
+    ///     .url(url)
     ///     .length(70772893)
     ///     .mime_type("audio/ogg")
     ///     .finalize();
     ///
-    /// let item = ItemBuilder::new()
+    /// let item = ItemBuilder::default()
     ///     .enclosure(enclosure)
     ///     .finalize();
     ///
@@ -257,9 +249,9 @@ impl Item {
     /// ```
     ///
     /// ```
-    /// use rss::{ItemBuilder, Item};
+    /// use rss::ItemBuilder;
     ///
-    /// let item = ItemBuilder::new()
+    /// let item = ItemBuilder::default()
     ///     .enclosure(None)
     ///     .finalize();
     ///
@@ -269,28 +261,28 @@ impl Item {
         self.enclosure.as_ref()
     }
 
-    /// Get the optional guid that exists under `Item`.
+    /// Return the GUID for this `Item`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{GuidBuilder, ItemBuilder, Item};
+    /// use rss::{GuidBuilder, ItemBuilder};
     ///
-    /// let guid = GuidBuilder::new()
+    /// let guid = GuidBuilder::default()
     ///     .value("9DE46946-2F90-4D5D-9047-7E9165C16E7C")
-    ///     .is_permalink(None)
     ///     .finalize();
     ///
-    /// let item = ItemBuilder::new()
+    /// let item = ItemBuilder::default()
     ///     .guid(guid)
     ///     .finalize();
+    ///
     /// assert!(item.guid().is_some())
     /// ```
     ///
     /// ```
-    /// use rss::{ItemBuilder, Item};
+    /// use rss::ItemBuilder;
     ///
-    /// let item = ItemBuilder::new()
+    /// let item = ItemBuilder::default()
     ///     .guid(None)
     ///     .finalize();
     ///
@@ -300,29 +292,26 @@ impl Item {
         self.guid.as_ref()
     }
 
-    /// Get the optional pub date that exists under `Item`.
+    /// Return the publication date for this `Item`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ItemBuilder, Item};
+    /// use rss::ItemBuilder;
     ///
     /// let pub_date = "Sun, 13 Mar 2016 20:02:02 -0700";
     ///
-    /// let item = ItemBuilder::new()
+    /// let item = ItemBuilder::default()
     ///     .pub_date(pub_date.to_string())
     ///     .finalize();
     ///
-    /// let local = item.pub_date();
-    /// assert!(local.is_some());
-    ///
-    /// assert_eq!(pub_date.to_string(), local.unwrap());
+    /// assert_eq!(Some(pub_date), item.pub_date());
     /// ```
     ///
     /// ```
-    /// use rss::{ItemBuilder, Item};
+    /// use rss::ItemBuilder;
     ///
-    /// let item = ItemBuilder::new()
+    /// let item = ItemBuilder::default()
     ///     .pub_date(None)
     ///     .finalize();
     ///
@@ -332,18 +321,18 @@ impl Item {
         self.pub_date.as_ref().map(|s| s.as_str())
     }
 
-    /// Get the optional source that exists under `Item`.
+    /// Return the source URL for this `Item`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ItemBuilder, Item, SourceBuilder};
+    /// use rss::{ItemBuilder, SourceBuilder};
     ///
-    /// let source = SourceBuilder::new()
+    /// let source = SourceBuilder::default()
     ///     .url("http://www.tomalak.org/links2.xml")
     ///     .finalize();
     ///
-    /// let item = ItemBuilder::new()
+    /// let item = ItemBuilder::default()
     ///     .source(source)
     ///     .finalize();
     ///
@@ -351,9 +340,9 @@ impl Item {
     /// ```
     ///
     /// ```
-    /// use rss::{ItemBuilder, Item};
+    /// use rss::ItemBuilder;
     ///
-    /// let item = ItemBuilder::new()
+    /// let item = ItemBuilder::default()
     ///     .source(None)
     ///     .finalize();
     ///
@@ -363,39 +352,34 @@ impl Item {
         self.source.as_ref()
     }
 
-    /// Get the optional `ITunesItemExtension` under `Item`.
+    /// Return the content of this `Item`.
+    pub fn content(&self) -> Option<&str> {
+        self.content.as_ref().map(|s| s.as_str())
+    }
+
+    /// Return the `ITunesItemExtension` for this `Item`.
+    ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{ItemBuilder, Item};
+    /// use rss::ItemBuilder;
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let itunes_item = ITunesItemExtensionBuilder::new()
+    /// let itunes_item = ITunesItemExtensionBuilder::default()
     ///     .author("author".to_string())
-    ///     .block("block".to_string())
-    ///     .image("image".to_string())
-    ///     .duration("duration".to_string())
-    ///     .explicit("explicit".to_string())
-    ///     .closed_captioned("closed_captioned".to_string())
-    ///     .order("order".to_string())
-    ///     .subtitle("subtitle".to_string())
-    ///     .summary("summary".to_string())
-    ///     .keywords("keywords".to_string())
     ///     .finalize();
     ///
-    /// let item = ItemBuilder::new()
-    ///     .title("Making Music with Linux | LAS 408".to_string())
+    /// let item = ItemBuilder::default()
     ///     .itunes_ext(itunes_item)
     ///     .finalize();
     ///
-    /// assert!(item.itunes_ext().is_some());
+    /// assert!(item.itunes_ext().is_some())
     /// ```
     ///
     /// ```
-    /// use rss::{ItemBuilder, Item};
+    /// use rss::ItemBuilder;
     ///
-    /// let item = ItemBuilder::new()
-    ///     .title("Making Music with Linux | LAS 408".to_string())
+    /// let item = ItemBuilder::default()
     ///     .itunes_ext(None)
     ///     .finalize();
     ///
@@ -405,19 +389,14 @@ impl Item {
         self.itunes_ext.as_ref()
     }
 
-    /// Get the optional `DublinCoreExtension` under `Item`.
+    /// Return the `DublinCoreExtension` for this `Item`.
     pub fn dublin_core_ext(&self) -> Option<&DublinCoreExtension> {
         self.dublin_core_ext.as_ref()
     }
 
-    /// Get the `ExtensionMap` under `Item`.
+    /// Return the extensions for this `Item`.
     pub fn extensions(&self) -> &ExtensionMap {
         &self.extensions
-    }
-
-    /// Get the optional content under `Item`.
-    pub fn content(&self) -> Option<&str> {
-        self.content.as_ref().map(|s| s.as_str())
     }
 }
 
@@ -561,7 +540,7 @@ impl ToXml for Item {
     }
 }
 
-/// This `ItemBuilder` struct creates the `Item`.
+/// A builder used to create an `Item`.
 #[derive(Debug, Clone, Default)]
 pub struct ItemBuilder {
     title: Option<String>,
@@ -581,120 +560,112 @@ pub struct ItemBuilder {
 }
 
 impl ItemBuilder {
-    /// Construct a new `ItemBuilder` and return default values.
+    /// Set the title of the `Item`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ItemBuilder;
     ///
-    /// let item_builder = ItemBuilder::new();
-    /// ```
-    pub fn new() -> ItemBuilder {
-        ItemBuilder::default()
-    }
-
-
-    /// Set the optional title that exists under `Item`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rss::ItemBuilder;
-    ///
-    /// let item_builder = ItemBuilder::new()
+    /// let builder = ItemBuilder::default()
     ///     .title("Making Music with Linux | LAS 408".to_string());
     /// ```
-    pub fn title<V: Into<Option<String>>>(mut self, title: V) -> ItemBuilder {
+    pub fn title<V>(mut self, title: V) -> ItemBuilder
+        where V: Into<Option<String>>
+    {
         self.title = title.into();
         self
     }
 
-
-    /// Set the optional link that exists under `Item`.
+    /// Set the URL for the `Item`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ItemBuilder;
     ///
-    /// let item_builder = ItemBuilder::new()
+    /// let builder = ItemBuilder::default()
     ///     .link("http://www.jupiterbroadcasting.com".to_string());
     /// ```
-    pub fn link<V: Into<Option<String>>>(mut self, link: V) -> ItemBuilder {
+    pub fn link<V>(mut self, link: V) -> ItemBuilder
+        where V: Into<Option<String>>
+    {
         self.link = link.into();
         self
     }
 
-
-    /// Set the optional description that exists under `Item`.
+    /// Set the description of this `Item`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ItemBuilder;
     ///
-    /// let item_builder = ItemBuilder::new()
+    /// let builder = ItemBuilder::default()
     ///     .description("This is a test description".to_string());
     /// ```
-    pub fn description<V: Into<Option<String>>>(mut self, description: V) -> ItemBuilder {
+    pub fn description<V>(mut self, description: V) -> ItemBuilder
+        where V: Into<Option<String>>
+    {
         self.description = description.into();
         self
     }
 
-
-    /// Set the optional author that exists under `Item`.
+    /// Set the author of the `Item`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ItemBuilder;
     ///
-    /// let item_builder = ItemBuilder::new()
+    /// let builder = ItemBuilder::default()
     ///     .author("Chris Fisher".to_string());
     /// ```
-    pub fn author<V: Into<Option<String>>>(mut self, author: V) -> ItemBuilder {
+    pub fn author<V>(mut self, author: V) -> ItemBuilder
+        where V: Into<Option<String>>
+    {
         self.author = author.into();
         self
     }
 
-
-    /// Set the optional categories that exists under `Item`.
+    /// Set the categories that the `Item` belongs to.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::{CategoryBuilder, ItemBuilder};
     ///
-    /// let category = CategoryBuilder::new()
+    /// let category = CategoryBuilder::default()
     ///     .finalize();
     ///
-    /// let item_builder = ItemBuilder::new()
+    /// let builder = ItemBuilder::default()
     ///     .categories(vec![category]);
     /// ```
-    pub fn categories<V: Into<Vec<Category>>>(mut self, categories: V) -> ItemBuilder {
+    pub fn categories<V>(mut self, categories: V) -> ItemBuilder
+        where V: Into<Vec<Category>>
+    {
         self.categories = categories.into();
         self
     }
 
-
-    /// Set the optional comments that exists under `Item`.
+    /// Set the URL for comments about the `Item`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ItemBuilder;
     ///
-    /// let item_builder = ItemBuilder::new()
+    /// let builder = ItemBuilder::default()
     ///     .comments("A comment".to_string());
     /// ```
-    pub fn comments<V: Into<Option<String>>>(mut self, comments: V) -> ItemBuilder {
+    pub fn comments<V>(mut self, comments: V) -> ItemBuilder
+        where V: Into<Option<String>>
+    {
         self.comments = comments.into();
         self
     }
 
-
-    /// Set the optional enclosure that exists under `Item`.
+    /// Set the enclosure information for the `Item`.
     ///
     /// # Examples
     ///
@@ -704,76 +675,80 @@ impl ItemBuilder {
     /// let url = "http://www.podtrac.com/pts/redirect.ogg/traffic.libsyn.com/jnite/\
     ///     linuxactionshowep408.ogg";
     ///
-    /// let enclosure = EnclosureBuilder::new()
+    /// let enclosure = EnclosureBuilder::default()
     ///     .url(url)
     ///     .mime_type("audio/ogg")
     ///     .finalize();
     ///
-    /// let item_builder = ItemBuilder::new()
+    /// let builder = ItemBuilder::default()
     ///     .enclosure(enclosure);
     /// ```
-    pub fn enclosure<V: Into<Option<Enclosure>>>(mut self, enclosure: V) -> ItemBuilder {
+    pub fn enclosure<V>(mut self, enclosure: V) -> ItemBuilder
+        where V: Into<Option<Enclosure>>
+    {
         self.enclosure = enclosure.into();
         self
     }
 
-
-    /// Set the optional guid that exists under `Item`.
+    /// Set the GUID for the `Item`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::{GuidBuilder, ItemBuilder};
     ///
-    /// let guid = GuidBuilder::new()
+    /// let guid = GuidBuilder::default()
     ///     .finalize();
     ///
-    /// let item_builder = ItemBuilder::new()
+    /// let builder = ItemBuilder::default()
     ///     .guid(guid);
     /// ```
-    pub fn guid<V: Into<Option<Guid>>>(mut self, guid: V) -> ItemBuilder {
+    pub fn guid<V>(mut self, guid: V) -> ItemBuilder
+        where V: Into<Option<Guid>>
+    {
         self.guid = guid.into();
         self
     }
 
-
-    /// Set the optional pub date that exists under `Item`.
+    /// Set the publication date for the `Item`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ItemBuilder;
     ///
-    /// let item_builder = ItemBuilder::new()
+    /// let builder = ItemBuilder::default()
     ///     .pub_date("Sun, 13 Mar 2016 20:02:02-0700".to_string());
     /// ```
-    pub fn pub_date<V: Into<Option<String>>>(mut self, pub_date: V) -> ItemBuilder {
+    pub fn pub_date<V>(mut self, pub_date: V) -> ItemBuilder
+        where V: Into<Option<String>>
+    {
         self.pub_date = pub_date.into();
         self
     }
 
-
-    /// Set the optional source that exists under `Item`.
+    /// Set the source URL for the `Item`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::{ItemBuilder, SourceBuilder};
     ///
-    /// let source = SourceBuilder::new()
+    /// let source = SourceBuilder::default()
     ///     .url("http://www.tomalak.org/links2.xml")
     ///     .finalize();
     ///
-    /// let item_builder = ItemBuilder::new()
+    /// let builder = ItemBuilder::default()
     ///     .source(source);
     /// ```
-    pub fn source<V: Into<Option<Source>>>(mut self, source: V) -> ItemBuilder {
+    pub fn source<V>(mut self, source: V) -> ItemBuilder
+        where V: Into<Option<Source>>
+    {
         self.source = source.into();
         self
     }
 
-
-    /// Set the optional itunes_ext that exists under `Item`.
+    /// Set the `ITunesItemExtension` for the `Item`.
     ///
     /// # Examples
     ///
@@ -781,20 +756,11 @@ impl ItemBuilder {
     /// use rss::ItemBuilder;
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let itunes_item = ITunesItemExtensionBuilder::new()
+    /// let itunes_item = ITunesItemExtensionBuilder::default()
     ///     .author("author".to_string())
-    ///     .block("block".to_string())
-    ///     .image("image".to_string())
-    ///     .duration("duration".to_string())
-    ///     .explicit("explicit".to_string())
-    ///     .closed_captioned("closed_captioned".to_string())
-    ///     .order("order".to_string())
-    ///     .subtitle("subtitle".to_string())
-    ///     .summary("summary".to_string())
-    ///     .keywords("keywords".to_string())
     ///     .finalize();
     ///
-    /// let item_builder = ItemBuilder::new()
+    /// let builder = ItemBuilder::default()
     ///     .itunes_ext(itunes_item);
     /// ```
     pub fn itunes_ext<V>(mut self, itunes_ext: V) -> ItemBuilder
@@ -804,7 +770,7 @@ impl ItemBuilder {
         self
     }
 
-    /// Set the optional dublin_core_ext that exists under `Item`.
+    /// Set the `DublinCoreExtension` for the `Item`.
     pub fn dublin_core_ext<V>(mut self, dublin_core_ext: V) -> ItemBuilder
         where V: Into<Option<DublinCoreExtension>>
     {
@@ -812,39 +778,34 @@ impl ItemBuilder {
         self
     }
 
-    /// Set the extensions that exists under `Item`.
-    pub fn extensions<V: Into<ExtensionMap>>(mut self, extensions: V) -> ItemBuilder {
+    /// Set the extensions for the `Item`.
+    pub fn extensions<V>(mut self, extensions: V) -> ItemBuilder
+        where V: Into<ExtensionMap>
+    {
         self.extensions = extensions.into();
         self
     }
 
-    /// Set the optional content that exists under `Item`.
-    pub fn content<V: Into<Option<String>>>(mut self, content: V) -> ItemBuilder {
+    /// Set the content of the `Item`.
+    pub fn content<V>(mut self, content: V) -> ItemBuilder
+        where V: Into<Option<String>>
+    {
         self.content = content.into();
         self
     }
 
-    /// Validate the contents of `Item`.
+    /// Validate the contents of this `ItemBuilder`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ItemBuilder;
     ///
-    /// let item = ItemBuilder::new()
+    /// let item = ItemBuilder::default()
     ///     .title("Making Music with Linux | LAS 408".to_string())
     ///     .link("http://www.jupiterbroadcasting.com".to_string())
-    ///     .description(None)
-    ///     .author(None)
-    ///     .categories(Vec::new())
-    ///     .comments(None)
-    ///     .enclosure(None)
-    ///     .guid(None)
-    ///     .pub_date(None)
-    ///     .source(None)
     ///     .validate()
-    ///     .unwrap()
-    ///     .finalize();
+    ///     .unwrap();
     /// ```
     pub fn validate(self) -> Result<ItemBuilder, Error> {
         if let Some(ref link) = self.link {
@@ -863,24 +824,16 @@ impl ItemBuilder {
     }
 
 
-    /// Construct the `Item` from the `ItemBuilder`.
+    /// Construct the `Item` from this `ItemBuilder`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::ItemBuilder;
     ///
-    /// let item = ItemBuilder::new()
+    /// let item = ItemBuilder::default()
     ///     .title("Making Music with Linux | LAS 408".to_string())
     ///     .link("http://www.jupiterbroadcasting.com".to_string())
-    ///     .description(None)
-    ///     .author(None)
-    ///     .categories(Vec::new())
-    ///     .comments(None)
-    ///     .enclosure(None)
-    ///     .guid(None)
-    ///     .pub_date(None)
-    ///     .source(None)
     ///     .finalize();
     /// ```
     pub fn finalize(self) -> Item {

--- a/src/item.rs
+++ b/src/item.rs
@@ -67,7 +67,7 @@ impl Item {
     /// let title_string = "Making Music with Linux | LAS 408";
     ///
     /// let item = ItemBuilder::new()
-    ///     .title(Some(title_string.to_string()))
+    ///     .title(title_string.to_string())
     ///     .finalize();
     ///
     /// assert_eq!(Some(title_string), item.title());
@@ -95,7 +95,7 @@ impl Item {
     ///
     /// let link_string = "http://www.jupiterbroadcasting.com/";
     /// let item = ItemBuilder::new()
-    ///     .link(Some(link_string.to_string()))
+    ///     .link(link_string.to_string())
     ///     .finalize();
     ///
     /// assert_eq!(Some(link_string), item.link());
@@ -124,7 +124,7 @@ impl Item {
     /// let description_string = "This is a test description";
     ///
     /// let item = ItemBuilder::new()
-    ///     .description(Some(description_string.to_string()))
+    ///     .description(description_string.to_string())
     ///     .finalize();
     ///
     /// assert_eq!(Some(description_string), item.description());
@@ -153,7 +153,7 @@ impl Item {
     /// let author_string = "Chris Fisher";
     ///
     /// let item = ItemBuilder::new()
-    ///     .author(Some(author_string.to_string()))
+    ///     .author(author_string.to_string())
     ///     .finalize();
     ///
     /// assert_eq!(Some(author_string), item.author());
@@ -185,7 +185,7 @@ impl Item {
     ///     .finalize();
     ///
     /// let category_2 = CategoryBuilder::new()
-    ///     .domain(Some("http://jupiterbroadcasting.com".to_string()))
+    ///     .domain("http://jupiterbroadcasting.com".to_string())
     ///     .name("Podcast")
     ///     .finalize();
     ///
@@ -211,7 +211,7 @@ impl Item {
     /// let comments_string = "http://example.com/comments";
     ///
     /// let item = ItemBuilder::new()
-    ///     .comments(Some(comments_string.to_string()))
+    ///     .comments(comments_string.to_string())
     ///     .finalize();
     ///
     /// let comments_option =  item.comments();
@@ -250,7 +250,7 @@ impl Item {
     ///     .finalize();
     ///
     /// let item = ItemBuilder::new()
-    ///     .enclosure(Some(enclosure))
+    ///     .enclosure(enclosure)
     ///     .finalize();
     ///
     /// assert!(item.enclosure().is_some());
@@ -282,7 +282,7 @@ impl Item {
     ///     .finalize();
     ///
     /// let item = ItemBuilder::new()
-    ///     .guid(Some(guid))
+    ///     .guid(guid)
     ///     .finalize();
     /// assert!(item.guid().is_some())
     /// ```
@@ -310,7 +310,7 @@ impl Item {
     /// let pub_date = "Sun, 13 Mar 2016 20:02:02 -0700";
     ///
     /// let item = ItemBuilder::new()
-    ///     .pub_date(Some(pub_date.to_string()))
+    ///     .pub_date(pub_date.to_string())
     ///     .finalize();
     ///
     /// let local = item.pub_date();
@@ -344,7 +344,7 @@ impl Item {
     ///     .finalize();
     ///
     /// let item = ItemBuilder::new()
-    ///     .source(Some(source))
+    ///     .source(source)
     ///     .finalize();
     ///
     /// assert!(item.source().is_some())
@@ -371,21 +371,21 @@ impl Item {
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
     /// let itunes_item = ITunesItemExtensionBuilder::new()
-    ///     .author(Some("author".to_string()))
-    ///     .block(Some("block".to_string()))
-    ///     .image(Some("image".to_string()))
-    ///     .duration(Some("duration".to_string()))
-    ///     .explicit(Some("explicit".to_string()))
-    ///     .closed_captioned(Some("closed_captioned".to_string()))
-    ///     .order(Some("order".to_string()))
-    ///     .subtitle(Some("subtitle".to_string()))
-    ///     .summary(Some("summary".to_string()))
-    ///     .keywords(Some("keywords".to_string()))
+    ///     .author("author".to_string())
+    ///     .block("block".to_string())
+    ///     .image("image".to_string())
+    ///     .duration("duration".to_string())
+    ///     .explicit("explicit".to_string())
+    ///     .closed_captioned("closed_captioned".to_string())
+    ///     .order("order".to_string())
+    ///     .subtitle("subtitle".to_string())
+    ///     .summary("summary".to_string())
+    ///     .keywords("keywords".to_string())
     ///     .finalize();
     ///
     /// let item = ItemBuilder::new()
-    ///     .title(Some("Making Music with Linux | LAS 408".to_string()))
-    ///     .itunes_ext(Some(itunes_item))
+    ///     .title("Making Music with Linux | LAS 408".to_string())
+    ///     .itunes_ext(itunes_item)
     ///     .finalize();
     ///
     /// assert!(item.itunes_ext().is_some());
@@ -395,7 +395,7 @@ impl Item {
     /// use rss::{ItemBuilder, Item};
     ///
     /// let item = ItemBuilder::new()
-    ///     .title(Some("Making Music with Linux | LAS 408".to_string()))
+    ///     .title("Making Music with Linux | LAS 408".to_string())
     ///     .itunes_ext(None)
     ///     .finalize();
     ///
@@ -603,10 +603,10 @@ impl ItemBuilder {
     /// use rss::ItemBuilder;
     ///
     /// let item_builder = ItemBuilder::new()
-    ///     .title(Some("Making Music with Linux | LAS 408".to_string()));
+    ///     .title("Making Music with Linux | LAS 408".to_string());
     /// ```
-    pub fn title(mut self, title: Option<String>) -> ItemBuilder {
-        self.title = title;
+    pub fn title<V: Into<Option<String>>>(mut self, title: V) -> ItemBuilder {
+        self.title = title.into();
         self
     }
 
@@ -619,10 +619,10 @@ impl ItemBuilder {
     /// use rss::ItemBuilder;
     ///
     /// let item_builder = ItemBuilder::new()
-    ///     .link(Some("http://www.jupiterbroadcasting.com".to_string()));
+    ///     .link("http://www.jupiterbroadcasting.com".to_string());
     /// ```
-    pub fn link(mut self, link: Option<String>) -> ItemBuilder {
-        self.link = link;
+    pub fn link<V: Into<Option<String>>>(mut self, link: V) -> ItemBuilder {
+        self.link = link.into();
         self
     }
 
@@ -635,10 +635,10 @@ impl ItemBuilder {
     /// use rss::ItemBuilder;
     ///
     /// let item_builder = ItemBuilder::new()
-    ///     .description(Some("This is a test description".to_string()));
+    ///     .description("This is a test description".to_string());
     /// ```
-    pub fn description(mut self, description: Option<String>) -> ItemBuilder {
-        self.description = description;
+    pub fn description<V: Into<Option<String>>>(mut self, description: V) -> ItemBuilder {
+        self.description = description.into();
         self
     }
 
@@ -651,10 +651,10 @@ impl ItemBuilder {
     /// use rss::ItemBuilder;
     ///
     /// let item_builder = ItemBuilder::new()
-    ///     .author(Some("Chris Fisher".to_string()));
+    ///     .author("Chris Fisher".to_string());
     /// ```
-    pub fn author(mut self, author: Option<String>) -> ItemBuilder {
-        self.author = author;
+    pub fn author<V: Into<Option<String>>>(mut self, author: V) -> ItemBuilder {
+        self.author = author.into();
         self
     }
 
@@ -672,8 +672,8 @@ impl ItemBuilder {
     /// let item_builder = ItemBuilder::new()
     ///     .categories(vec![category]);
     /// ```
-    pub fn categories(mut self, categories: Vec<Category>) -> ItemBuilder {
-        self.categories = categories;
+    pub fn categories<V: Into<Vec<Category>>>(mut self, categories: V) -> ItemBuilder {
+        self.categories = categories.into();
         self
     }
 
@@ -686,10 +686,10 @@ impl ItemBuilder {
     /// use rss::ItemBuilder;
     ///
     /// let item_builder = ItemBuilder::new()
-    ///     .comments(Some("A comment".to_string()));
+    ///     .comments("A comment".to_string());
     /// ```
-    pub fn comments(mut self, comments: Option<String>) -> ItemBuilder {
-        self.comments = comments;
+    pub fn comments<V: Into<Option<String>>>(mut self, comments: V) -> ItemBuilder {
+        self.comments = comments.into();
         self
     }
 
@@ -710,10 +710,10 @@ impl ItemBuilder {
     ///     .finalize();
     ///
     /// let item_builder = ItemBuilder::new()
-    ///     .enclosure(Some(enclosure));
+    ///     .enclosure(enclosure);
     /// ```
-    pub fn enclosure(mut self, enclosure: Option<Enclosure>) -> ItemBuilder {
-        self.enclosure = enclosure;
+    pub fn enclosure<V: Into<Option<Enclosure>>>(mut self, enclosure: V) -> ItemBuilder {
+        self.enclosure = enclosure.into();
         self
     }
 
@@ -729,10 +729,10 @@ impl ItemBuilder {
     ///     .finalize();
     ///
     /// let item_builder = ItemBuilder::new()
-    ///     .guid(Some(guid));
+    ///     .guid(guid);
     /// ```
-    pub fn guid(mut self, guid: Option<Guid>) -> ItemBuilder {
-        self.guid = guid;
+    pub fn guid<V: Into<Option<Guid>>>(mut self, guid: V) -> ItemBuilder {
+        self.guid = guid.into();
         self
     }
 
@@ -745,10 +745,10 @@ impl ItemBuilder {
     /// use rss::ItemBuilder;
     ///
     /// let item_builder = ItemBuilder::new()
-    ///     .pub_date(Some("Sun, 13 Mar 2016 20:02:02-0700".to_string()));
+    ///     .pub_date("Sun, 13 Mar 2016 20:02:02-0700".to_string());
     /// ```
-    pub fn pub_date(mut self, pub_date: Option<String>) -> ItemBuilder {
-        self.pub_date = pub_date;
+    pub fn pub_date<V: Into<Option<String>>>(mut self, pub_date: V) -> ItemBuilder {
+        self.pub_date = pub_date.into();
         self
     }
 
@@ -765,10 +765,10 @@ impl ItemBuilder {
     ///     .finalize();
     ///
     /// let item_builder = ItemBuilder::new()
-    ///     .source(Some(source));
+    ///     .source(source);
     /// ```
-    pub fn source(mut self, source: Option<Source>) -> ItemBuilder {
-        self.source = source;
+    pub fn source<V: Into<Option<Source>>>(mut self, source: V) -> ItemBuilder {
+        self.source = source.into();
         self
     }
 
@@ -782,41 +782,45 @@ impl ItemBuilder {
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
     /// let itunes_item = ITunesItemExtensionBuilder::new()
-    ///     .author(Some("author".to_string()))
-    ///     .block(Some("block".to_string()))
-    ///     .image(Some("image".to_string()))
-    ///     .duration(Some("duration".to_string()))
-    ///     .explicit(Some("explicit".to_string()))
-    ///     .closed_captioned(Some("closed_captioned".to_string()))
-    ///     .order(Some("order".to_string()))
-    ///     .subtitle(Some("subtitle".to_string()))
-    ///     .summary(Some("summary".to_string()))
-    ///     .keywords(Some("keywords".to_string()))
+    ///     .author("author".to_string())
+    ///     .block("block".to_string())
+    ///     .image("image".to_string())
+    ///     .duration("duration".to_string())
+    ///     .explicit("explicit".to_string())
+    ///     .closed_captioned("closed_captioned".to_string())
+    ///     .order("order".to_string())
+    ///     .subtitle("subtitle".to_string())
+    ///     .summary("summary".to_string())
+    ///     .keywords("keywords".to_string())
     ///     .finalize();
     ///
     /// let item_builder = ItemBuilder::new()
-    ///     .itunes_ext(Some(itunes_item));
+    ///     .itunes_ext(itunes_item);
     /// ```
-    pub fn itunes_ext(mut self, itunes_ext: Option<ITunesItemExtension>) -> ItemBuilder {
-        self.itunes_ext = itunes_ext;
+    pub fn itunes_ext<V>(mut self, itunes_ext: V) -> ItemBuilder
+        where V: Into<Option<ITunesItemExtension>>
+    {
+        self.itunes_ext = itunes_ext.into();
         self
     }
 
     /// Set the optional dublin_core_ext that exists under `Item`.
-    pub fn dublin_core_ext(mut self, dublin_core_ext: Option<DublinCoreExtension>) -> ItemBuilder {
-        self.dublin_core_ext = dublin_core_ext;
+    pub fn dublin_core_ext<V>(mut self, dublin_core_ext: V) -> ItemBuilder
+        where V: Into<Option<DublinCoreExtension>>
+    {
+        self.dublin_core_ext = dublin_core_ext.into();
         self
     }
 
     /// Set the extensions that exists under `Item`.
-    pub fn extensions(mut self, extensions: ExtensionMap) -> ItemBuilder {
-        self.extensions = extensions;
+    pub fn extensions<V: Into<ExtensionMap>>(mut self, extensions: V) -> ItemBuilder {
+        self.extensions = extensions.into();
         self
     }
 
     /// Set the optional content that exists under `Item`.
-    pub fn content(mut self, content: Option<String>) -> ItemBuilder {
-        self.content = content;
+    pub fn content<V: Into<Option<String>>>(mut self, content: V) -> ItemBuilder {
+        self.content = content.into();
         self
     }
 
@@ -828,8 +832,8 @@ impl ItemBuilder {
     /// use rss::ItemBuilder;
     ///
     /// let item = ItemBuilder::new()
-    ///     .title(Some("Making Music with Linux | LAS 408".to_string()))
-    ///     .link(Some("http://www.jupiterbroadcasting.com".to_string()))
+    ///     .title("Making Music with Linux | LAS 408".to_string())
+    ///     .link("http://www.jupiterbroadcasting.com".to_string())
     ///     .description(None)
     ///     .author(None)
     ///     .categories(Vec::new())
@@ -867,8 +871,8 @@ impl ItemBuilder {
     /// use rss::ItemBuilder;
     ///
     /// let item = ItemBuilder::new()
-    ///     .title(Some("Making Music with Linux | LAS 408".to_string()))
-    ///     .link(Some("http://www.jupiterbroadcasting.com".to_string()))
+    ///     .title("Making Music with Linux | LAS 408".to_string())
+    ///     .link("http://www.jupiterbroadcasting.com".to_string())
     ///     .description(None)
     ///     .author(None)
     ///     .categories(Vec::new())

--- a/src/item.rs
+++ b/src/item.rs
@@ -882,11 +882,6 @@ impl ItemBuilder {
     ///     .finalize().unwrap();
     /// ```
     pub fn validate(self) -> Result<ItemBuilder, Error> {
-        if self.title.is_none() && self.description.is_none() {
-            return Err(Error::Validation("Either Title or Description must have a value."
-                                             .to_string()));
-        }
-
         if let Some(ref link) = self.link {
             Url::parse(link.as_str())?;
         }

--- a/src/item.rs
+++ b/src/item.rs
@@ -68,8 +68,7 @@ impl Item {
     ///
     /// let item = ItemBuilder::new()
     ///     .title(Some(title_string.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(title_string), item.title());
     /// ```
@@ -79,8 +78,7 @@ impl Item {
     ///
     /// let item = ItemBuilder::new()
     ///     .title(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(item.title().is_none());
     /// ```
@@ -98,8 +96,7 @@ impl Item {
     /// let link_string = "http://www.jupiterbroadcasting.com/";
     /// let item = ItemBuilder::new()
     ///     .link(Some(link_string.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(link_string), item.link());
     /// ```
@@ -109,8 +106,7 @@ impl Item {
     ///
     /// let item = ItemBuilder::new()
     ///     .link(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(item.link().is_none());
     /// ```
@@ -129,8 +125,7 @@ impl Item {
     ///
     /// let item = ItemBuilder::new()
     ///     .description(Some(description_string.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(description_string), item.description());
     /// ```
@@ -140,8 +135,7 @@ impl Item {
     ///
     /// let item = ItemBuilder::new()
     ///     .description(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(item.description().is_none());
     /// ```
@@ -160,8 +154,7 @@ impl Item {
     ///
     /// let item = ItemBuilder::new()
     ///     .author(Some(author_string.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(author_string), item.author());
     /// ```
@@ -171,8 +164,7 @@ impl Item {
     ///
     /// let item = ItemBuilder::new()
     ///     .author(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(item.author().is_none());
     /// ```
@@ -190,21 +182,18 @@ impl Item {
     /// let category_1 = CategoryBuilder::new()
     ///     .domain(None)
     ///     .name("Media")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let category_2 = CategoryBuilder::new()
     ///     .domain(Some("http://jupiterbroadcasting.com".to_string()))
     ///     .name("Podcast")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let categories_vec = vec![category_1, category_2];
     ///
     /// let item = ItemBuilder::new()
     ///     .categories(categories_vec.clone())
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(categories_vec.clone().len(), item.categories().len());
     /// ```
@@ -223,8 +212,7 @@ impl Item {
     ///
     /// let item = ItemBuilder::new()
     ///     .comments(Some(comments_string.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let comments_option =  item.comments();
     /// assert!(comments_option.is_some());
@@ -237,8 +225,7 @@ impl Item {
     ///
     /// let item = ItemBuilder::new()
     ///     .comments(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(item.comments().is_none());
     /// ```
@@ -260,13 +247,11 @@ impl Item {
     ///     .url(url.as_ref())
     ///     .length(70772893)
     ///     .mime_type("audio/ogg")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let item = ItemBuilder::new()
     ///     .enclosure(Some(enclosure))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(item.enclosure().is_some());
     /// ```
@@ -276,8 +261,7 @@ impl Item {
     ///
     /// let item = ItemBuilder::new()
     ///     .enclosure(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(item.enclosure().is_none());
     /// ```
@@ -295,13 +279,11 @@ impl Item {
     /// let guid = GuidBuilder::new()
     ///     .value("9DE46946-2F90-4D5D-9047-7E9165C16E7C")
     ///     .is_permalink(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let item = ItemBuilder::new()
     ///     .guid(Some(guid))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     /// assert!(item.guid().is_some())
     /// ```
     ///
@@ -310,8 +292,7 @@ impl Item {
     ///
     /// let item = ItemBuilder::new()
     ///     .guid(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(item.guid().is_none());
     /// ```
@@ -330,8 +311,7 @@ impl Item {
     ///
     /// let item = ItemBuilder::new()
     ///     .pub_date(Some(pub_date.to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let local = item.pub_date();
     /// assert!(local.is_some());
@@ -344,8 +324,7 @@ impl Item {
     ///
     /// let item = ItemBuilder::new()
     ///     .pub_date(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(item.pub_date().is_none());
     /// ```
@@ -362,13 +341,11 @@ impl Item {
     ///
     /// let source = SourceBuilder::new()
     ///     .url("http://www.tomalak.org/links2.xml")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let item = ItemBuilder::new()
     ///     .source(Some(source))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(item.source().is_some())
     /// ```
@@ -378,8 +355,7 @@ impl Item {
     ///
     /// let item = ItemBuilder::new()
     ///     .source(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(item.source().is_none());
     /// ```
@@ -405,14 +381,12 @@ impl Item {
     ///     .subtitle(Some("subtitle".to_string()))
     ///     .summary(Some("summary".to_string()))
     ///     .keywords(Some("keywords".to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let item = ItemBuilder::new()
     ///     .title(Some("Making Music with Linux | LAS 408".to_string()))
     ///     .itunes_ext(Some(itunes_item))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(item.itunes_ext().is_some());
     /// ```
@@ -423,8 +397,7 @@ impl Item {
     /// let item = ItemBuilder::new()
     ///     .title(Some("Making Music with Linux | LAS 408".to_string()))
     ///     .itunes_ext(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert!(item.itunes_ext().is_none());
     /// ```
@@ -696,8 +669,7 @@ impl ItemBuilder {
     /// use rss::{CategoryBuilder, ItemBuilder};
     ///
     /// let category = CategoryBuilder::new()
-    ///     .finalize()
-    ///     .unwrap();;
+    ///     .finalize();
     /// let categories = vec![category];
     ///
     /// let mut item_builder = ItemBuilder::new();
@@ -738,8 +710,7 @@ impl ItemBuilder {
     /// let enclosure = EnclosureBuilder::new()
     ///     .url(url.as_str())
     ///     .mime_type("audio/ogg")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let mut item_builder = ItemBuilder::new();
     /// item_builder.enclosure(Some(enclosure));
@@ -758,8 +729,7 @@ impl ItemBuilder {
     /// use rss::{GuidBuilder, ItemBuilder};
     ///
     /// let guid = GuidBuilder::new()
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let mut item_builder = ItemBuilder::new();
     /// item_builder.guid(Some(guid));
@@ -798,8 +768,7 @@ impl ItemBuilder {
     ///
     /// let source = SourceBuilder::new()
     ///     .url(url)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let mut item_builder = ItemBuilder::new();
     /// item_builder.source(Some(source));
@@ -831,8 +800,7 @@ impl ItemBuilder {
     ///     .subtitle(Some("subtitle".to_string()))
     ///     .summary(Some("summary".to_string()))
     ///     .keywords(Some("keywords".to_string()))
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// let mut item_builder = ItemBuilder::new();
     /// item_builder.itunes_ext(Some(itunes_item));
@@ -878,8 +846,9 @@ impl ItemBuilder {
     ///     .guid(None)
     ///     .pub_date(None)
     ///     .source(None)
-    ///     .validate().unwrap()
-    ///     .finalize().unwrap();
+    ///     .validate()
+    ///     .unwrap()
+    ///     .finalize();
     /// ```
     pub fn validate(self) -> Result<ItemBuilder, Error> {
         if let Some(ref link) = self.link {
@@ -916,25 +885,24 @@ impl ItemBuilder {
     ///     .guid(None)
     ///     .pub_date(None)
     ///     .source(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     /// ```
-    pub fn finalize(self) -> Result<Item, Error> {
-        Ok(Item {
-               title: self.title,
-               link: self.link,
-               description: self.description,
-               author: self.author,
-               categories: self.categories,
-               comments: self.comments,
-               enclosure: self.enclosure,
-               guid: self.guid,
-               pub_date: self.pub_date,
-               source: self.source,
-               extensions: self.extensions,
-               itunes_ext: self.itunes_ext,
-               dublin_core_ext: self.dublin_core_ext,
-               content: self.content,
-           })
+    pub fn finalize(self) -> Item {
+        Item {
+            title: self.title,
+            link: self.link,
+            description: self.description,
+            author: self.author,
+            categories: self.categories,
+            comments: self.comments,
+            enclosure: self.enclosure,
+            guid: self.guid,
+            pub_date: self.pub_date,
+            source: self.source,
+            extensions: self.extensions,
+            itunes_ext: self.itunes_ext,
+            dublin_core_ext: self.dublin_core_ext,
+            content: self.content,
+        }
     }
 }

--- a/src/item.rs
+++ b/src/item.rs
@@ -602,9 +602,8 @@ impl ItemBuilder {
     /// ```
     /// use rss::ItemBuilder;
     ///
-    /// let mut item_builder = ItemBuilder::new();
-    /// item_builder.title(Some("Making Music with Linux | LAS
-    /// 408".to_string()));
+    /// let item_builder = ItemBuilder::new()
+    ///     .title(Some("Making Music with Linux | LAS 408".to_string()));
     /// ```
     pub fn title(mut self, title: Option<String>) -> ItemBuilder {
         self.title = title;
@@ -619,9 +618,8 @@ impl ItemBuilder {
     /// ```
     /// use rss::ItemBuilder;
     ///
-    /// let mut item_builder = ItemBuilder::new();
-    /// item_builder.link(Some("http://www.jupiterbroadcasting.com".
-    /// to_owned()));
+    /// let item_builder = ItemBuilder::new()
+    ///     .link(Some("http://www.jupiterbroadcasting.com".to_string()));
     /// ```
     pub fn link(mut self, link: Option<String>) -> ItemBuilder {
         self.link = link;
@@ -636,8 +634,8 @@ impl ItemBuilder {
     /// ```
     /// use rss::ItemBuilder;
     ///
-    /// let mut item_builder = ItemBuilder::new();
-    /// item_builder.description(Some("This is a test description".to_string()));
+    /// let item_builder = ItemBuilder::new()
+    ///     .description(Some("This is a test description".to_string()));
     /// ```
     pub fn description(mut self, description: Option<String>) -> ItemBuilder {
         self.description = description;
@@ -652,8 +650,8 @@ impl ItemBuilder {
     /// ```
     /// use rss::ItemBuilder;
     ///
-    /// let mut item_builder = ItemBuilder::new();
-    /// item_builder.author(Some("Chris Fisher".to_string()));
+    /// let item_builder = ItemBuilder::new()
+    ///     .author(Some("Chris Fisher".to_string()));
     /// ```
     pub fn author(mut self, author: Option<String>) -> ItemBuilder {
         self.author = author;
@@ -670,10 +668,9 @@ impl ItemBuilder {
     ///
     /// let category = CategoryBuilder::new()
     ///     .finalize();
-    /// let categories = vec![category];
     ///
-    /// let mut item_builder = ItemBuilder::new();
-    /// item_builder.categories(categories);
+    /// let item_builder = ItemBuilder::new()
+    ///     .categories(vec![category]);
     /// ```
     pub fn categories(mut self, categories: Vec<Category>) -> ItemBuilder {
         self.categories = categories;
@@ -688,8 +685,8 @@ impl ItemBuilder {
     /// ```
     /// use rss::ItemBuilder;
     ///
-    /// let mut item_builder = ItemBuilder::new();
-    /// item_builder.comments(Some("Test Comment".to_string()));
+    /// let item_builder = ItemBuilder::new()
+    ///     .comments(Some("A comment".to_string()));
     /// ```
     pub fn comments(mut self, comments: Option<String>) -> ItemBuilder {
         self.comments = comments;
@@ -704,16 +701,16 @@ impl ItemBuilder {
     /// ```
     /// use rss::{EnclosureBuilder, ItemBuilder};
     ///
-    /// let url = "http://www.podtrac.com/pts/redirect.ogg/".to_string()
-    /// + "traffic.libsyn.com/jnite/linuxactionshowep408.ogg";
+    /// let url = "http://www.podtrac.com/pts/redirect.ogg/traffic.libsyn.com/jnite/\
+    ///     linuxactionshowep408.ogg";
     ///
     /// let enclosure = EnclosureBuilder::new()
-    ///     .url(url.as_str())
+    ///     .url(url)
     ///     .mime_type("audio/ogg")
     ///     .finalize();
     ///
-    /// let mut item_builder = ItemBuilder::new();
-    /// item_builder.enclosure(Some(enclosure));
+    /// let item_builder = ItemBuilder::new()
+    ///     .enclosure(Some(enclosure));
     /// ```
     pub fn enclosure(mut self, enclosure: Option<Enclosure>) -> ItemBuilder {
         self.enclosure = enclosure;
@@ -731,8 +728,8 @@ impl ItemBuilder {
     /// let guid = GuidBuilder::new()
     ///     .finalize();
     ///
-    /// let mut item_builder = ItemBuilder::new();
-    /// item_builder.guid(Some(guid));
+    /// let item_builder = ItemBuilder::new()
+    ///     .guid(Some(guid));
     /// ```
     pub fn guid(mut self, guid: Option<Guid>) -> ItemBuilder {
         self.guid = guid;
@@ -747,9 +744,8 @@ impl ItemBuilder {
     /// ```
     /// use rss::ItemBuilder;
     ///
-    /// let mut item_builder = ItemBuilder::new();
-    /// item_builder.pub_date(Some("Sun, 13 Mar 2016
-    /// 20:02:02-0700".to_string()));
+    /// let item_builder = ItemBuilder::new()
+    ///     .pub_date(Some("Sun, 13 Mar 2016 20:02:02-0700".to_string()));
     /// ```
     pub fn pub_date(mut self, pub_date: Option<String>) -> ItemBuilder {
         self.pub_date = pub_date;
@@ -764,14 +760,12 @@ impl ItemBuilder {
     /// ```
     /// use rss::{ItemBuilder, SourceBuilder};
     ///
-    /// let url = "http://www.tomalak.org/links2.xml";
-    ///
     /// let source = SourceBuilder::new()
-    ///     .url(url)
+    ///     .url("http://www.tomalak.org/links2.xml")
     ///     .finalize();
     ///
-    /// let mut item_builder = ItemBuilder::new();
-    /// item_builder.source(Some(source));
+    /// let item_builder = ItemBuilder::new()
+    ///     .source(Some(source));
     /// ```
     pub fn source(mut self, source: Option<Source>) -> ItemBuilder {
         self.source = source;
@@ -787,8 +781,6 @@ impl ItemBuilder {
     /// use rss::ItemBuilder;
     /// use rss::extension::itunes::ITunesItemExtensionBuilder;
     ///
-    /// let url = "http://www.tomalak.org/links2.xml";
-    ///
     /// let itunes_item = ITunesItemExtensionBuilder::new()
     ///     .author(Some("author".to_string()))
     ///     .block(Some("block".to_string()))
@@ -802,8 +794,8 @@ impl ItemBuilder {
     ///     .keywords(Some("keywords".to_string()))
     ///     .finalize();
     ///
-    /// let mut item_builder = ItemBuilder::new();
-    /// item_builder.itunes_ext(Some(itunes_item));
+    /// let item_builder = ItemBuilder::new()
+    ///     .itunes_ext(Some(itunes_item));
     /// ```
     pub fn itunes_ext(mut self, itunes_ext: Option<ITunesItemExtension>) -> ItemBuilder {
         self.itunes_ext = itunes_ext;

--- a/src/item.rs
+++ b/src/item.rs
@@ -456,8 +456,8 @@ impl FromXml for Item {
         let mut buf = Vec::new();
 
         loop {
-            match reader.read_event(&mut buf) {
-                Ok(Event::Start(element)) => {
+            match reader.read_event(&mut buf)? {
+                Event::Start(element) => {
                     match element.name() {
                         b"category" => {
                             let category = Category::from_xml(reader, element.attributes())?;
@@ -495,7 +495,7 @@ impl FromXml for Item {
                         }
                     }
                 }
-                Ok(Event::End(_)) => {
+                Event::End(_) => {
                     if !item.extensions.is_empty() {
                         if let Some(map) = item.extensions.remove("itunes") {
                             item.itunes_ext = Some(ITunesItemExtension::from_map(map));
@@ -508,8 +508,7 @@ impl FromXml for Item {
 
                     return Ok(item);
                 }
-                Ok(Event::Eof) => break,
-                Err(err) => return Err(err.into()),
+                Event::Eof => break,
                 _ => {}
             }
             buf.clear();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,37 +22,31 @@
 //!
 //! use rss::{ChannelBuilder, ImageBuilder};
 //!
-//! fn main()
-//! {
-//!     let image = ImageBuilder::new()
-//!             .url("http://jupiterbroadcasting.com/images/LAS-300-Badge.jpg")
-//!             .title("LAS 300 Logo")
-//!             .link("http://www.jupiterbroadcasting.com")
-//!             .width(Some(88))
-//!             .height(Some(88))
-//!             .description(Some("This is a test".to_string()))
-//!             .finalize()
-//!             .unwrap();
+//! fn main() {
+//!     let image = ImageBuilder::default()
+//!         .url("http://jupiterbroadcasting.com/images/LAS-300-Badge.jpg")
+//!         .title("LAS 300 Logo")
+//!         .link("http://www.jupiterbroadcasting.com")
+//!         .finalize();
 //!
-//!     let description = "Ogg Vorbis audio versions of The Linux ".to_string()
-//!     + "Action Show! A show that covers everything geeks care about in the "
-//!     + "computer industry. Get a solid dose of Linux, gadgets, news events "
-//!     + "and much more!";
+//!     let description = "Ogg Vorbis audio versions of The Linux Action Show! A show that \
+//!         covers everything geeks care about in the computer industry. Get a solid dose of \
+//!         Linux, gadgets, news events and much more!";
 //!
-//!     let channel = ChannelBuilder::new()
-//!             .title("The Linux Action Show! OGG")
-//!             .link("http://www.jupiterbroadcasting.com")
-//!             .description(description.as_ref())
-//!             .finalize()
-//!             .unwrap();
+//!     let channel = ChannelBuilder::default()
+//!         .title("The Linux Action Show! OGG")
+//!         .link("http://www.jupiterbroadcasting.com")
+//!         .description(description.as_ref())
+//!         .image(image)
+//!         .finalize();
 //! }
 //! ```
 //!
 //! # Reading
 //!
-//! A channel can be read from any object that implements the `BufRead` trait.
+//! ## From a `BufRead`
 //!
-//! ## Example
+//! A channel can be read from any object that implements the `BufRead` trait.
 //!
 //! ```rust,no_run
 //! use std::fs::File;
@@ -63,25 +57,23 @@
 //! let reader = BufReader::new(file);
 //! let channel = Channel::read_from(reader).unwrap();
 //! ```
+//! ## From a URL
 //!
-//! A channel can be read from an url.
+//! A channel can also be read from a URL.
 //!
-//! To enable this functionality you must enable the from_url feature in your Cargo.toml.
+//! To enable this functionality you must enable the `from_url` feature in your Cargo.toml.
 //!
 //! ```toml
 //! [dependencies]
 //! rss = { version = "*", features = ["from_url"] }
 //! ```
 //!
-//! # Examples
-//!
-//! ```
+//! ```ignore
 //! extern crate rss;
 //!
 //! use rss::Channel;
 //!
-//! fn main()
-//! {
+//! fn main() {
 //!     let url = "https://feedpress.me/usererror.xml";
 //!     let channel = Channel::from_url(url).unwrap();
 //! }
@@ -123,8 +115,7 @@
 //!
 //! use rss::Channel;
 //!
-//! fn main()
-//! {
+//! fn main() {
 //!     let input = include_str!("tests/data/rss2sample.xml");
 //!
 //!     let channel = input.parse::<Channel>().unwrap();
@@ -139,18 +130,12 @@
 //!
 //! use rss::ImageBuilder;
 //!
-//! fn main()
-//! {
-//!     let image = ImageBuilder::new()
+//! fn main() {
+//!     let builder = ImageBuilder::default()
 //!             .url("http://jupiterbroadcasting.com/images/LAS-300-Badge.jpg")
 //!             .title("LAS 300 Logo")
 //!             .link("http://www.jupiterbroadcasting.com")
-//!             .width(Some(88))
-//!             .height(Some(88))
-//!             .description(Some("This is a test".to_string()))
 //!             .validate()
-//!             .unwrap()
-//!             .finalize()
 //!             .unwrap();
 //! }
 //! ```

--- a/src/source.rs
+++ b/src/source.rs
@@ -56,7 +56,7 @@ impl Source {
     /// let url = "http://www.tomalak.org/links2.xml";
     ///
     /// let source_obj = SourceBuilder::new()
-    ///     .title(Some(title.to_string()))
+    ///     .title(title.to_string())
     ///     .url(url)
     ///     .finalize();
     ///
@@ -154,10 +154,10 @@ impl SourceBuilder {
     /// use rss::SourceBuilder;
     ///
     /// let source_builder = SourceBuilder::new()
-    ///     .title(Some("Test".to_string()));
+    ///     .title("Test".to_string());
     /// ```
-    pub fn title(mut self, title: Option<String>) -> SourceBuilder {
-        self.title = title;
+    pub fn title<V: Into<Option<String>>>(mut self, title: V) -> SourceBuilder {
+        self.title = title.into();
         self
     }
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -82,11 +82,10 @@ impl FromXml for Source {
             }
         }
 
-        let url = url.unwrap_or_default();
         let content = element_text(reader)?;
 
         Ok(Source {
-               url: url,
+               url: url.unwrap_or_default(),
                title: content,
            })
     }
@@ -138,11 +137,11 @@ impl SourceBuilder {
     /// ```
     /// use rss::SourceBuilder;
     ///
-    /// let mut source_builder = SourceBuilder::new();
-    /// source_builder.url("http://www.example.com/source");
+    /// let source_builder = SourceBuilder::new()
+    ///     .url("http://www.example.com/source");
     /// ```
-    pub fn url(mut self, url: &str) -> SourceBuilder {
-        self.url = url.to_string();
+    pub fn url<S: Into<String>>(mut self, url: S) -> SourceBuilder {
+        self.url = url.into();
         self
     }
 
@@ -154,8 +153,8 @@ impl SourceBuilder {
     /// ```
     /// use rss::SourceBuilder;
     ///
-    /// let mut source_builder = SourceBuilder::new();
-    /// source_builder.title(Some("Test".to_string()));
+    /// let source_builder = SourceBuilder::new()
+    ///     .title(Some("Test".to_string()));
     /// ```
     pub fn title(mut self, title: Option<String>) -> SourceBuilder {
         self.title = title;

--- a/src/source.rs
+++ b/src/source.rs
@@ -25,16 +25,16 @@ pub struct Source {
 }
 
 impl Source {
-    /// Get the url that exists under `Source`.
+    /// Return the URL for this `Source`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{SourceBuilder, Source};
+    /// use rss::SourceBuilder;
     ///
     /// let url = "http://www.tomalak.org/links2.xml";
     ///
-    /// let source = SourceBuilder::new()
+    /// let source = SourceBuilder::default()
     ///     .url(url)
     ///     .finalize();
     ///
@@ -44,23 +44,20 @@ impl Source {
         self.url.as_str()
     }
 
-    /// Get the source that exists under `Source`.
+    /// Return the title of this `Source`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{SourceBuilder, Source};
+    /// use rss::SourceBuilder;
     ///
     /// let title = "Tomalak's Realm";
     ///
-    /// let url = "http://www.tomalak.org/links2.xml";
-    ///
-    /// let source_obj = SourceBuilder::new()
+    /// let source = SourceBuilder::default()
     ///     .title(title.to_string())
-    ///     .url(url)
     ///     .finalize();
     ///
-    /// assert_eq!(Some(title), source_obj.title());
+    /// assert_eq!(Some(title), source.title());
     /// ```
     pub fn title(&self) -> Option<&str> {
         self.title.as_ref().map(|s| s.as_str())
@@ -108,7 +105,7 @@ impl ToXml for Source {
     }
 }
 
-/// This `SourceBuilder` struct creates the `Source`.
+/// A builder used to create a `Source`.
 #[derive(Debug, Clone, Default)]
 pub struct SourceBuilder {
     url: String,
@@ -116,65 +113,51 @@ pub struct SourceBuilder {
 }
 
 impl SourceBuilder {
-    /// Construct a new `SourceBuilder` and return default values.
+    /// Set the URL for the `Source`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::SourceBuilder;
     ///
-    /// let source_builder = SourceBuilder::new();
-    /// ```
-    pub fn new() -> SourceBuilder {
-        SourceBuilder::default()
-    }
-
-
-    /// Set the url that exists under `Source`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rss::SourceBuilder;
-    ///
-    /// let source_builder = SourceBuilder::new()
+    /// let builder = SourceBuilder::default()
     ///     .url("http://www.example.com/source");
     /// ```
-    pub fn url<S: Into<String>>(mut self, url: S) -> SourceBuilder {
+    pub fn url<S>(mut self, url: S) -> SourceBuilder
+        where S: Into<String>
+    {
         self.url = url.into();
         self
     }
 
-
-    /// Set the source that exists under `Source`.
+    /// Set the title of the `Source`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::SourceBuilder;
     ///
-    /// let source_builder = SourceBuilder::new()
+    /// let builder = SourceBuilder::default()
     ///     .title("Test".to_string());
     /// ```
-    pub fn title<V: Into<Option<String>>>(mut self, title: V) -> SourceBuilder {
+    pub fn title<V>(mut self, title: V) -> SourceBuilder
+        where V: Into<Option<String>>
+    {
         self.title = title.into();
         self
     }
 
-
-    /// Validate the contents of `Source`.
+    /// Validate the contents of this `SourceBuilder`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::SourceBuilder;
     ///
-    /// let source = SourceBuilder::new()
+    /// let source = SourceBuilder::default()
     ///     .url("http://www.example.com/source")
-    ///     .title(None)
     ///     .validate()
-    ///     .unwrap()
-    ///     .finalize();
+    ///     .unwrap();
     /// ```
     pub fn validate(self) -> Result<SourceBuilder, Error> {
         Url::parse(self.url.as_str())?;
@@ -182,17 +165,15 @@ impl SourceBuilder {
         Ok(self)
     }
 
-
-    /// Construct the `Source` from the `SourceBuilder`.
+    /// Construct the `Source` from this `SourceBuilder`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::SourceBuilder;
     ///
-    /// let source = SourceBuilder::new()
+    /// let source = SourceBuilder::default()
     ///     .url("http://www.example.com/source")
-    ///     .title(None)
     ///     .finalize();
     /// ```
     pub fn finalize(self) -> Source {

--- a/src/source.rs
+++ b/src/source.rs
@@ -78,7 +78,7 @@ impl FromXml for Source {
         for attr in atts.with_checks(false) {
             if let Ok(attr) = attr {
                 if attr.key == b"url" {
-                    url = Some(attr.unescape_and_decode_value(&reader)?);
+                    url = Some(attr.unescape_and_decode_value(reader)?);
                     break;
                 }
             }

--- a/src/source.rs
+++ b/src/source.rs
@@ -36,8 +36,7 @@ impl Source {
     ///
     /// let source = SourceBuilder::new()
     ///     .url(url)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(url, source.url());
     /// ```
@@ -59,8 +58,7 @@ impl Source {
     /// let source_obj = SourceBuilder::new()
     ///     .title(Some(title.to_string()))
     ///     .url(url)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(Some(title), source_obj.title());
     /// ```
@@ -177,8 +175,7 @@ impl SourceBuilder {
     ///     .title(None)
     ///     .validate()
     ///     .unwrap()
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     /// ```
     pub fn validate(self) -> Result<SourceBuilder, Error> {
         Url::parse(self.url.as_str())?;
@@ -197,13 +194,12 @@ impl SourceBuilder {
     /// let source = SourceBuilder::new()
     ///     .url("http://www.example.com/source")
     ///     .title(None)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     /// ```
-    pub fn finalize(self) -> Result<Source, Error> {
-        Ok(Source {
-               url: self.url,
-               title: self.title,
-           })
+    pub fn finalize(self) -> Source {
+        Source {
+            url: self.url,
+            title: self.title,
+        }
     }
 }

--- a/src/textinput.rs
+++ b/src/textinput.rs
@@ -125,8 +125,8 @@ impl FromXml for TextInput {
         let mut skip_buf = Vec::new();
 
         loop {
-            match reader.read_event(&mut buf) {
-                Ok(Event::Start(element)) => {
+            match reader.read_event(&mut buf)? {
+                Event::Start(element) => {
                     match element.name() {
                         b"title" => title = element_text(reader)?,
                         b"description" => description = element_text(reader)?,
@@ -135,7 +135,7 @@ impl FromXml for TextInput {
                         n => reader.read_to_end(n, &mut skip_buf)?,
                     }
                 }
-                Ok(Event::End(_)) => {
+                Event::End(_) => {
                     let title = title.unwrap_or_default();
                     let description = description.unwrap_or_default();
                     let name = name.unwrap_or_default();
@@ -148,8 +148,7 @@ impl FromXml for TextInput {
                                   link: link,
                               });
                 }
-                Ok(Event::Eof) => break,
-                Err(err) => return Err(err.into()),
+                Event::Eof => break,
                 _ => {}
             }
             buf.clear();

--- a/src/textinput.rs
+++ b/src/textinput.rs
@@ -29,18 +29,17 @@ pub struct TextInput {
 }
 
 impl TextInput {
-    /// Get the title that exists under `TextInput`.
+    /// Return the title for this `TextInput`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{TextInputBuilder, TextInput};
+    /// use rss::TextInputBuilder;
     ///
     /// let title = "Enter Comment";
     ///
-    /// let text_input = TextInputBuilder::new()
+    /// let text_input = TextInputBuilder::default()
     ///     .title(title)
-    ///     .link("http://www.example.com/feedback")
     ///     .finalize();
     ///
     /// assert_eq!(title, text_input.title());
@@ -49,18 +48,17 @@ impl TextInput {
         self.title.as_str()
     }
 
-    /// Get the description that exists under `TextInput`.
+    /// Return the description of this `TextInput`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{TextInputBuilder, TextInput};
+    /// use rss::TextInputBuilder;
     ///
     /// let description = "Provided Feedback";
     ///
-    /// let text_input = TextInputBuilder::new()
+    /// let text_input = TextInputBuilder::default()
     ///     .description(description)
-    ///     .link("http://www.example.com/feedback")
     ///     .finalize();
     ///
     /// assert_eq!(description, text_input.description());
@@ -69,18 +67,17 @@ impl TextInput {
         self.description.as_str()
     }
 
-    /// Get the name that exists under `TextInput`.
+    /// Return the name of this `TextInput`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{TextInputBuilder, TextInput};
+    /// use rss::TextInputBuilder;
     ///
     /// let name = "Comment";
     ///
-    /// let text_input = TextInputBuilder::new()
+    /// let text_input = TextInputBuilder::default()
     ///     .name(name)
-    ///     .link("http://www.example.com/feedback")
     ///     .finalize();
     ///
     /// assert_eq!(name, text_input.name());
@@ -89,16 +86,16 @@ impl TextInput {
         self.name.as_str()
     }
 
-    /// Get the link that exists under `TextInput`.
+    /// Return the submission URL for this `TextInput`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rss::{TextInputBuilder, TextInput};
+    /// use rss::TextInputBuilder;
     ///
     /// let link = "http://www.example.com/feedback";
     ///
-    /// let text_input = TextInputBuilder::new()
+    /// let text_input = TextInputBuilder::default()
     ///     .link(link)
     ///     .finalize();
     ///
@@ -172,7 +169,7 @@ impl ToXml for TextInput {
     }
 }
 
-/// This `TextInputBuilder` struct creates the `TextInput`.
+/// A builder used to create a `TextInput`.
 #[derive(Debug, Clone, Default)]
 pub struct TextInputBuilder {
     title: String,
@@ -182,94 +179,88 @@ pub struct TextInputBuilder {
 }
 
 impl TextInputBuilder {
-    /// Construct a new `TextInputBuilder` and return default values.
+    /// Set the title for the `TextInput`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::TextInputBuilder;
     ///
-    /// let text_input_builder = TextInputBuilder::new();
-    /// ```
-    pub fn new() -> TextInputBuilder {
-        TextInputBuilder::default()
-    }
-
-    /// Set the title that exists under `TextInput`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rss::TextInputBuilder;
-    ///
-    /// let text_input_builder = TextInputBuilder::new()
+    /// let builder = TextInputBuilder::default()
     ///     .title("Title");
     /// ```
-    pub fn title<S: Into<String>>(mut self, title: S) -> TextInputBuilder {
+    pub fn title<S>(mut self, title: S) -> TextInputBuilder
+        where S: Into<String>
+    {
         self.title = title.into();
         self
     }
 
-    /// Set the description that exists under `TextInput`.
+    /// Set the description of the `TextInput`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::TextInputBuilder;
     ///
-    /// let text_input_builder = TextInputBuilder::new()
+    /// let builder = TextInputBuilder::default()
     ///     .description("This is a test description.");
     /// ```
-    pub fn description<S: Into<String>>(mut self, description: S) -> TextInputBuilder {
+    pub fn description<S>(mut self, description: S) -> TextInputBuilder
+        where S: Into<String>
+    {
         self.description = description.into();
         self
     }
 
-    /// Set the name that exists under `TextInput`.
+    /// Set the name of the `TextInput`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::TextInputBuilder;
     ///
-    /// let text_input_builder = TextInputBuilder::new()
+    /// let builder = TextInputBuilder::default()
     ///     .name("Comments");
     /// ```
-    pub fn name<S: Into<String>>(mut self, name: S) -> TextInputBuilder {
+    pub fn name<S>(mut self, name: S) -> TextInputBuilder
+        where S: Into<String>
+    {
         self.name = name.into();
         self
     }
 
-    /// Set the link that exists under `TextInput`.
+    /// Set the submission URL for the `TextInput`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::TextInputBuilder;
     ///
-    /// let text_input_builder = TextInputBuilder::new()
+    /// let builder = TextInputBuilder::default()
     ///     .link("http://www.example.com/feedback");
     /// ```
-    pub fn link<S: Into<String>>(mut self, link: S) -> TextInputBuilder {
+    pub fn link<S>(mut self, link: S) -> TextInputBuilder
+        where S: Into<String>
+    {
         self.link = link.into();
         self
     }
 
-    /// Validate the contents of `TextInput`.
+    /// Validate the contents of this `TextInputBuilder`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::TextInputBuilder;
     ///
-    /// let text_input = TextInputBuilder::new()
+    /// let text_input = TextInputBuilder::default()
     ///         .title("Title")
     ///         .description("This is a test description.")
     ///         .name("Comments")
     ///         .link("http://www.example.com/feedback")
     ///         .validate()
-    ///         .unwrap()
-    ///         .finalize();
+    ///         .unwrap();
     /// ```
     pub fn validate(self) -> Result<TextInputBuilder, Error> {
         Url::parse(self.link.as_str())?;
@@ -277,14 +268,14 @@ impl TextInputBuilder {
         Ok(self)
     }
 
-    /// Construct the `TextInput` from the `TextInputBuilder`.
+    /// Construct the `TextInput` from this `TextInputBuilder`.
     ///
     /// # Examples
     ///
     /// ```
     /// use rss::TextInputBuilder;
     ///
-    /// let text_input = TextInputBuilder::new()
+    /// let text_input = TextInputBuilder::default()
     ///         .title("Title")
     ///         .description("This is a test description.")
     ///         .name("Comments")

--- a/src/textinput.rs
+++ b/src/textinput.rs
@@ -202,11 +202,11 @@ impl TextInputBuilder {
     /// ```
     /// use rss::TextInputBuilder;
     ///
-    /// let mut text_input_builder = TextInputBuilder::new();
-    /// text_input_builder.title("Title");
+    /// let text_input_builder = TextInputBuilder::new()
+    ///     .title("Title");
     /// ```
-    pub fn title(mut self, title: &str) -> TextInputBuilder {
-        self.title = title.to_string();
+    pub fn title<S: Into<String>>(mut self, title: S) -> TextInputBuilder {
+        self.title = title.into();
         self
     }
 
@@ -217,11 +217,11 @@ impl TextInputBuilder {
     /// ```
     /// use rss::TextInputBuilder;
     ///
-    /// let mut text_input_builder = TextInputBuilder::new();
-    /// text_input_builder.description("This is a test description.");
+    /// let text_input_builder = TextInputBuilder::new()
+    ///     .description("This is a test description.");
     /// ```
-    pub fn description(mut self, description: &str) -> TextInputBuilder {
-        self.description = description.to_string();
+    pub fn description<S: Into<String>>(mut self, description: S) -> TextInputBuilder {
+        self.description = description.into();
         self
     }
 
@@ -232,11 +232,11 @@ impl TextInputBuilder {
     /// ```
     /// use rss::TextInputBuilder;
     ///
-    /// let mut text_input_builder = TextInputBuilder::new();
-    /// text_input_builder.name("Comments");
+    /// let text_input_builder = TextInputBuilder::new()
+    ///     .name("Comments");
     /// ```
-    pub fn name(mut self, name: &str) -> TextInputBuilder {
-        self.name = name.to_string();
+    pub fn name<S: Into<String>>(mut self, name: S) -> TextInputBuilder {
+        self.name = name.into();
         self
     }
 
@@ -247,11 +247,11 @@ impl TextInputBuilder {
     /// ```
     /// use rss::TextInputBuilder;
     ///
-    /// let mut text_input_builder = TextInputBuilder::new();
-    /// text_input_builder.link("http://www.example.com/feedback");
+    /// let text_input_builder = TextInputBuilder::new()
+    ///     .link("http://www.example.com/feedback");
     /// ```
-    pub fn link(mut self, link: &str) -> TextInputBuilder {
-        self.link = link.to_string();
+    pub fn link<S: Into<String>>(mut self, link: S) -> TextInputBuilder {
+        self.link = link.into();
         self
     }
 

--- a/src/textinput.rs
+++ b/src/textinput.rs
@@ -41,8 +41,7 @@ impl TextInput {
     /// let text_input = TextInputBuilder::new()
     ///     .title(title)
     ///     .link("http://www.example.com/feedback")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(title, text_input.title());
     /// ```
@@ -62,8 +61,7 @@ impl TextInput {
     /// let text_input = TextInputBuilder::new()
     ///     .description(description)
     ///     .link("http://www.example.com/feedback")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(description, text_input.description());
     /// ```
@@ -83,8 +81,7 @@ impl TextInput {
     /// let text_input = TextInputBuilder::new()
     ///     .name(name)
     ///     .link("http://www.example.com/feedback")
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(name, text_input.name());
     /// ```
@@ -103,8 +100,7 @@ impl TextInput {
     ///
     /// let text_input = TextInputBuilder::new()
     ///     .link(link)
-    ///     .finalize()
-    ///     .unwrap();
+    ///     .finalize();
     ///
     /// assert_eq!(link, text_input.link());
     /// ```
@@ -273,8 +269,7 @@ impl TextInputBuilder {
     ///         .link("http://www.example.com/feedback")
     ///         .validate()
     ///         .unwrap()
-    ///         .finalize()
-    ///         .unwrap();
+    ///         .finalize();
     /// ```
     pub fn validate(self) -> Result<TextInputBuilder, Error> {
         Url::parse(self.link.as_str())?;
@@ -294,15 +289,14 @@ impl TextInputBuilder {
     ///         .description("This is a test description.")
     ///         .name("Comments")
     ///         .link("http://www.example.com/feedback")
-    ///         .finalize()
-    ///         .unwrap();
+    ///         .finalize();
     /// ```
-    pub fn finalize(self) -> Result<TextInput, Error> {
-        Ok(TextInput {
-               title: self.title,
-               description: self.description,
-               name: self.name,
-               link: self.link,
-           })
+    pub fn finalize(self) -> TextInput {
+        TextInput {
+            title: self.title,
+            description: self.description,
+            name: self.name,
+            link: self.link,
+        }
     }
 }

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -254,22 +254,22 @@ fn read_extension() {
                "http://example.com/");
     assert_eq!(channel.namespaces().len(), 1);
 
-    assert_eq!(get_extension_values(&channel
-                                         .items()
-                                         .get(0)
-                                         .unwrap()
-                                         .extensions()
-                                         .get("ext")
-                                         .unwrap(),
+    assert_eq!(get_extension_values(channel
+                                        .items()
+                                        .get(0)
+                                        .unwrap()
+                                        .extensions()
+                                        .get("ext")
+                                        .unwrap(),
                                     "creator"),
                Some(vec!["Creator Name"]));
-    assert_eq!(get_extension_values(&channel
-                                         .items()
-                                         .get(0)
-                                         .unwrap()
-                                         .extensions()
-                                         .get("ext")
-                                         .unwrap(),
+    assert_eq!(get_extension_values(channel
+                                        .items()
+                                        .get(0)
+                                        .unwrap()
+                                        .extensions()
+                                        .get("ext")
+                                        .unwrap(),
                                     "contributor"),
                Some(vec!["Contributor 1", "Contributor 2"]));
     assert_eq!(channel
@@ -507,15 +507,15 @@ fn read_dublincore() {
                    vec!["Type"]);
     }
 
-    test_ext(&channel
-                  .dublin_core_ext()
-                  .as_ref()
-                  .expect("dc extension missing"));
-    test_ext(&channel
-                  .items()
-                  .get(0)
-                  .unwrap()
-                  .dublin_core_ext()
-                  .as_ref()
-                  .expect("ds extension missing"));
+    test_ext(channel
+                 .dublin_core_ext()
+                 .as_ref()
+                 .expect("dc extension missing"));
+    test_ext(channel
+                 .items()
+                 .get(0)
+                 .unwrap()
+                 .dublin_core_ext()
+                 .as_ref()
+                 .expect("ds extension missing"));
 }

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -111,15 +111,15 @@ fn write_dublincore() {
 
 #[test]
 fn verify_write_format() {
-    let item = ItemBuilder::new()
-        .itunes_ext(extension::itunes::ITunesItemExtensionBuilder::new().finalize())
-        .dublin_core_ext(extension::dublincore::DublinCoreExtensionBuilder::new().finalize())
+    let item = ItemBuilder::default()
+        .itunes_ext(extension::itunes::ITunesItemExtensionBuilder::default().finalize())
+        .dublin_core_ext(extension::dublincore::DublinCoreExtensionBuilder::default().finalize())
         .finalize();
 
     let mut namespaces: HashMap<String, String> = HashMap::new();
     namespaces.insert("ext".to_string(), "http://example.com/".to_string());
 
-    let channel = ChannelBuilder::new()
+    let channel = ChannelBuilder::default()
         .title("Title")
         .link("http://example.com/")
         .description("Description")

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -112,14 +112,9 @@ fn write_dublincore() {
 #[test]
 fn verify_write_format() {
     let item = ItemBuilder::new()
-        .itunes_ext(Some(extension::itunes::ITunesItemExtensionBuilder::new()
-                             .finalize()
-                             .unwrap()))
-        .dublin_core_ext(Some(extension::dublincore::DublinCoreExtensionBuilder::new()
-                                  .finalize()
-                                  .unwrap()))
-        .finalize()
-        .unwrap();
+        .itunes_ext(Some(extension::itunes::ITunesItemExtensionBuilder::new().finalize()))
+        .dublin_core_ext(Some(extension::dublincore::DublinCoreExtensionBuilder::new().finalize()))
+        .finalize();
 
     let mut namespaces: HashMap<String, String> = HashMap::new();
     namespaces.insert("ext".to_string(), "http://example.com/".to_string());
@@ -130,8 +125,7 @@ fn verify_write_format() {
         .description("Description")
         .items(vec![item])
         .namespaces(namespaces)
-        .finalize()
-        .unwrap();
+        .finalize();
 
     let output = include_str!("data/verify_write_format.xml")
         .replace("\n", "")

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -112,8 +112,8 @@ fn write_dublincore() {
 #[test]
 fn verify_write_format() {
     let item = ItemBuilder::new()
-        .itunes_ext(Some(extension::itunes::ITunesItemExtensionBuilder::new().finalize()))
-        .dublin_core_ext(Some(extension::dublincore::DublinCoreExtensionBuilder::new().finalize()))
+        .itunes_ext(extension::itunes::ITunesItemExtensionBuilder::new().finalize())
+        .dublin_core_ext(extension::dublincore::DublinCoreExtensionBuilder::new().finalize())
         .finalize();
 
     let mut namespaces: HashMap<String, String> = HashMap::new();


### PR DESCRIPTION
* Changed `finalize` to return `T` instead of `Result<T, E>`
* Changed builder methods to take `Into<T>` instead of `T`
* Removed `new` methods on builders since they offer no advantage over just using `default`
* Cleaned up the quick-xml event matching by using `?` on `read_event`
* Shortened some of the longer doc comments so that its easier to read the documentation  
* Improved the message from a few of the `Validation` errors

This PR includes breaking changes related to the builders so a new semver 0.x version is required.