### PR TITLE
Add email validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,5 @@ quick-xml = "0.7.3"
 chrono = "0.3"
 url = "1.4"
 mime = "0.2"
+mailchecker = "3.0"
 reqwest = { version = "0.6", optional = true }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -17,6 +17,7 @@ use fromxml::{self, FromXml, parse_extension, element_text};
 use guid::GuidBuilder;
 use image::{Image, ImageBuilder};
 use item::{Item, ItemBuilder};
+use mailchecker;
 use quick_xml::reader::Reader;
 use quick_xml::writer::Writer;
 use quick_xml::events::{Event, BytesStart, BytesEnd};
@@ -1896,6 +1897,22 @@ impl ChannelBuilder {
 
         if let Some(ref docs) = self.docs {
             Url::parse(docs.as_str())?;
+        }
+
+        if let Some(ref managing_editor) = self.managing_editor {
+            let email: Vec<&str> = managing_editor.split(' ').collect();
+            if !mailchecker::is_valid(email.get(0).unwrap()) {
+                let message = "Managing Editor contains an invalid or disposable email address.";
+                return Err(Error::Validation(message.to_string()));
+            }
+        }
+
+        if let Some(ref webmaster) = self.webmaster {
+            let email: Vec<&str> = webmaster.split(' ').collect();
+            if !mailchecker::is_valid(email.get(0).unwrap()) {
+                let message = "Webmaster contains an invalid or disposable email address.";
+                return Err(Error::Validation(message.to_string()));
+            }
         }
 
         for day in self.skip_days.as_slice() {

--- a/src/image.rs
+++ b/src/image.rs
@@ -48,7 +48,7 @@ impl Image {
     ///
     /// assert_eq!(url, image.url());
     /// ```
-    pub fn url(&self) -> &str() {
+    pub fn url(&self) -> &str {
         self.url.as_str()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@
 //! * Ensures that the integer properties are within their valid range according to the RSS 2.0
 //! specification
 //! * Ensures that URL properties can be parsed
+//! * Ensures that email is valid and does not come from a disposable email service
 //! * Ensures that string properties where only certain values are allowed fall within those
 //! valid values
 //!
@@ -129,6 +130,7 @@
 extern crate quick_xml;
 extern crate chrono;
 extern crate url;
+extern crate mailchecker;
 extern crate mime;
 
 #[cfg(feature = "from_url")]

--- a/tests/data/rss2sample.xml
+++ b/tests/data/rss2sample.xml
@@ -9,8 +9,8 @@
 		<lastBuildDate>Tue, 10 Jun 2003 09:41:01 GMT</lastBuildDate>
 		<docs>http://blogs.law.harvard.edu/tech/rss</docs>
 		<generator>Weblog Editor 2.0</generator>
-		<managingEditor>editor@example.com</managingEditor>
-		<webMaster>webmaster@example.com</webMaster>
+		<managingEditor>editor@jupiterbroadcasting.com (Editor)</managingEditor>
+		<webMaster>webmaster@jupiterbroadcasting.com</webMaster>
 		<item>
 			<title>Star City</title>
 			<link>http://liftoff.msfc.nasa.gov/news/2003/news-starcity.asp</link>


### PR DESCRIPTION
Add email validation by means of mailchecker for webmaster and managingEditor in channel and author in item.