### PR TITLE
Add a default builders feature that can be disabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,9 @@ before_script:
 script:
   - |
       travis-cargo --only nighlty fmt -- --write-mode=diff &&
-      cargo build --release --features "from_url serde validation" &&
-      cargo test --release --features "from_url serde validation" &&
+      cargo build --release --no-default-features &&
+      cargo build --release --all-features &&
+      cargo test --release --all-features &&
       travis-cargo --only stable doc -- --features "from_url validation serde"
 
 after_success:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,14 @@ edition = "2018"
 all-features = false
 
 [features]
+default = ["builders"]
+builders = ["derive_builder"]
 from_url = ["reqwest"]
 validation = ["chrono", "url", "mime"]
 
 [dependencies]
 quick-xml = { version = "0.17", features = ["encoding"] }
-derive_builder = "0.9"
+derive_builder = { version = "0.9", optional = true }
 chrono = {version = "0.4", optional = true }
 url = { version = "2.1", optional = true }
 mime = { version = "0.3", optional = true }

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ let string = channel.to_string(); // convert the channel to a string
 
 Builder methods are provided to assist in the creation of channels.
 
+**Note**: This requires the `builders` feature, which is enabled by default.
+
 ```rust
 use rss::ChannelBuilder;
 

--- a/src/category.rs
+++ b/src/category.rs
@@ -19,8 +19,9 @@ use crate::util::element_text;
 
 /// Represents a category in an RSS feed.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Default, Clone, PartialEq, Builder)]
-#[builder(setter(into), default)]
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "builders", derive(Builder))]
+#[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Category {
     /// The name of the category.
     name: String,

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -31,8 +31,9 @@ use crate::util::element_text;
 
 /// Represents the channel of an RSS feed.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Default, Clone, PartialEq, Builder)]
-#[builder(setter(into), default)]
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "builders", derive(Builder))]
+#[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Channel {
     /// The name of the channel.
     title: String,

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -18,8 +18,9 @@ use crate::toxml::ToXml;
 
 /// Represents a cloud in an RSS feed.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Default, Clone, PartialEq, Builder)]
-#[builder(setter(into), default)]
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "builders", derive(Builder))]
+#[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Cloud {
     /// The domain to register with.
     domain: String,

--- a/src/enclosure.rs
+++ b/src/enclosure.rs
@@ -18,8 +18,9 @@ use crate::toxml::ToXml;
 
 /// Represents an enclosure in an RSS item.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Default, Clone, PartialEq, Builder)]
-#[builder(setter(into), default)]
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "builders", derive(Builder))]
+#[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Enclosure {
     /// The URL of the enclosure.
     url: String,

--- a/src/extension/dublincore.rs
+++ b/src/extension/dublincore.rs
@@ -21,8 +21,9 @@ pub const NAMESPACE: &str = "http://purl.org/dc/elements/1.1/";
 
 /// A Dublin Core element extension.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Default, Clone, PartialEq, Builder)]
-#[builder(setter(into), default)]
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "builders", derive(Builder))]
+#[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct DublinCoreExtension {
     /// An entity responsible for making contributions to the resource.
     contributors: Vec<String>,

--- a/src/extension/itunes/itunes_category.rs
+++ b/src/extension/itunes/itunes_category.rs
@@ -16,8 +16,9 @@ use crate::toxml::ToXml;
 
 /// A category for an iTunes podcast.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Default, Clone, PartialEq, Builder)]
-#[builder(setter(into), default)]
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "builders", derive(Builder))]
+#[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct ITunesCategory {
     /// The name of the category.
     text: String,

--- a/src/extension/itunes/itunes_channel_extension.rs
+++ b/src/extension/itunes/itunes_channel_extension.rs
@@ -20,8 +20,9 @@ use crate::toxml::{ToXml, WriterExt};
 
 /// An iTunes channel element extension.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Default, Clone, PartialEq, Builder)]
-#[builder(setter(into), default)]
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "builders", derive(Builder))]
+#[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct ITunesChannelExtension {
     /// The author of the podcast.
     author: Option<String>,

--- a/src/extension/itunes/itunes_item_extension.rs
+++ b/src/extension/itunes/itunes_item_extension.rs
@@ -19,8 +19,9 @@ use crate::toxml::{ToXml, WriterExt};
 
 /// An iTunes item element extension.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Default, Clone, PartialEq, Builder)]
-#[builder(setter(into), default)]
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "builders", derive(Builder))]
+#[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct ITunesItemExtension {
     /// The author of the podcast episode.
     author: Option<String>,

--- a/src/extension/itunes/itunes_owner.rs
+++ b/src/extension/itunes/itunes_owner.rs
@@ -15,8 +15,9 @@ use crate::toxml::{ToXml, WriterExt};
 
 /// The contact information for the owner of an iTunes podcast.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Default, Clone, PartialEq, Builder)]
-#[builder(setter(into), default)]
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "builders", derive(Builder))]
+#[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct ITunesOwner {
     /// The name of the owner.
     name: Option<String>,

--- a/src/extension/mod.rs
+++ b/src/extension/mod.rs
@@ -32,8 +32,9 @@ pub type ExtensionMap = HashMap<String, HashMap<String, Vec<Extension>>>;
 
 /// A namespaced extension such as iTunes or Dublin Core.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Default, Clone, PartialEq, Builder)]
-#[builder(setter(into), default)]
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "builders", derive(Builder))]
+#[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Extension {
     /// The qualified name of the extension element.
     name: String,

--- a/src/extension/syndication.rs
+++ b/src/extension/syndication.rs
@@ -64,8 +64,9 @@ impl fmt::Display for UpdatePeriod {
 
 /// An RSS syndication element extension.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Builder)]
-#[builder(setter(into), default)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "builders", derive(Builder))]
+#[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct SyndicationExtension {
     /// The refresh period for this channel
     period: UpdatePeriod,

--- a/src/guid.rs
+++ b/src/guid.rs
@@ -19,8 +19,9 @@ use crate::util::element_text;
 
 /// Represents the GUID of an RSS item.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Builder)]
-#[builder(setter(into), default)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "builders", derive(Builder))]
+#[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Guid {
     /// The value of the GUID.
     value: String,

--- a/src/image.rs
+++ b/src/image.rs
@@ -19,8 +19,9 @@ use crate::util::element_text;
 
 /// Represents an image in an RSS feed.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Default, Clone, PartialEq, Builder)]
-#[builder(setter(into), default)]
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "builders", derive(Builder))]
+#[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Image {
     /// The URL of the image.
     url: String,

--- a/src/item.rs
+++ b/src/item.rs
@@ -28,8 +28,9 @@ use std::collections::HashMap;
 
 /// Represents an item in an RSS feed.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Default, Clone, PartialEq, Builder)]
-#[builder(setter(into), default)]
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "builders", derive(Builder))]
+#[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Item {
     /// The title of the item.
     title: Option<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,8 @@
 //!
 //! Builder methods are provided to assist in the creation of channels.
 //!
+//! **Note**: This requires the `builders` feature, which is enabled by default.
+//!
 //! ```
 //! use rss::ChannelBuilder;
 //!
