### PR TITLE
fix clippy warnings

### DIFF
--- a/src/category.rs
+++ b/src/category.rs
@@ -74,7 +74,7 @@ impl Category {
     /// assert_eq!(category.domain(), Some("http://example.com"));
     /// ```
     pub fn domain(&self) -> Option<&str> {
-        self.domain.as_ref().map(String::as_str)
+        self.domain.as_deref()
     }
 
     /// Set the domain of this category.

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -228,7 +228,7 @@ impl Channel {
     /// assert_eq!(channel.copyright(), Some("© 2017 John Doe"));
     /// ```
     pub fn copyright(&self) -> Option<&str> {
-        self.copyright.as_ref().map(String::as_str)
+        self.copyright.as_deref()
     }
 
     /// Set the copyright notice for this channel.
@@ -260,7 +260,7 @@ impl Channel {
     /// assert_eq!(channel.managing_editor(), Some("johndoe@example.com"));
     /// ```
     pub fn managing_editor(&self) -> Option<&str> {
-        self.managing_editor.as_ref().map(String::as_str)
+        self.managing_editor.as_deref()
     }
 
     /// Set the email address for the managing editor of this channel.
@@ -293,7 +293,7 @@ impl Channel {
     /// assert_eq!(channel.webmaster(), Some("johndoe@example.com"));
     /// ```
     pub fn webmaster(&self) -> Option<&str> {
-        self.webmaster.as_ref().map(String::as_str)
+        self.webmaster.as_deref()
     }
 
     /// Set the email address for webmaster of this channel.
@@ -325,7 +325,7 @@ impl Channel {
     /// assert_eq!(channel.pub_date(), Some("Mon, 1 Jan 2017 12:00:00 GMT"));
     /// ```
     pub fn pub_date(&self) -> Option<&str> {
-        self.pub_date.as_ref().map(String::as_str)
+        self.pub_date.as_deref()
     }
 
     /// Set the publication date for the content of this channel as an RFC822 timestamp.
@@ -357,7 +357,7 @@ impl Channel {
     /// assert_eq!(channel.last_build_date(), Some("Mon, 1 Jan 2017 12:00:00 GMT"));
     /// ```
     pub fn last_build_date(&self) -> Option<&str> {
-        self.last_build_date.as_ref().map(String::as_str)
+        self.last_build_date.as_deref()
     }
 
     /// Set the time that the content of this channel was last changed as an RFC822 timestamp.
@@ -426,7 +426,7 @@ impl Channel {
     /// assert_eq!(channel.generator(), Some("Program Name"));
     /// ```
     pub fn generator(&self) -> Option<&str> {
-        self.generator.as_ref().map(String::as_str)
+        self.generator.as_deref()
     }
 
     /// Set a string indicating the program used to generate the channel.
@@ -458,7 +458,7 @@ impl Channel {
     /// assert_eq!(channel.docs(), Some("https://cyber.harvard.edu/rss/rss.html"));
     /// ```
     pub fn docs(&self) -> Option<&str> {
-        self.docs.as_ref().map(String::as_str)
+        self.docs.as_deref()
     }
 
     /// Set a URL that points to the documentation of the RSS format used in this channel.
@@ -525,7 +525,7 @@ impl Channel {
     /// assert_eq!(channel.ttl(), Some("60"));
     /// ```
     pub fn ttl(&self) -> Option<&str> {
-        self.ttl.as_ref().map(String::as_str)
+        self.ttl.as_deref()
     }
 
     /// Set the time to live of this channel. This indicates the number of minutes the
@@ -580,7 +580,7 @@ impl Channel {
 
     /// Return the [PICS](https://www.w3.org/PICS/) rating for this channel.
     pub fn rating(&self) -> Option<&str> {
-        self.rating.as_ref().map(String::as_str)
+        self.rating.as_deref()
     }
 
     /// Set the [PICS](https://www.w3.org/PICS/) rating for this channel.

--- a/src/extension/itunes/itunes_category.rs
+++ b/src/extension/itunes/itunes_category.rs
@@ -12,7 +12,6 @@ use quick_xml::Error as XmlError;
 use quick_xml::Writer;
 
 use crate::toxml::ToXml;
-use std::ops::Deref;
 
 /// A category for an iTunes podcast.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -72,7 +71,7 @@ impl ITunesCategory {
     /// assert!(category.subcategory().is_some());
     /// ```
     pub fn subcategory(&self) -> Option<&ITunesCategory> {
-        self.subcategory.as_ref().map(|x| x.deref())
+        self.subcategory.as_deref()
     }
 
     /// Set the subcategory for this category.

--- a/src/extension/itunes/itunes_channel_extension.rs
+++ b/src/extension/itunes/itunes_channel_extension.rs
@@ -66,7 +66,7 @@ impl ITunesChannelExtension {
     /// assert_eq!(extension.author(), Some("John Doe"));
     /// ```
     pub fn author(&self) -> Option<&str> {
-        self.author.as_ref().map(String::as_str)
+        self.author.as_deref()
     }
 
     /// Set the author of this podcast.
@@ -101,7 +101,7 @@ impl ITunesChannelExtension {
     /// assert_eq!(extension.block(), Some("Yes"));
     /// ```
     pub fn block(&self) -> Option<&str> {
-        self.block.as_ref().map(String::as_str)
+        self.block.as_deref()
     }
 
     /// Set whether the podcast should be blocked from appearing in the iTunes Store.
@@ -173,7 +173,7 @@ impl ITunesChannelExtension {
     /// assert_eq!(extension.image(), Some("http://example.com/artwork.png"));
     /// ```
     pub fn image(&self) -> Option<&str> {
-        self.image.as_ref().map(String::as_str)
+        self.image.as_deref()
     }
 
     /// Set the artwork URL for the podcast.
@@ -209,7 +209,7 @@ impl ITunesChannelExtension {
     /// assert_eq!(extension.explicit(), Some("Yes"));
     /// ```
     pub fn explicit(&self) -> Option<&str> {
-        self.explicit.as_ref().map(String::as_str)
+        self.explicit.as_deref()
     }
 
     /// Set whether the podcast contains explicit content.
@@ -247,7 +247,7 @@ impl ITunesChannelExtension {
     /// assert_eq!(extension.complete(), Some("Yes"));
     /// ```
     pub fn complete(&self) -> Option<&str> {
-        self.complete.as_ref().map(String::as_str)
+        self.complete.as_deref()
     }
 
     /// Set whether the podcast is complete and no new episodes will be posted.
@@ -281,7 +281,7 @@ impl ITunesChannelExtension {
     /// assert_eq!(extension.new_feed_url(), Some("http://example.com/feed"));
     /// ```
     pub fn new_feed_url(&self) -> Option<&str> {
-        self.new_feed_url.as_ref().map(String::as_str)
+        self.new_feed_url.as_deref()
     }
 
     /// Set the new feed URL for this podcast.
@@ -345,7 +345,7 @@ impl ITunesChannelExtension {
     /// assert_eq!(extension.subtitle(), Some("A podcast"));
     /// ```
     pub fn subtitle(&self) -> Option<&str> {
-        self.subtitle.as_ref().map(String::as_str)
+        self.subtitle.as_deref()
     }
 
     /// Set the description of this podcast.
@@ -377,7 +377,7 @@ impl ITunesChannelExtension {
     /// assert_eq!(extension.summary(), Some("A podcast"));
     /// ```
     pub fn summary(&self) -> Option<&str> {
-        self.summary.as_ref().map(String::as_str)
+        self.summary.as_deref()
     }
 
     /// Set the summary for this podcast.
@@ -411,7 +411,7 @@ impl ITunesChannelExtension {
     /// assert_eq!(extension.keywords(), Some("technology"));
     /// ```
     pub fn keywords(&self) -> Option<&str> {
-        self.keywords.as_ref().map(String::as_str)
+        self.keywords.as_deref()
     }
 
     /// Set the keywords for this podcast.

--- a/src/extension/itunes/itunes_item_extension.rs
+++ b/src/extension/itunes/itunes_item_extension.rs
@@ -64,7 +64,7 @@ impl ITunesItemExtension {
     /// assert_eq!(extension.author(), Some("John Doe"));
     /// ```
     pub fn author(&self) -> Option<&str> {
-        self.author.as_ref().map(String::as_str)
+        self.author.as_deref()
     }
 
     /// Set the author of this podcast episode.
@@ -99,7 +99,7 @@ impl ITunesItemExtension {
     /// assert_eq!(extension.block(), Some("Yes"));
     /// ```
     pub fn block(&self) -> Option<&str> {
-        self.block.as_ref().map(String::as_str)
+        self.block.as_deref()
     }
 
     /// Set whether this podcast episode should be blocked from appearing in the iTunes Store.
@@ -134,7 +134,7 @@ impl ITunesItemExtension {
     /// assert_eq!(extension.image(), Some("http://example.com/artwork.png"));
     /// ```
     pub fn image(&self) -> Option<&str> {
-        self.image.as_ref().map(String::as_str)
+        self.image.as_deref()
     }
 
     /// Set the artwork URL for this podcast episode.
@@ -168,7 +168,7 @@ impl ITunesItemExtension {
     /// assert_eq!(extension.duration(), Some("1:00"));
     /// ```
     pub fn duration(&self) -> Option<&str> {
-        self.duration.as_ref().map(String::as_str)
+        self.duration.as_deref()
     }
 
     /// Set the duration of this podcast episode.
@@ -206,7 +206,7 @@ impl ITunesItemExtension {
     /// assert_eq!(extension.explicit(), Some("Yes"));
     /// ```
     pub fn explicit(&self) -> Option<&str> {
-        self.explicit.as_ref().map(String::as_str)
+        self.explicit.as_deref()
     }
 
     /// Set whether this podcast episode contains explicit content.
@@ -244,7 +244,7 @@ impl ITunesItemExtension {
     /// assert_eq!(extension.closed_captioned(), Some("Yes"));
     /// ```
     pub fn closed_captioned(&self) -> Option<&str> {
-        self.closed_captioned.as_ref().map(String::as_str)
+        self.closed_captioned.as_deref()
     }
 
     /// Set whether this podcast episode contains embedded closed captioning.
@@ -278,7 +278,7 @@ impl ITunesItemExtension {
     /// assert_eq!(extension.order(), Some("1"));
     /// ```
     pub fn order(&self) -> Option<&str> {
-        self.order.as_ref().map(String::as_str)
+        self.order.as_deref()
     }
 
     /// Set the value used to override the default sorting order for episodes.
@@ -310,7 +310,7 @@ impl ITunesItemExtension {
     /// assert_eq!(extension.subtitle(), Some("An episode"));
     /// ```
     pub fn subtitle(&self) -> Option<&str> {
-        self.subtitle.as_ref().map(String::as_str)
+        self.subtitle.as_deref()
     }
 
     /// Set the description of this podcast episode.
@@ -342,7 +342,7 @@ impl ITunesItemExtension {
     /// assert_eq!(extension.summary(), Some("An episode"));
     /// ```
     pub fn summary(&self) -> Option<&str> {
-        self.summary.as_ref().map(String::as_str)
+        self.summary.as_deref()
     }
 
     /// Set the summary for this podcast episode.
@@ -376,7 +376,7 @@ impl ITunesItemExtension {
     /// assert_eq!(extension.keywords(), Some("technology"));
     /// ```
     pub fn keywords(&self) -> Option<&str> {
-        self.keywords.as_ref().map(String::as_str)
+        self.keywords.as_deref()
     }
 
     /// Set the keywords for this podcast episode.

--- a/src/extension/itunes/itunes_owner.rs
+++ b/src/extension/itunes/itunes_owner.rs
@@ -38,7 +38,7 @@ impl ITunesOwner {
     /// assert_eq!(owner.name(), Some("John Doe"));
     /// ```
     pub fn name(&self) -> Option<&str> {
-        self.name.as_ref().map(String::as_str)
+        self.name.as_deref()
     }
 
     /// Set the name of this person.
@@ -70,7 +70,7 @@ impl ITunesOwner {
     /// assert_eq!(owner.email(), Some("johndoe@example.com"));
     /// ```
     pub fn email(&self) -> Option<&str> {
-        self.email.as_ref().map(String::as_str)
+        self.email.as_deref()
     }
 
     /// Set the email of this person.

--- a/src/extension/mod.rs
+++ b/src/extension/mod.rs
@@ -63,7 +63,7 @@ impl Extension {
 
     /// Return the text content of this extension.
     pub fn value(&self) -> Option<&str> {
-        self.value.as_ref().map(String::as_str)
+        self.value.as_deref()
     }
 
     /// Set the text content of this extension.
@@ -98,7 +98,7 @@ impl ToXml for Extension {
             writer.write_event(Event::Text(BytesText::from_escaped(value.as_bytes())))?;
         }
 
-        for extension in self.children.values().flat_map(|extensions| extensions) {
+        for extension in self.children.values().flatten() {
             extension.to_xml(writer)?;
         }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -149,7 +149,7 @@ impl Image {
     /// image.set_width("80".to_string());
     /// assert_eq!(image.width(), Some("80"));
     pub fn width(&self) -> Option<&str> {
-        self.width.as_ref().map(String::as_str)
+        self.width.as_deref()
     }
 
     /// Set the width of this image.
@@ -182,7 +182,7 @@ impl Image {
     /// assert_eq!(image.height(), Some("31"));
     /// ```
     pub fn height(&self) -> Option<&str> {
-        self.height.as_ref().map(String::as_str)
+        self.height.as_deref()
     }
 
     /// Set the height of this image.
@@ -216,7 +216,7 @@ impl Image {
     /// assert_eq!(image.description(), Some("Example Title"));
     /// ```
     pub fn description(&self) -> Option<&str> {
-        self.description.as_ref().map(String::as_str)
+        self.description.as_deref()
     }
 
     /// Set the title for the link formed around this image.

--- a/src/item.rs
+++ b/src/item.rs
@@ -75,7 +75,7 @@ impl Item {
     /// assert_eq!(item.title(), Some("Item Title"));
     /// ```
     pub fn title(&self) -> Option<&str> {
-        self.title.as_ref().map(String::as_str)
+        self.title.as_deref()
     }
 
     /// Set the title of this item.
@@ -107,7 +107,7 @@ impl Item {
     /// assert_eq!(item.link(), Some("http://example.com"));
     /// ```
     pub fn link(&self) -> Option<&str> {
-        self.link.as_ref().map(String::as_str)
+        self.link.as_deref()
     }
 
     /// Set the URL of this item.
@@ -139,7 +139,7 @@ impl Item {
     /// assert_eq!(item.description(), Some("Item description"));
     /// ```
     pub fn description(&self) -> Option<&str> {
-        self.description.as_ref().map(String::as_str)
+        self.description.as_deref()
     }
 
     /// Return the description of this item.
@@ -171,7 +171,7 @@ impl Item {
     /// assert_eq!(item.author(), Some("John Doe"));
     /// ```
     pub fn author(&self) -> Option<&str> {
-        self.author.as_ref().map(String::as_str)
+        self.author.as_deref()
     }
 
     /// Set the email address for the author of this item.
@@ -240,7 +240,7 @@ impl Item {
     /// assert_eq!(item.comments(), Some("http://example.com"));
     /// ```
     pub fn comments(&self) -> Option<&str> {
-        self.comments.as_ref().map(String::as_str)
+        self.comments.as_deref()
     }
 
     /// Set the URL for comments about this item.
@@ -336,7 +336,7 @@ impl Item {
     /// assert_eq!(item.pub_date(), Some("Mon, 01 Jan 2017 12:00:00 GMT"));
     /// ```
     pub fn pub_date(&self) -> Option<&str> {
-        self.pub_date.as_ref().map(String::as_str)
+        self.pub_date.as_deref()
     }
 
     /// Set the publication date of this item as an RFC822 timestamp.
@@ -401,7 +401,7 @@ impl Item {
     /// assert_eq!(item.content(), Some("Item content"));
     /// ```
     pub fn content(&self) -> Option<&str> {
-        self.content.as_ref().map(String::as_str)
+        self.content.as_deref()
     }
 
     /// Set the content of this item.

--- a/src/source.rs
+++ b/src/source.rs
@@ -74,7 +74,7 @@ impl Source {
     /// assert_eq!(source.title(), Some("Source Title"));
     /// ```
     pub fn title(&self) -> Option<&str> {
-        self.title.as_ref().map(String::as_str)
+        self.title.as_deref()
     }
 
     /// Set the title of this source.


### PR DESCRIPTION
Example:

```
warning: called `.as_ref().map(String::as_str)` on an Option value. This can be done more directly by calling `self.email.as_deref()` instead
  --> src/extension/itunes/itunes_owner.rs:73:9
   |
73 |         self.email.as_ref().map(String::as_str)
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try using as_deref instead: `self.email.as_deref()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#option_as_ref_deref
```