### PR TITLE
Micro-optimization to save allocations in extension::util::parse_extension() and extension::util::parse_extension_element()

### DIFF
--- a/benches/read.rs
+++ b/benches/read.rs
@@ -36,11 +36,19 @@ fn read_syndication(b: &mut Bencher) {
     });
 }
 
+fn read_extensions(b: &mut Bencher) {
+    let input: &[u8] = include_bytes!("../tests/data/extension.xml");
+    b.iter(|| {
+        let _ = Channel::read_from(input).expect("failed to parse feed");
+    });
+}
+
 benchmark_group!(
     benches,
     read_rss2sample,
     read_itunes,
     read_dublincore,
     read_syndication,
+    read_extensions,
 );
 benchmark_main!(benches);

--- a/src/extension/itunes/itunes_item_extension.rs
+++ b/src/extension/itunes/itunes_item_extension.rs
@@ -591,15 +591,15 @@ impl ToXml for ITunesItemExtension {
         }
 
         if let Some(episode) = self.episode.as_ref() {
-            writer.write_text_element(b"itunes:episode", episode.to_string())?;
+            writer.write_text_element(b"itunes:episode", episode)?;
         }
 
         if let Some(season) = self.season.as_ref() {
-            writer.write_text_element(b"itunes:season", season.to_string())?;
+            writer.write_text_element(b"itunes:season", season)?;
         }
 
         if let Some(episode_type) = self.episode_type.as_ref() {
-            writer.write_text_element(b"itunes:episodeType", episode_type.to_string())?;
+            writer.write_text_element(b"itunes:episodeType", episode_type)?;
         }
 
         Ok(())


### PR DESCRIPTION
It's pretty insignificant in terms of actual execution performance (in the added `read_extensions()` benchmark, the difference is only a couple percent) but it does cut down number of allocations (of the whole application!) by ~4%, at least in the application in which I'm using `rss` :)

It also (unrelated) cleans up some Clippy warnings in the 3rd commit