### PR TITLE
Format using rustfmt-nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: rust
+cache: cargo
 sudo: false
 
 rust:
@@ -7,15 +8,17 @@ rust:
   - stable
 
 before_script:
-  - pip install -v 'travis-cargo<0.2' --user
-  - (cargo install rustfmt || true)
   - export PATH=$HOME/.cargo/bin:$HOME/.local/bin:$PATH
+  - pip install -v 'travis-cargo<0.2' --user
+  - travis-cargo --only nightly install rustfmt-nightly -- --force
+
 script:
   - |
-      cargo fmt -- --write-mode=diff &&
+      travis-cargo --only nighlty fmt -- --write-mode=diff &&
       cargo build --features from_url &&
       cargo test --features from_url &&
       travis-cargo --only stable doc
+
 after_success:
   - travis-cargo --only stable doc-upload
 

--- a/src/category.rs
+++ b/src/category.rs
@@ -107,9 +107,8 @@ impl ToXml for Category {
             element.push_attribute(("domain", &**domain));
         }
         writer.write_event(Event::Start(element))?;
-        writer.write_event(
-            Event::Text(BytesText::borrowed(self.name.as_bytes())),
-        )?;
+        writer
+            .write_event(Event::Text(BytesText::borrowed(self.name.as_bytes())))?;
         writer.write_event(Event::End(BytesEnd::borrowed(name)))?;
         Ok(())
     }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1310,13 +1310,13 @@ impl ToXml for Channel {
     fn to_xml<W: ::std::io::Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"channel";
 
-        writer.write_event(
-            Event::Start(BytesStart::borrowed(name, name.len())),
-        )?;
+        writer
+            .write_event(Event::Start(BytesStart::borrowed(name, name.len())))?;
 
         writer.write_text_element(b"title", &self.title)?;
         writer.write_text_element(b"link", &self.link)?;
-        writer.write_text_element(b"description", &self.description)?;
+        writer
+            .write_text_element(b"description", &self.description)?;
 
         if let Some(language) = self.language.as_ref() {
             writer.write_text_element(b"language", language)?;
@@ -1327,10 +1327,8 @@ impl ToXml for Channel {
         }
 
         if let Some(managing_editor) = self.managing_editor.as_ref() {
-            writer.write_text_element(
-                b"managingEditor",
-                managing_editor,
-            )?;
+            writer
+                .write_text_element(b"managingEditor", managing_editor)?;
         }
 
         if let Some(webmaster) = self.webmaster.as_ref() {
@@ -1342,7 +1340,8 @@ impl ToXml for Channel {
         }
 
         if let Some(last_build_date) = self.last_build_date.as_ref() {
-            writer.write_text_element(b"lastBuildDate", last_build_date)?;
+            writer
+                .write_text_element(b"lastBuildDate", last_build_date)?;
         }
 
         writer.write_objects(&self.categories)?;
@@ -1377,9 +1376,8 @@ impl ToXml for Channel {
 
         if !self.skip_hours.is_empty() {
             let name = b"skipHours";
-            writer.write_event(
-                Event::Start(BytesStart::borrowed(name, name.len())),
-            )?;
+            writer
+                .write_event(Event::Start(BytesStart::borrowed(name, name.len())))?;
             for hour in &self.skip_hours {
                 writer.write_text_element(b"hour", hour)?;
             }
@@ -1388,9 +1386,8 @@ impl ToXml for Channel {
 
         if !self.skip_days.is_empty() {
             let name = b"skipDays";
-            writer.write_event(
-                Event::Start(BytesStart::borrowed(name, name.len())),
-            )?;
+            writer
+                .write_event(Event::Start(BytesStart::borrowed(name, name.len())))?;
             for day in &self.skip_days {
                 writer.write_text_element(b"day", day)?;
             }

--- a/src/extension/dublincore.rs
+++ b/src/extension/dublincore.rs
@@ -153,27 +153,19 @@ impl DublinCoreExtension {
 
 impl ToXml for DublinCoreExtension {
     fn to_xml<W: ::std::io::Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
-        writer.write_text_elements(
-            b"dc:contributor",
-            &self.contributors,
-        )?;
+        writer
+            .write_text_elements(b"dc:contributor", &self.contributors)?;
         writer.write_text_elements(b"dc:coverage", &self.coverages)?;
         writer.write_text_elements(b"dc:creator", &self.creators)?;
         writer.write_text_elements(b"dc:date", &self.dates)?;
-        writer.write_text_elements(
-            b"dc:description",
-            &self.descriptions,
-        )?;
+        writer
+            .write_text_elements(b"dc:description", &self.descriptions)?;
         writer.write_text_elements(b"dc:format", &self.formats)?;
-        writer.write_text_elements(
-            b"dc:identifier",
-            &self.identifiers,
-        )?;
+        writer
+            .write_text_elements(b"dc:identifier", &self.identifiers)?;
         writer.write_text_elements(b"dc:language", &self.languages)?;
-        writer.write_text_elements(
-            b"dc:publisher",
-            &self.publishers,
-        )?;
+        writer
+            .write_text_elements(b"dc:publisher", &self.publishers)?;
         writer.write_text_elements(b"dc:relation", &self.relations)?;
         writer.write_text_elements(b"dc:rights", &self.rights)?;
         writer.write_text_elements(b"dc:source", &self.sources)?;

--- a/src/extension/itunes/itunes_channel_extension.rs
+++ b/src/extension/itunes/itunes_channel_extension.rs
@@ -425,10 +425,8 @@ impl ToXml for ITunesChannelExtension {
         }
 
         if let Some(new_feed_url) = self.new_feed_url.as_ref() {
-            writer.write_text_element(
-                b"itunes:new-feed-url",
-                new_feed_url,
-            )?;
+            writer
+                .write_text_element(b"itunes:new-feed-url", new_feed_url)?;
         }
 
         if let Some(owner) = self.owner.as_ref() {

--- a/src/extension/itunes/itunes_item_extension.rs
+++ b/src/extension/itunes/itunes_item_extension.rs
@@ -377,10 +377,8 @@ impl ToXml for ITunesItemExtension {
         }
 
         if let Some(closed_captioned) = self.closed_captioned.as_ref() {
-            writer.write_text_element(
-                b"itunes:isClosedCaptioned",
-                closed_captioned,
-            )?;
+            writer
+                .write_text_element(b"itunes:isClosedCaptioned", closed_captioned)?;
         }
 
         if let Some(order) = self.order.as_ref() {

--- a/src/extension/itunes/itunes_owner.rs
+++ b/src/extension/itunes/itunes_owner.rs
@@ -83,9 +83,8 @@ impl ToXml for ITunesOwner {
     fn to_xml<W: ::std::io::Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"itunes:owner";
 
-        writer.write_event(
-            Event::Start(BytesStart::borrowed(name, name.len())),
-        )?;
+        writer
+            .write_event(Event::Start(BytesStart::borrowed(name, name.len())))?;
 
         if let Some(name) = self.name.as_ref() {
             writer.write_text_element(b"name", name)?;

--- a/src/extension/itunes/mod.rs
+++ b/src/extension/itunes/mod.rs
@@ -81,12 +81,14 @@ fn parse_owner(map: &mut HashMap<String, Vec<Extension>>) -> Result<Option<ITune
         None => return Ok(None),
     };
 
-    let name = element.children.remove("name").and_then(
-        |mut v| v.remove(0).value,
-    );
-    let email = element.children.remove("email").and_then(
-        |mut v| v.remove(0).value,
-    );
+    let name = element
+        .children
+        .remove("name")
+        .and_then(|mut v| v.remove(0).value);
+    let email = element
+        .children
+        .remove("email")
+        .and_then(|mut v| v.remove(0).value);
 
     Ok(Some(
         ITunesOwnerBuilder::default()

--- a/src/extension/mod.rs
+++ b/src/extension/mod.rs
@@ -69,18 +69,16 @@ impl ToXml for Extension {
         writer.write_event(Event::Start(element))?;
 
         if let Some(value) = self.value.as_ref() {
-            writer.write_event(
-                Event::Text(BytesText::borrowed(value.as_bytes())),
-            )?;
+            writer
+                .write_event(Event::Text(BytesText::borrowed(value.as_bytes())))?;
         }
 
         for extension in self.children.values().flat_map(|extensions| extensions) {
             extension.to_xml(writer)?;
         }
 
-        writer.write_event(
-            Event::End(BytesEnd::borrowed(self.name.as_bytes())),
-        )?;
+        writer
+            .write_event(Event::End(BytesEnd::borrowed(self.name.as_bytes())))?;
         Ok(())
     }
 }
@@ -163,9 +161,9 @@ pub fn remove_extension_value(
     map: &mut HashMap<String, Vec<Extension>>,
     key: &str,
 ) -> Option<String> {
-    map.remove(key).map(|mut v| v.remove(0)).and_then(
-        |ext| ext.value,
-    )
+    map.remove(key)
+        .map(|mut v| v.remove(0))
+        .and_then(|ext| ext.value)
 }
 
 /// Get a reference to all values for the extensions with the specified key.

--- a/src/guid.rs
+++ b/src/guid.rs
@@ -129,9 +129,8 @@ impl ToXml for Guid {
 
         writer.write_event(Event::Start(element))?;
 
-        writer.write_event(Event::Text(
-            BytesText::borrowed(self.value.as_bytes()),
-        ))?;
+        writer
+            .write_event(Event::Text(BytesText::borrowed(self.value.as_bytes())))?;
 
         writer.write_event(Event::End(BytesEnd::borrowed(name)))?;
         Ok(())

--- a/src/image.rs
+++ b/src/image.rs
@@ -213,9 +213,8 @@ impl ToXml for Image {
     fn to_xml<W: ::std::io::Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"image";
 
-        writer.write_event(
-            Event::Start(BytesStart::borrowed(name, name.len())),
-        )?;
+        writer
+            .write_event(Event::Start(BytesStart::borrowed(name, name.len())))?;
 
         writer.write_text_element(b"url", &self.url)?;
         writer.write_text_element(b"title", &self.title)?;

--- a/src/item.rs
+++ b/src/item.rs
@@ -477,9 +477,8 @@ impl ToXml for Item {
     fn to_xml<W: ::std::io::Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"item";
 
-        writer.write_event(
-            Event::Start(BytesStart::borrowed(name, name.len())),
-        )?;
+        writer
+            .write_event(Event::Start(BytesStart::borrowed(name, name.len())))?;
 
         if let Some(title) = self.title.as_ref() {
             writer.write_text_element(b"title", title)?;

--- a/src/textinput.rs
+++ b/src/textinput.rs
@@ -156,12 +156,12 @@ impl ToXml for TextInput {
     fn to_xml<W: ::std::io::Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"textInput";
 
-        writer.write_event(
-            Event::Start(BytesStart::borrowed(name, name.len())),
-        )?;
+        writer
+            .write_event(Event::Start(BytesStart::borrowed(name, name.len())))?;
 
         writer.write_text_element(b"title", &self.title)?;
-        writer.write_text_element(b"description", &self.description)?;
+        writer
+            .write_text_element(b"description", &self.description)?;
         writer.write_text_element(b"name", &self.name)?;
         writer.write_text_element(b"link", &self.link)?;
 

--- a/src/toxml.rs
+++ b/src/toxml.rs
@@ -53,12 +53,8 @@ impl<W: ::std::io::Write> WriterExt for Writer<W> {
         text: T,
     ) -> Result<(), XmlError> {
         let name = name.as_ref();
-        self.write_event(
-            Event::Start(BytesStart::borrowed(name, name.len())),
-        )?;
-        self.write_event(
-            Event::Text(BytesText::borrowed(text.as_ref())),
-        )?;
+        self.write_event(Event::Start(BytesStart::borrowed(name, name.len())))?;
+        self.write_event(Event::Text(BytesText::borrowed(text.as_ref())))?;
         self.write_event(Event::End(BytesEnd::borrowed(name)))?;
         Ok(())
     }
@@ -81,12 +77,8 @@ impl<W: ::std::io::Write> WriterExt for Writer<W> {
         text: T,
     ) -> Result<(), XmlError> {
         let name = name.as_ref();
-        self.write_event(
-            Event::Start(BytesStart::borrowed(name, name.len())),
-        )?;
-        self.write_event(
-            Event::CData(BytesText::borrowed(text.as_ref())),
-        )?;
+        self.write_event(Event::Start(BytesStart::borrowed(name, name.len())))?;
+        self.write_event(Event::CData(BytesText::borrowed(text.as_ref())))?;
         self.write_event(Event::End(BytesEnd::borrowed(name)))?;
         Ok(())
     }

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -67,7 +67,7 @@ fn read_rss091() {
         item.description(),
         Some(
             "WorldOS is a framework on which to build programs that work like Freenet or \
-                    Gnutella -allowing distributed applications using peer-to-peer routing.",
+             Gnutella -allowing distributed applications using peer-to-peer routing.",
         )
     );
 }
@@ -85,9 +85,9 @@ fn read_rss092() {
     assert_eq!(
         channel.description(),
         "A high-fidelity Grateful Dead song every day. This is where we're experimenting \
-               with enclosures on RSS news items that download when you're not using your \
-               computer. If it works (it will) it will be the end of the Click-And-Wait \
-               multimedia experience on the Internet."
+         with enclosures on RSS news items that download when you're not using your \
+         computer. If it works (it will) it will be the end of the Click-And-Wait \
+         multimedia experience on the Internet."
     );
     assert_eq!(
         channel.last_build_date(),
@@ -117,13 +117,13 @@ fn read_rss092() {
         item.description(),
         Some(
             "It's been a few days since I added a song to the Grateful Dead channel. Now \
-                    that there are all these new Radio users, many of whom are tuned into this \
-                    channel (it's #16 on the hotlist of upstreaming Radio users, there's no way \
-                             of knowing how many non-upstreaming users are subscribing, have to \
-                             do something about this..). Anyway, tonight's song is a live \
-                    version of Weather Report Suite from Dick's Picks Volume 7. It's wistful \
-                    music. Of course a beautiful song, oft-quoted here on Scripting News. <i>A \
-                    little change, the wind and rain.</i>",
+             that there are all these new Radio users, many of whom are tuned into this \
+             channel (it's #16 on the hotlist of upstreaming Radio users, there's no way \
+             of knowing how many non-upstreaming users are subscribing, have to \
+             do something about this..). Anyway, tonight's song is a live \
+             version of Weather Report Suite from Dick's Picks Volume 7. It's wistful \
+             music. Of course a beautiful song, oft-quoted here on Scripting News. <i>A \
+             little change, the wind and rain.</i>",
         )
     );
 
@@ -146,7 +146,7 @@ fn read_rss1() {
     assert_eq!(
         channel.description(),
         "XML.com features a rich mix of information and services \n      \
-               for the XML community."
+         for the XML community."
     );
 
     let image = channel.image().unwrap();
@@ -172,8 +172,8 @@ fn read_rss1() {
         item.description(),
         Some(
             "Processing document inclusions with general XML tools can be \n     \
-                    problematic. This article proposes a way of preserving inclusion \n     \
-                    information through SAX-based processing.",
+             problematic. This article proposes a way of preserving inclusion \n     \
+             information through SAX-based processing.",
         )
     );
 }
@@ -248,17 +248,23 @@ fn read_source() {
     let channel = input.parse::<Channel>().expect("failed to parse xml");
 
     assert_eq!(
-        channel.items().get(0).unwrap().source().as_ref().map(
-            |v| v.url(),
-        ),
+        channel
+            .items()
+            .get(0,)
+            .unwrap()
+            .source()
+            .as_ref()
+            .map(|v| v.url(),),
         Some("http://example.com/feed/")
     );
     assert_eq!(
-        channel.items().get(0).unwrap().source().as_ref().and_then(
-            |v| {
-                v.title()
-            },
-        ),
+        channel
+            .items()
+            .get(0,)
+            .unwrap()
+            .source()
+            .as_ref()
+            .and_then(|v| { v.title() },),
         Some("Feed")
     );
 }
@@ -269,28 +275,44 @@ fn read_guid() {
     let channel = input.parse::<Channel>().expect("failed to parse xml");
 
     assert_eq!(
-        channel.items().get(0).unwrap().guid().as_ref().map(|v| {
-            v.is_permalink()
-        }),
+        channel
+            .items()
+            .get(0)
+            .unwrap()
+            .guid()
+            .as_ref()
+            .map(|v| { v.is_permalink() }),
         Some(false)
     );
     assert_eq!(
-        channel.items().get(0).unwrap().guid().as_ref().map(
-            |v| v.value(),
-        ),
+        channel
+            .items()
+            .get(0,)
+            .unwrap()
+            .guid()
+            .as_ref()
+            .map(|v| v.value(),),
         Some("abc")
     );
 
     assert_eq!(
-        channel.items().get(1).unwrap().guid().as_ref().map(|v| {
-            v.is_permalink()
-        }),
+        channel
+            .items()
+            .get(1)
+            .unwrap()
+            .guid()
+            .as_ref()
+            .map(|v| { v.is_permalink() }),
         Some(true)
     );
     assert_eq!(
-        channel.items().get(1).unwrap().guid().as_ref().map(
-            |v| v.value(),
-        ),
+        channel
+            .items()
+            .get(1,)
+            .unwrap()
+            .guid()
+            .as_ref()
+            .map(|v| v.value(),),
         Some("def")
     );
 }
@@ -301,27 +323,33 @@ fn read_enclosure() {
     let channel = input.parse::<Channel>().expect("failed to parse xml");
 
     assert_eq!(
-        channel.items().get(0).unwrap().enclosure().as_ref().map(
-            |v| {
-                v.url()
-            },
-        ),
+        channel
+            .items()
+            .get(0,)
+            .unwrap()
+            .enclosure()
+            .as_ref()
+            .map(|v| { v.url() },),
         Some("http://example.com/media.mp3")
     );
     assert_eq!(
-        channel.items().get(0).unwrap().enclosure().as_ref().map(
-            |v| {
-                v.length()
-            },
-        ),
+        channel
+            .items()
+            .get(0,)
+            .unwrap()
+            .enclosure()
+            .as_ref()
+            .map(|v| { v.length() },),
         Some("4992349")
     );
     assert_eq!(
-        channel.items().get(0).unwrap().enclosure().as_ref().map(
-            |v| {
-                v.mime_type()
-            },
-        ),
+        channel
+            .items()
+            .get(0,)
+            .unwrap()
+            .enclosure()
+            .as_ref()
+            .map(|v| { v.mime_type() },),
         Some("audio/mpeg")
     );
 }
@@ -558,15 +586,21 @@ fn read_itunes() {
         Some("http://example.com/feed/")
     );
     assert_eq!(
-        channel.itunes_ext().unwrap().owner().as_ref().and_then(
-            |v| v.name(),
-        ),
+        channel
+            .itunes_ext()
+            .unwrap()
+            .owner()
+            .as_ref()
+            .and_then(|v| v.name(),),
         Some("Name")
     );
     assert_eq!(
-        channel.itunes_ext().unwrap().owner().as_ref().and_then(
-            |v| v.email(),
-        ),
+        channel
+            .itunes_ext()
+            .unwrap()
+            .owner()
+            .as_ref()
+            .and_then(|v| v.email(),),
         Some("example@example.com")
     );
     assert_eq!(channel.itunes_ext().unwrap().subtitle(), Some("Subtitle"));
@@ -769,9 +803,12 @@ fn read_dublincore() {
         );
     }
 
-    test_ext(channel.dublin_core_ext().as_ref().expect(
-        "dc extension missing",
-    ));
+    test_ext(
+        channel
+            .dublin_core_ext()
+            .as_ref()
+            .expect("dc extension missing"),
+    );
     test_ext(
         channel
             .items()


### PR DESCRIPTION
`rustfmt` has split in to `rustfmt` and `rustfmt-nightly`, the latter of which only compiles on the nightly toolchain. The nightly version of rustfmt is the one that is actively developed and seems to enforce a better style.