### PR TITLE
Adding item itunes:episodeType tag.

### DIFF
--- a/src/extension/itunes/itunes_item_extension.rs
+++ b/src/extension/itunes/itunes_item_extension.rs
@@ -475,7 +475,6 @@ impl ITunesItemExtension {
     {
         self.episode_type = episode_type.into()
     }
-
 }
 
 impl ITunesItemExtension {

--- a/src/extension/itunes/itunes_item_extension.rs
+++ b/src/extension/itunes/itunes_item_extension.rs
@@ -51,6 +51,8 @@ pub struct ITunesItemExtension {
     pub keywords: Option<String>,
     /// Season number for this episode.
     pub season: Option<String>,
+    /// Type of episode. Usually `full`, but potentially also `trailer` or `bonus`
+    pub episode_type: Option<String>,
 }
 
 impl ITunesItemExtension {
@@ -436,6 +438,44 @@ impl ITunesItemExtension {
     {
         self.season = season.into()
     }
+
+    /// Return the episode_type of this podcast episode
+    ///
+    /// The episode type will be a string usually "full" "trailer" or "bonus"
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rss::extension::itunes::ITunesItemExtension;
+    ///
+    /// let mut extension = ITunesItemExtension::default();
+    /// extension.set_episode_type("trailer".to_string());
+    /// assert_eq!(extension.episode_type(), Some("trailer"));
+    /// ```
+    pub fn episode_type(&self) -> Option<&str> {
+        self.episode_type.as_deref()
+    }
+
+    /// Set the the episode type for this episode.
+    ///
+    /// A string, usually "full" but maybe "trailer" or "bonus"
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rss::extension::itunes::ITunesItemExtension;
+    ///
+    /// let mut extension = ITunesItemExtension::default();
+    /// extension.set_episode_type("full".to_string());
+    /// assert_eq!(extension.episode_type(), Some("full"));
+    /// ```
+    pub fn set_episode_type<V>(&mut self, episode_type: V)
+    where
+        V: Into<Option<String>>,
+    {
+        self.episode_type = episode_type.into()
+    }
+
 }
 
 impl ITunesItemExtension {
@@ -453,6 +493,7 @@ impl ITunesItemExtension {
         ext.summary = remove_extension_value(&mut map, "summary");
         ext.keywords = remove_extension_value(&mut map, "keywords");
         ext.season = remove_extension_value(&mut map, "season");
+        ext.episode_type = remove_extension_value(&mut map, "episodeType");
         ext
     }
 }
@@ -505,6 +546,10 @@ impl ToXml for ITunesItemExtension {
 
         if let Some(season) = self.season.as_ref() {
             writer.write_text_element(b"itunes:season", season.to_string())?;
+        }
+
+        if let Some(episode_type) = self.episode_type.as_ref() {
+            writer.write_text_element(b"itunes:episodeType", episode_type.to_string())?;
         }
 
         Ok(())

--- a/tests/data/itunes.xml
+++ b/tests/data/itunes.xml
@@ -31,6 +31,7 @@
 			<itunes:summary>Summary</itunes:summary>
 			<itunes:keywords>key1,key2,key3</itunes:keywords>
 			<itunes:season>3</itunes:season>
+			<itunes:episodeType>trailer</itunes:episodeType>
 		</item>
 	</channel>
 </rss>

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -738,6 +738,16 @@ fn read_itunes() {
             .season(),
         Some("3")
     );
+    assert_eq!(
+        channel
+            .items()
+            .get(0)
+            .unwrap()
+            .itunes_ext()
+            .unwrap()
+            .episode_type(),
+        Some("trailer")
+    );
 }
 
 #[test]


### PR DESCRIPTION
One last tag.  `<itunes:episodeType>`, which can be either "episodic" or "serial".  If it is "serial", then apple mandates that you must have episode numbers on your episodes.

https://help.apple.com/itc/podcasts_connect/#/itcb54353390