### PR TITLE
read url to bytes buffer instead of a string

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -922,9 +922,9 @@ impl Channel {
     pub fn from_url(url: &str) -> Result<Channel, Error> {
         use std::io::Read;
 
-        let mut content = String::new();
-        ::reqwest::get(url)?.read_to_string(&mut content)?;
-        Ok(Channel::from_str(content.as_str())?)
+        let mut content = Vec::new();
+        ::reqwest::get(url)?.read_to_end(&mut content)?;
+        Ok(Channel::read_from(&content[..])?)
     }
 
     /// Attempt to read an RSS channel from a reader.


### PR DESCRIPTION
RSS feed can be encoded in different encodings than UTF-8 and the
quick_xml library is capable of handling this feature. The previous
implementation prevented this from working by loading the
response into UTF-8 encoded string, which failed. By using a byte array
instead of the string we can use the feature.