@@ -82,6 +84,7 @@
 //! channel.validate().unwrap();
 //! ```
 
+#[cfg(feature = "builders")]
 #[macro_use]
 extern crate derive_builder;
 
@@ -122,14 +125,32 @@ pub mod extension;
 #[cfg(feature = "validation")]
 pub mod validation;
 
-pub use crate::channel::{Channel, ChannelBuilder};
-pub use crate::category::{Category, CategoryBuilder};
-pub use crate::cloud::{Cloud, CloudBuilder};
-pub use crate::enclosure::{Enclosure, EnclosureBuilder};
-pub use crate::guid::{Guid, GuidBuilder};
-pub use crate::image::{Image, ImageBuilder};
-pub use crate::item::{Item, ItemBuilder};
-pub use crate::source::{Source, SourceBuilder};
-pub use crate::textinput::{TextInput, TextInputBuilder};
+pub use crate::channel::Channel;
+#[cfg(feature = "builders")]
+pub use crate::channel::ChannelBuilder;
+pub use crate::category::Category;
+#[cfg(feature = "builders")]
+pub use crate::category::CategoryBuilder;
+pub use crate::cloud::Cloud;
+#[cfg(feature = "builders")]
+pub use crate::cloud::CloudBuilder;
+pub use crate::enclosure::Enclosure;
+#[cfg(feature = "builders")]
+pub use crate::enclosure::EnclosureBuilder;
+pub use crate::guid::Guid;
+#[cfg(feature = "builders")]
+pub use crate::guid::GuidBuilder;
+pub use crate::image::Image;
+#[cfg(feature = "builders")]
+pub use crate::image::ImageBuilder;
+pub use crate::item::Item;
+#[cfg(feature = "builders")]
+pub use crate::item::ItemBuilder;
+pub use crate::source::Source;
+#[cfg(feature = "builders")]
+pub use crate::source::SourceBuilder;
+pub use crate::textinput::TextInput;
+#[cfg(feature = "builders")]
+pub use crate::textinput::TextInputBuilder;
 
 pub use crate::error::Error;

--- a/src/source.rs
+++ b/src/source.rs
@@ -19,8 +19,9 @@ use crate::util::element_text;
 
 /// Represents the source of an RSS item.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Default, Clone, PartialEq, Builder)]
-#[builder(setter(into), default)]
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "builders", derive(Builder))]
+#[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Source {
     /// The URL of the source.
     url: String,

--- a/src/textinput.rs
+++ b/src/textinput.rs
@@ -19,8 +19,9 @@ use crate::util::element_text;
 
 /// Represents a text input for an RSS channel.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Default, Clone, PartialEq, Builder)]
-#[builder(setter(into), default)]
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "builders", derive(Builder))]
+#[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct TextInput {
     /// The label of the Submit button for the text input.
     title: String,


### PR DESCRIPTION
The `rss` crate depends on `derive_builder` to generate convenient builders for creating the contents of an rss feed. However, for users that only want to parse an rss feed, not create their own, this results in 12 additional dependencies, some of which are pretty heavy.

This change adds a `builders` feature to the crate which is enabled by default. When disabled, though, none of the builders are included in the crate, and the `derive_builder` dependency is omitted. This should be a backwards-compatible way that users can opt for having lighter dependencies.

While more features and cfg attributes always add complexity to code, I think this comes out pretty manageable. I added a step to the travis tests to ensure that the crate compiles with and without the feature.