### PR TITLE
Bump dependencies and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ include = ["src/*", "Cargo.toml", "LICENSE-MIT", "LICENSE-APACHE", "README.md"]
 from_url = ["reqwest"]
 
 [dependencies]
-quick-xml = "0.7.3"
-chrono = "0.3"
+quick-xml = "0.8"
+chrono = "0.4"
 url = "1.4"
-mime = "0.2"
+mime = "0.3"
 reqwest = { version = "0.6", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rss"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["James Hurst <jh.jameshurst@gmail.com>", "Corey Farwell <coreyf@rwell.org>", "Chris Palmer <pennstate5013@gmail.com>"]
 description = "Library for serializing the RSS web content syndication format"
 repository = "https://github.com/rust-syndication/rss"


### PR DESCRIPTION
The most notable bump here is chrono since it allows people to use
serde1.0 with the rss library again.