### PR TITLE
Add itunes season tag

### DIFF
--- a/src/extension/itunes/itunes_item_extension.rs
+++ b/src/extension/itunes/itunes_item_extension.rs
@@ -49,6 +49,8 @@ pub struct ITunesItemExtension {
     pub summary: Option<String>,
     /// Keywords for the podcast. The string contains a comma separated list of keywords.
     pub keywords: Option<String>,
+    /// Season number for this episode.
+    pub season: Option<String>,
 }
 
 impl ITunesItemExtension {
@@ -397,6 +399,42 @@ impl ITunesItemExtension {
     {
         self.keywords = keywords.into();
     }
+
+    /// Return the season of this podcast episode
+    ///
+    /// The duration will be a string although it is typically a number in practice
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rss::extension::itunes::ITunesItemExtension;
+    ///
+    /// let mut extension = ITunesItemExtension::default();
+    /// extension.set_season("3".to_string());
+    /// assert_eq!(extension.season(), Some("3"));
+    /// ```
+    pub fn season(&self) -> Option<&str> {
+        self.season.as_deref()
+    }
+
+    /// Set the the season number for this episode.
+    ///
+    /// An integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rss::extension::itunes::ITunesItemExtension;
+    ///
+    /// let mut extension = ITunesItemExtension::default();
+    /// extension.set_season("3".to_string());
+    /// ```
+    pub fn set_season<V>(&mut self, season: V)
+    where
+        V: Into<Option<String>>,
+    {
+        self.season = season.into()
+    }
 }
 
 impl ITunesItemExtension {
@@ -413,6 +451,7 @@ impl ITunesItemExtension {
         ext.subtitle = remove_extension_value(&mut map, "subtitle");
         ext.summary = remove_extension_value(&mut map, "summary");
         ext.keywords = remove_extension_value(&mut map, "keywords");
+        ext.season = remove_extension_value(&mut map, "season");
         ext
     }
 }
@@ -461,6 +500,10 @@ impl ToXml for ITunesItemExtension {
 
         if let Some(keywords) = self.keywords.as_ref() {
             writer.write_text_element(b"itunes:keywords", keywords)?;
+        }
+
+        if let Some(season) = self.season.as_ref() {
+            writer.write_text_element(b"itunes:season", season.to_string())?;
         }
 
         Ok(())

--- a/src/extension/itunes/itunes_item_extension.rs
+++ b/src/extension/itunes/itunes_item_extension.rs
@@ -402,7 +402,7 @@ impl ITunesItemExtension {
 
     /// Return the season of this podcast episode
     ///
-    /// The duration will be a string although it is typically a number in practice
+    /// The season will be a string although it is typically a number in practice
     ///
     /// # Examples
     ///

--- a/src/extension/itunes/itunes_item_extension.rs
+++ b/src/extension/itunes/itunes_item_extension.rs
@@ -428,6 +428,7 @@ impl ITunesItemExtension {
     ///
     /// let mut extension = ITunesItemExtension::default();
     /// extension.set_season("3".to_string());
+    /// assert_eq!(extension.season(), Some("3"));
     /// ```
     pub fn set_season<V>(&mut self, season: V)
     where

--- a/tests/data/itunes.xml
+++ b/tests/data/itunes.xml
@@ -29,6 +29,7 @@
 			<itunes:subtitle>Subtitle</itunes:subtitle>
 			<itunes:summary>Summary</itunes:summary>
 			<itunes:keywords>key1,key2,key3</itunes:keywords>
+			<itunes:season>3</itunes:season>
 		</item>
 	</channel>
 </rss>

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -725,6 +725,17 @@ fn read_itunes() {
             .keywords(),
         Some("key1,key2,key3")
     );
+
+    assert_eq!(
+        channel
+            .items()
+            .get(0)
+            .unwrap()
+            .itunes_ext()
+            .unwrap()
+            .season(),
+        Some("3")
+    );
 }
 
 #[test]


### PR DESCRIPTION
I don't think this tag has been around for long.  In any case using this library there's no way to get at the `itunes:season` tag if it does happen exist.

I left it as a string because everything else is a string and I didn't want to rock the boat.

Description of the tag can be found at https://help.apple.com/itc/podcasts_connect/#/itcb54353390