### PR TITLE
update quick-xml version to 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ builders = ["derive_builder"]
 validation = ["chrono", "url", "mime"]
 
 [dependencies]
-quick-xml = { version = "0.17", features = ["encoding"] }
+quick-xml = { version = "0.18", features = ["encoding"] }
 derive_builder = { version = "0.9", optional = true }
 chrono = {version = "0.4", optional = true }
 url = { version = "2.1", optional = true }


### PR DESCRIPTION
The version of `quick-xml` in [atom-syndication](https://github.com/rust-syndication/atom) is `0.18`. So I thought to bump the version here to match it over there.