### PR TITLE
Escape Guid value

### DIFF
--- a/src/guid.rs
+++ b/src/guid.rs
@@ -137,7 +137,7 @@ impl ToXml for Guid {
 
         writer.write_event(Event::Start(element))?;
 
-        writer.write_event(Event::Text(BytesText::from_escaped(self.value.as_bytes())))?;
+        writer.write_event(Event::Text(BytesText::from_plain_str(&self.value)))?;
 
         writer.write_event(Event::End(BytesEnd::borrowed(name)))?;
         Ok(())

--- a/tests/data/guid.xml
+++ b/tests/data/guid.xml
@@ -5,7 +5,7 @@
 			<guid isPermaLink="false">abc</guid>
 		</item>
 		<item>
-			<guid>def</guid>
+			<guid>def?g=h&amp;i=j</guid>
 		</item>
 	</channel>
 </rss>

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -326,7 +326,7 @@ fn read_guid() {
             .guid()
             .as_ref()
             .map(|v| v.value()),
-        Some("def")
+        Some("def?g=h&i=j")
     );
 }
 


### PR DESCRIPTION
This is a fix for invalid xml generated if `guid` is a url with unescaped xml characters:

```xml
    <item>
      <link>https://example.com/?foo=7&amp;bar=11</link>
      <guid>https://example.com/?foo=7&bar=11</guid>
    </item>
```