### PR TITLE
Consume Channel and return the owned Vector of Items

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ before_script:
 script:
   - |
       travis-cargo --only nighlty fmt -- --write-mode=diff &&
-      cargo build --features "from_url serde validation" &&
-      cargo test --features "from_url serde validation" &&
+      cargo build --release --features "from_url serde validation" &&
+      cargo test --release --features "from_url serde validation" &&
       travis-cargo --only stable doc -- --features "from_url validation serde"
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ rust:
   - beta
   - stable
 
-allow_failures:
-  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
 
 before_script:
   - export PATH=$HOME/.cargo/bin:$HOME/.local/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ rust:
   - beta
   - stable
 
+allow_failures:
+  - nightly
+
 before_script:
   - export PATH=$HOME/.cargo/bin:$HOME/.local/bin:$PATH
   - pip install -v 'travis-cargo<0.2' --user

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -716,6 +716,21 @@ impl Channel {
         &mut self.items
     }
 
+    /// Consume the `Channel` and return a Vector of owned `Item`s.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rss::{Channel, Item};
+    ///
+    /// let mut channel = Channel::default();
+    /// channel.set_items(vec![Item::default()]);
+    /// assert_eq!(channel.items_owned().len(), 1);
+    /// ```
+    pub fn items_owned(self) -> Vec<Item> {
+        self.items
+    }
+
     /// Set the items in this channel.
     ///
     /// # Examples

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -716,7 +716,7 @@ impl Channel {
         &mut self.items
     }
 
-    /// Consume the `Channel` and return a Vector of owned `Item`s.
+    /// Consume the `Channel` and return a vector of `Item`s.
     ///
     /// # Examples
     ///
@@ -725,9 +725,9 @@ impl Channel {
     ///
     /// let mut channel = Channel::default();
     /// channel.set_items(vec![Item::default()]);
-    /// assert_eq!(channel.items_owned().len(), 1);
+    /// assert_eq!(channel.into_items().len(), 1);
     /// ```
-    pub fn items_owned(self) -> Vec<Item> {
+    pub fn into_items(self) -> Vec<Item> {
         self.items
     }
 


### PR DESCRIPTION
This allows to consume the `Channel` and get the owned
vector/slice of `Items`. This can avoid the reallocation/clone
of the whole Items slice in situations where you need to pass
the ownership of the data, like when using futures.

For example the compiler rightfully complains when trying to do the following:

```rust
extern crate rss;
extern crate futures;

use futures::prelude::*;
use futures::stream;

use rss::{Item, Channel};
use std::error::Error;

struct Foo;

fn foo(_item: &Item) -> Box<Future<Item = Foo, Error = Box<Error>>> {
    unimplemented!()
}

fn bar(channel: Channel) -> Box<Future<Item = Vec<Foo>, Error = Box<Error>>> {
    let stream = stream::iter_ok::<_, Box<Error>>(channel.items());
    let results = stream.and_then(|item| foo(item)).collect();
    Box::new(results)
}

fn main() {}
```

Since you can only get a reference to an `Item` the compiler can't guarantee that it will satisfy the `'static` lifetime requirement.  

```sh
error[E0597]: `channel` does not live long enough
  --> src/main.rs:17:51
   |
17 |     let stream = stream::iter_ok::<_, Box<Error>>(channel.items());
   |                                                   ^^^^^^^ borrowed value does not live long enough
...
20 | }
   | - borrowed value only lives until here
   |
   = note: borrowed value must be valid for the static lifetime...

error: aborting due to previous error

error: Could not compile `foo`.
```

A way to get the above example to compile is make the signature of `fn  bar` the following:

```rust
fn bar<'a>(channel: &'a Channel) -> Box<Future<Item = Vec<Foo>, Error = Box<Error>> + 'a > {
```

But that only moves the ownership problem in a higher part of the code, since you can never guarantee that `channel` will live until the `Future` is resolved.