### PR TITLE
Some mirror changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ validation = ["chrono", "url", "mime"]
 
 [dependencies]
 failure = "0.1"
-quick-xml = "0.14"
+quick-xml = "0.15"
 derive_builder = "0.7"
 chrono = {version = "0.4", optional = true }
 url = { version = "1.7", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT/Apache-2.0"
 readme = "README.md"
 keywords = ["rss", "feed", "parser", "parsing"]
 include = ["src/*", "Cargo.toml", "LICENSE-MIT", "LICENSE-APACHE", "README.md"]
+edition = "2018"
 
 [package.metadata.docs.rs]
 all-features = false

--- a/src/category.rs
+++ b/src/category.rs
@@ -13,9 +13,9 @@ use quick_xml::events::attributes::Attributes;
 use quick_xml::Reader;
 use quick_xml::Writer;
 
-use error::Error;
-use toxml::ToXml;
-use util::element_text;
+use crate::error::Error;
+use crate::toxml::ToXml;
+use crate::util::element_text;
 
 /// Represents a category in an RSS feed.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -15,19 +15,19 @@ use quick_xml::events::attributes::Attributes;
 use quick_xml::Reader;
 use quick_xml::Writer;
 
-use category::Category;
-use cloud::Cloud;
-use error::Error;
-use extension::ExtensionMap;
-use extension::dublincore;
-use extension::itunes;
-use extension::syndication;
-use extension::util::{extension_name, parse_extension};
-use image::Image;
-use item::Item;
-use textinput::TextInput;
-use toxml::{ToXml, WriterExt};
-use util::element_text;
+use crate::category::Category;
+use crate::cloud::Cloud;
+use crate::error::Error;
+use crate::extension::ExtensionMap;
+use crate::extension::dublincore;
+use crate::extension::itunes;
+use crate::extension::syndication;
+use crate::extension::util::{extension_name, parse_extension};
+use crate::image::Image;
+use crate::item::Item;
+use crate::textinput::TextInput;
+use crate::toxml::{ToXml, WriterExt};
+use crate::util::element_text;
 
 /// Represents the channel of an RSS feed.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -13,8 +13,8 @@ use quick_xml::events::attributes::Attributes;
 use quick_xml::Reader;
 use quick_xml::Writer;
 
-use error::Error;
-use toxml::ToXml;
+use crate::error::Error;
+use crate::toxml::ToXml;
 
 /// Represents a cloud in an RSS feed.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/enclosure.rs
+++ b/src/enclosure.rs
@@ -13,8 +13,8 @@ use quick_xml::events::attributes::Attributes;
 use quick_xml::Reader;
 use quick_xml::Writer;
 
-use error::Error;
-use toxml::ToXml;
+use crate::error::Error;
+use crate::toxml::ToXml;
 
 /// Represents an enclosure in an RSS item.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,7 +45,7 @@ impl StdError for Error {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             Error::Utf8(ref err) => Some(err),
             Error::Xml(ref err) => StdError::source(err),

--- a/src/extension/dublincore.rs
+++ b/src/extension/dublincore.rs
@@ -11,10 +11,10 @@ use std::io::Write;
 use quick_xml::Error as XmlError;
 use quick_xml::Writer;
 
-use extension::Extension;
-use extension::util::remove_extension_values;
+use crate::extension::Extension;
+use crate::extension::util::remove_extension_values;
 
-use toxml::{ToXml, WriterExt};
+use crate::toxml::{ToXml, WriterExt};
 
 /// The Dublin Core XML namespace.
 pub const NAMESPACE: &str = "http://purl.org/dc/elements/1.1/";

--- a/src/extension/itunes/itunes_category.rs
+++ b/src/extension/itunes/itunes_category.rs
@@ -7,10 +7,11 @@
 
 use std::io::Write;
 
-use quick_xml::Error as XmlError;
 use quick_xml::events::{BytesEnd, BytesStart, Event};
+use quick_xml::Error as XmlError;
 use quick_xml::Writer;
 
+use std::ops::Deref;
 use toxml::ToXml;
 
 /// A category for an iTunes podcast.
@@ -69,8 +70,8 @@ impl ITunesCategory {
     /// category.set_subcategory(Box::new(ITunesCategory::default()));
     /// assert!(category.subcategory().is_some());
     /// ```
-    pub fn subcategory(&self) -> Option<&Box<ITunesCategory>> {
-        self.subcategory.as_ref()
+    pub fn subcategory(&self) -> Option<&ITunesCategory> {
+        self.subcategory.as_ref().map(|x| x.deref())
     }
 
     /// Set the subcategory for this category.

--- a/src/extension/itunes/itunes_category.rs
+++ b/src/extension/itunes/itunes_category.rs
@@ -12,7 +12,7 @@ use quick_xml::Error as XmlError;
 use quick_xml::Writer;
 
 use std::ops::Deref;
-use toxml::ToXml;
+use crate::toxml::ToXml;
 
 /// A category for an iTunes podcast.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/extension/itunes/itunes_channel_extension.rs
+++ b/src/extension/itunes/itunes_channel_extension.rs
@@ -13,10 +13,10 @@ use quick_xml::events::{BytesStart, Event};
 use quick_xml::Writer;
 
 use super::{parse_categories, parse_image, parse_owner};
-use extension::Extension;
-use extension::itunes::{ITunesCategory, ITunesOwner};
-use extension::util::remove_extension_value;
-use toxml::{ToXml, WriterExt};
+use crate::extension::Extension;
+use crate::extension::itunes::{ITunesCategory, ITunesOwner};
+use crate::extension::util::remove_extension_value;
+use crate::toxml::{ToXml, WriterExt};
 
 /// An iTunes channel element extension.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/extension/itunes/itunes_item_extension.rs
+++ b/src/extension/itunes/itunes_item_extension.rs
@@ -13,9 +13,9 @@ use quick_xml::events::{BytesEnd, BytesStart, Event};
 use quick_xml::Writer;
 
 use super::parse_image;
-use extension::Extension;
-use extension::util::remove_extension_value;
-use toxml::{ToXml, WriterExt};
+use crate::extension::Extension;
+use crate::extension::util::remove_extension_value;
+use crate::toxml::{ToXml, WriterExt};
 
 /// An iTunes item element extension.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/extension/itunes/itunes_owner.rs
+++ b/src/extension/itunes/itunes_owner.rs
@@ -11,7 +11,7 @@ use quick_xml::Error as XmlError;
 use quick_xml::events::{BytesEnd, BytesStart, Event};
 use quick_xml::Writer;
 
-use toxml::{ToXml, WriterExt};
+use crate::toxml::{ToXml, WriterExt};
 
 /// The contact information for the owner of an iTunes podcast.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/extension/itunes/mod.rs
+++ b/src/extension/itunes/mod.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashMap;
 
-use extension::Extension;
+use crate::extension::Extension;
 
 mod itunes_category;
 mod itunes_channel_extension;

--- a/src/extension/mod.rs
+++ b/src/extension/mod.rs
@@ -13,7 +13,7 @@ use quick_xml::Error as XmlError;
 use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
 use quick_xml::Writer;
 
-use toxml::ToXml;
+use crate::toxml::ToXml;
 
 /// Types and methods for
 /// [iTunes](https://help.apple.com/itc/podcasts_connect/#/itcb54353390) extensions.

--- a/src/extension/syndication.rs
+++ b/src/extension/syndication.rs
@@ -13,8 +13,8 @@ use std::str::FromStr;
 use quick_xml::Error as XmlError;
 use quick_xml::Writer;
 
-use extension::Extension;
-use toxml::WriterExt;
+use crate::extension::Extension;
+use crate::toxml::WriterExt;
 
 /// The Syndication XML namespace.
 pub const NAMESPACE: &str = "http://purl.org/rss/1.0/modules/syndication/";

--- a/src/extension/util.rs
+++ b/src/extension/util.rs
@@ -13,8 +13,8 @@ use quick_xml::events::Event;
 use quick_xml::events::attributes::Attributes;
 use quick_xml::Reader;
 
-use error::Error;
-use extension::{Extension, ExtensionMap};
+use crate::error::Error;
+use crate::extension::{Extension, ExtensionMap};
 
 pub fn extension_name(element_name: &[u8]) -> Option<(&[u8], &[u8])> {
     let mut split = element_name.splitn(2, |b| *b == b':');

--- a/src/guid.rs
+++ b/src/guid.rs
@@ -13,9 +13,9 @@ use quick_xml::events::attributes::Attributes;
 use quick_xml::Reader;
 use quick_xml::Writer;
 
-use error::Error;
-use toxml::ToXml;
-use util::element_text;
+use crate::error::Error;
+use crate::toxml::ToXml;
+use crate::util::element_text;
 
 /// Represents the GUID of an RSS item.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/image.rs
+++ b/src/image.rs
@@ -13,9 +13,9 @@ use quick_xml::events::attributes::Attributes;
 use quick_xml::Reader;
 use quick_xml::Writer;
 
-use error::Error;
-use toxml::{ToXml, WriterExt};
-use util::element_text;
+use crate::error::Error;
+use crate::toxml::{ToXml, WriterExt};
+use crate::util::element_text;
 
 /// Represents an image in an RSS feed.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/item.rs
+++ b/src/item.rs
@@ -13,17 +13,17 @@ use quick_xml::events::attributes::Attributes;
 use quick_xml::Reader;
 use quick_xml::Writer;
 
-use category::Category;
-use enclosure::Enclosure;
-use error::Error;
-use extension::ExtensionMap;
-use extension::dublincore;
-use extension::itunes;
-use extension::util::{extension_name, parse_extension};
-use guid::Guid;
-use source::Source;
-use toxml::{ToXml, WriterExt};
-use util::element_text;
+use crate::category::Category;
+use crate::enclosure::Enclosure;
+use crate::error::Error;
+use crate::extension::ExtensionMap;
+use crate::extension::dublincore;
+use crate::extension::itunes;
+use crate::extension::util::{extension_name, parse_extension};
+use crate::guid::Guid;
+use crate::source::Source;
+use crate::toxml::{ToXml, WriterExt};
+use crate::util::element_text;
 use std::collections::HashMap;
 
 /// Represents an item in an RSS feed.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,14 +123,14 @@ pub mod extension;
 #[cfg(feature = "validation")]
 pub mod validation;
 
-pub use channel::{Channel, ChannelBuilder};
-pub use category::{Category, CategoryBuilder};
-pub use cloud::{Cloud, CloudBuilder};
-pub use enclosure::{Enclosure, EnclosureBuilder};
-pub use guid::{Guid, GuidBuilder};
-pub use image::{Image, ImageBuilder};
-pub use item::{Item, ItemBuilder};
-pub use source::{Source, SourceBuilder};
-pub use textinput::{TextInput, TextInputBuilder};
+pub use crate::channel::{Channel, ChannelBuilder};
+pub use crate::category::{Category, CategoryBuilder};
+pub use crate::cloud::{Cloud, CloudBuilder};
+pub use crate::enclosure::{Enclosure, EnclosureBuilder};
+pub use crate::guid::{Guid, GuidBuilder};
+pub use crate::image::{Image, ImageBuilder};
+pub use crate::item::{Item, ItemBuilder};
+pub use crate::source::{Source, SourceBuilder};
+pub use crate::textinput::{TextInput, TextInputBuilder};
 
-pub use error::Error;
+pub use crate::error::Error;

--- a/src/source.rs
+++ b/src/source.rs
@@ -13,9 +13,9 @@ use quick_xml::events::attributes::Attributes;
 use quick_xml::Reader;
 use quick_xml::Writer;
 
-use error::Error;
-use toxml::ToXml;
-use util::element_text;
+use crate::error::Error;
+use crate::toxml::ToXml;
+use crate::util::element_text;
 
 /// Represents the source of an RSS item.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/textinput.rs
+++ b/src/textinput.rs
@@ -13,9 +13,9 @@ use quick_xml::events::attributes::Attributes;
 use quick_xml::Reader;
 use quick_xml::Writer;
 
-use error::Error;
-use toxml::{ToXml, WriterExt};
-use util::element_text;
+use crate::error::Error;
+use crate::toxml::{ToXml, WriterExt};
+use crate::util::element_text;
 
 /// Represents a text input for an RSS channel.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,7 +10,7 @@ use std::io::BufRead;
 use quick_xml::events::Event;
 use quick_xml::Reader;
 
-use error::Error;
+use crate::error::Error;
 
 pub fn element_text<R: BufRead>(reader: &mut Reader<R>) -> Result<Option<String>, Error> {
     let mut content: Option<String> = None;

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -12,8 +12,8 @@ use std::num::ParseIntError;
 
 use chrono::DateTime;
 use chrono::ParseError as DateParseError;
-use mime::Mime;
 use mime::FromStrError as MimeParseError;
+use mime::Mime;
 use url::ParseError as UrlParseError;
 use url::Url;
 
@@ -45,7 +45,7 @@ impl StdError for ValidationError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             ValidationError::DateParsing(ref err) => Some(err),
             ValidationError::IntParsing(ref err) => Some(err),

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -17,7 +17,7 @@ use mime::Mime;
 use url::ParseError as UrlParseError;
 use url::Url;
 
-use {Category, Channel, Cloud, Enclosure, Image, Item, Source, TextInput};
+use crate::{Category, Channel, Cloud, Enclosure, Image, Item, Source, TextInput};
 
 #[derive(Debug)]
 /// Errors that occur during validation.


### PR DESCRIPTION
1. upgrade dependencies(quick-xml): 0,14 -> 0,15
2. work with rustfmt and clippy
3. migrate to 2018 edition