### PR TITLE
Add the itunes channel "itunes:type" tag.

### DIFF
--- a/src/extension/itunes/itunes_channel_extension.rs
+++ b/src/extension/itunes/itunes_channel_extension.rs
@@ -52,7 +52,7 @@ pub struct ITunesChannelExtension {
     /// Keywords for the podcast. The string contains a comma separated list of keywords.
     pub keywords: Option<String>,
     /// The type of the podcast.  Usually `serial` or `episodic`.
-    pub podcast_type: Option<String>,
+    pub r#type: Option<String>,
 }
 
 impl ITunesChannelExtension {
@@ -435,7 +435,7 @@ impl ITunesChannelExtension {
         self.keywords = keywords.into();
     }
 
-    /// Return the podcast_type of this podcast.
+    /// Return the type of this podcast.
     ///
     /// A string usually "serial" or "episodic"
     ///
@@ -445,11 +445,11 @@ impl ITunesChannelExtension {
     /// use rss::extension::itunes::ITunesChannelExtension;
     ///
     /// let mut extension = ITunesChannelExtension::default();
-    /// extension.set_podcast_type("episodic".to_string());
-    /// assert_eq!(extension.podcast_type(), Some("episodic"));
+    /// extension.set_type("episodic".to_string());
+    /// assert_eq!(extension.r#type(), Some("episodic"));
     /// ```
-    pub fn podcast_type(&self) -> Option<&str> {
-        self.podcast_type.as_deref()
+    pub fn r#type(&self) -> Option<&str> {
+        self.r#type.as_deref()
     }
 
     /// Set the type of this podcast.
@@ -462,13 +462,13 @@ impl ITunesChannelExtension {
     /// use rss::extension::itunes::ITunesChannelExtension;
     ///
     /// let mut extension = ITunesChannelExtension::default();
-    /// extension.set_podcast_type("serial".to_string());
+    /// extension.set_type("serial".to_string());
     /// ```
-    pub fn set_podcast_type<V>(&mut self, t: V)
+    pub fn set_type<V>(&mut self, t: V)
     where
         V: Into<Option<String>>,
     {
-        self.podcast_type = t.into();
+        self.r#type = t.into();
     }
 }
 
@@ -487,7 +487,7 @@ impl ITunesChannelExtension {
         ext.subtitle = remove_extension_value(&mut map, "subtitle");
         ext.summary = remove_extension_value(&mut map, "summary");
         ext.keywords = remove_extension_value(&mut map, "keywords");
-        ext.podcast_type = remove_extension_value(&mut map, "type");
+        ext.r#type = remove_extension_value(&mut map, "type");
         ext
     }
 }
@@ -539,8 +539,8 @@ impl ToXml for ITunesChannelExtension {
             writer.write_text_element(b"itunes:keywords", keywords)?;
         }
 
-        if let Some(podcast_type) = self.podcast_type.as_ref() {
-            writer.write_text_element(b"itunes:type", podcast_type)?;
+        if let Some(r#type) = self.r#type.as_ref() {
+            writer.write_text_element(b"itunes:type", r#type)?;
         }
 
         Ok(())

--- a/src/extension/itunes/itunes_channel_extension.rs
+++ b/src/extension/itunes/itunes_channel_extension.rs
@@ -51,6 +51,8 @@ pub struct ITunesChannelExtension {
     pub summary: Option<String>,
     /// Keywords for the podcast. The string contains a comma separated list of keywords.
     pub keywords: Option<String>,
+    /// The type of the podcast.  Usually `serial` or `episodic`.
+    pub podcast_type: Option<String>,
 }
 
 impl ITunesChannelExtension {
@@ -432,6 +434,42 @@ impl ITunesChannelExtension {
     {
         self.keywords = keywords.into();
     }
+
+    /// Return the podcast_type of this podcast.
+    ///
+    /// A string usually "serial" or "episodic"
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rss::extension::itunes::ITunesChannelExtension;
+    ///
+    /// let mut extension = ITunesChannelExtension::default();
+    /// extension.set_podcast_type("episodic".to_string());
+    /// assert_eq!(extension.podcast_type(), Some("episodic"));
+    /// ```
+    pub fn podcast_type(&self) -> Option<&str> {
+        self.podcast_type.as_deref()
+    }
+
+    /// Set the type of this podcast.
+    ///
+    /// A string, usually "serial" or "episodic"
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rss::extension::itunes::ITunesChannelExtension;
+    ///
+    /// let mut extension = ITunesChannelExtension::default();
+    /// extension.set_podcast_type("serial".to_string());
+    /// ```
+    pub fn set_podcast_type<V>(&mut self, t: V)
+    where
+        V: Into<Option<String>>,
+    {
+        self.podcast_type = t.into();
+    }
 }
 
 impl ITunesChannelExtension {
@@ -449,6 +487,7 @@ impl ITunesChannelExtension {
         ext.subtitle = remove_extension_value(&mut map, "subtitle");
         ext.summary = remove_extension_value(&mut map, "summary");
         ext.keywords = remove_extension_value(&mut map, "keywords");
+        ext.podcast_type = remove_extension_value(&mut map, "type");
         ext
     }
 }
@@ -498,6 +537,10 @@ impl ToXml for ITunesChannelExtension {
 
         if let Some(keywords) = self.keywords.as_ref() {
             writer.write_text_element(b"itunes:keywords", keywords)?;
+        }
+
+        if let Some(podcast_type) = self.podcast_type.as_ref() {
+            writer.write_text_element(b"itunes:type", podcast_type)?;
         }
 
         Ok(())

--- a/tests/data/itunes.xml
+++ b/tests/data/itunes.xml
@@ -18,6 +18,7 @@
 		<itunes:subtitle>Subtitle</itunes:subtitle>
 		<itunes:summary>Summary</itunes:summary>
 		<itunes:keywords>key1,key2,key3</itunes:keywords>
+		<itunes:type>episodic</itunes:type>
 		<item>
 			<itunes:author>Author</itunes:author>
 			<itunes:block>yes</itunes:block>

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -625,10 +625,7 @@ fn read_itunes() {
         channel.itunes_ext().unwrap().keywords(),
         Some("key1,key2,key3")
     );
-    assert_eq!(
-        channel.itunes_ext().unwrap().r#type(),
-        Some("episodic")
-    );
+    assert_eq!(channel.itunes_ext().unwrap().r#type(),Some("episodic"));
 
     assert_eq!(
         channel

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -626,7 +626,7 @@ fn read_itunes() {
         Some("key1,key2,key3")
     );
     assert_eq!(
-        channel.itunes_ext().unwrap().podcast_type(),
+        channel.itunes_ext().unwrap().r#type(),
         Some("episodic")
     );
 

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -625,7 +625,7 @@ fn read_itunes() {
         channel.itunes_ext().unwrap().keywords(),
         Some("key1,key2,key3")
     );
-    assert_eq!(channel.itunes_ext().unwrap().r#type(),Some("episodic"));
+    assert_eq!(channel.itunes_ext().unwrap().r#type(), Some("episodic"));
 
     assert_eq!(
         channel

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -626,6 +626,11 @@ fn read_itunes() {
         Some("key1,key2,key3")
     );
     assert_eq!(
+        channel.itunes_ext().unwrap().podcast_type(),
+        Some("episodic")
+    );
+
+    assert_eq!(
         channel
             .items()
             .get(0)


### PR DESCRIPTION
This adds support for the itunes channel tag `itunes:type` which is meant to mark the podcast as either serial or episodic in nature.  Episodic podcasts are like news podcasts where you only want the most recent episodes, serials are podcasts that are meant to be listened from the start, like the appropriately named podcast "serial".

https://help.apple.com/itc/podcasts_connect/#/itcb54353390