### PR TITLE
update to quick-xml 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ from_url = ["reqwest"]
 validation = ["chrono", "url", "mime"]
 
 [dependencies]
-quick-xml = "0.7.3"
+quick-xml = "0.9.0"
 derive_builder = "0.5"
 chrono = {version = "0.4", optional = true }
 url = { version = "1.4", optional = true }


### PR DESCRIPTION
I've just updated quick-xml to use v0.9.0.
This version includes a PR to escape some characters on Text events: https://github.com/tafia/quick-xml/pull/78

This may close #32 
