### PR TITLE
Update to reqwest version 0.9.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,7 @@ name = "rss"
 version = "1.5.0"
 authors = ["James Hurst <jh.jameshurst@gmail.com>", "Corey Farwell <coreyf@rwell.org>", "Chris Palmer <pennstate5013@gmail.com>"]
 description = "Library for serializing the RSS web content syndication format"
-repository = "https://github.com/rust-syndication/rss"
-documentation = "https://docs.rs/rss/"
+repository = "https://github.com/rust-syndication/rss" documentation = "https://docs.rs/rss/"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 keywords = ["rss", "feed", "parser", "parsing"]
@@ -24,5 +23,7 @@ derive_builder = "0.5"
 chrono = {version = "0.4", optional = true }
 url = { version = "1.4", optional = true }
 mime = { version = "0.3", optional = true }
-reqwest = { version = "0.8", optional = true }
+reqwest = { version = "0.9", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
+
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ derive_builder = "0.5"
 chrono = {version = "0.4", optional = true }
 url = { version = "1.4", optional = true }
 mime = { version = "0.3", optional = true }
-reqwest = { version = "0.8", optional = true }
+reqwest = { version = "0.9.2", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,8 @@ name = "rss"
 version = "1.5.0"
 authors = ["James Hurst <jh.jameshurst@gmail.com>", "Corey Farwell <coreyf@rwell.org>", "Chris Palmer <pennstate5013@gmail.com>"]
 description = "Library for serializing the RSS web content syndication format"
-repository = "https://github.com/rust-syndication/rss" documentation = "https://docs.rs/rss/"
+repository = "https://github.com/rust-syndication/rss"
+documentation = "https://docs.rs/rss/"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 keywords = ["rss", "feed", "parser", "parsing"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ derive_builder = "0.5"
 chrono = {version = "0.4", optional = true }
 url = { version = "1.4", optional = true }
 mime = { version = "0.3", optional = true }
-reqwest = { version = "0.9", optional = true }
+reqwest = { version = "0.8", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 


### PR DESCRIPTION
Hello,

This is my all-time first pull request, please be kind if I am not following some contribution guidelines. :)

I have updated in the `Cargo.toml` to use the crate `reqwest` version of 0.9.2. 

I have encountered an issue while compiling with my `OpenSSL` 1.1.0 version (I am running ArchLinux).
The problem encountered led that the version 0.8 of `reqwest` crate depended on older versions of the `hyper-tls` crate and so on, till `openssl`, which led to an uncompatibility with my system's version of `OpenSSL `.

Chess.