### PR TITLE
Remove dependency on failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ from_url = ["reqwest"]
 validation = ["chrono", "url", "mime"]
 
 [dependencies]
-failure = "0.1"
 quick-xml = { version = "0.17", features = ["encoding"] }
 derive_builder = "0.9"
 chrono = {version = "0.4", optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,20 +31,7 @@ pub enum Error {
 }
 
 impl StdError for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::Utf8(ref err) => err.description(),
-            Error::Xml(_) => "xml error",
-            Error::InvalidStartTag => "the input did not begin with an rss tag",
-            Error::Eof => "reached end of input without finding a complete channel",
-            #[cfg(feature = "from_url")]
-            Error::UrlRequest(ref err) => err.description(),
-            #[cfg(feature = "from_url")]
-            Error::Io(ref err) => err.description(),
-        }
-    }
-
-    fn cause(&self) -> Option<&dyn StdError> {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match *self {
             Error::Utf8(ref err) => Some(err),
             Error::Xml(ref err) => Some(err),
@@ -60,14 +47,14 @@ impl StdError for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Utf8(ref err) => err.fmt(f),
-            Error::Xml(ref err) => err.fmt(f),
+            Error::Utf8(ref err) => fmt::Display::fmt(err, f),
+            Error::Xml(ref err) => fmt::Display::fmt(err, f),
             Error::InvalidStartTag => write!(f, "the input did not begin with an rss tag"),
             Error::Eof => write!(f, "reached end of input without finding a complete channel"),
             #[cfg(feature = "from_url")]
-            Error::UrlRequest(ref err) => err.fmt(f),
+            Error::UrlRequest(ref err) => fmt::Display::fmt(err, f),
             #[cfg(feature = "from_url")]
-            Error::Io(ref err) => err.fmt(f),
+            Error::Io(ref err) => fmt::Display::fmt(err, f),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,7 +9,6 @@ use std::error::Error as StdError;
 use std::fmt;
 use std::str::Utf8Error;
 
-use failure::{self, Fail};
 use quick_xml::Error as XmlError;
 
 #[derive(Debug)]
@@ -18,7 +17,7 @@ pub enum Error {
     /// An error while converting bytes to UTF8.
     Utf8(Utf8Error),
     /// An XML parsing error.
-    Xml(failure::Compat<XmlError>),
+    Xml(XmlError),
     /// The input didn't begin with an opening `<rss>` tag.
     InvalidStartTag,
     /// The end of the input was reached without finding a complete channel element.
@@ -48,7 +47,7 @@ impl StdError for Error {
     fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             Error::Utf8(ref err) => Some(err),
-            Error::Xml(ref err) => StdError::source(err),
+            Error::Xml(ref err) => Some(err),
             Error::InvalidStartTag | Error::Eof => None,
             #[cfg(feature = "from_url")]
             Error::UrlRequest(ref err) => Some(err),
@@ -75,7 +74,7 @@ impl fmt::Display for Error {
 
 impl From<XmlError> for Error {
     fn from(err: XmlError) -> Error {
-        Error::Xml(err.compat())
+        Error::Xml(err)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,6 @@
 #[macro_use]
 extern crate derive_builder;
 
-extern crate failure;
 extern crate quick_xml;
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
This used to be a dependency of `quick-xml`, but it was removed in version 0.17 by tafia/quick-xml#170. `rss` depended on it previously to work with `quick-xml::Error`, but this is no longer necessary. Keeping it means `rss` is pulling in a lot of other unnecessary dependencies.

This change also updates to stop using the deprecated parts of std's `Error` trait.