### PR TITLE
check if update_period and frequency are valid

### DIFF
--- a/src/extension/syndication.rs
+++ b/src/extension/syndication.rs
@@ -167,10 +167,14 @@ impl SyndicationExtension {
         let mut syn = SyndicationExtension::default();
 
         with_first_ext_value(&map, "updatePeriod", |value| {
-            syn.period = value.parse().unwrap()
+            if let Ok(update_period) = value.parse() {
+                syn.period = update_period
+            }
         });
         with_first_ext_value(&map, "updateFrequency", |value| {
-            syn.frequency = value.parse().unwrap()
+            if let Ok(frequency) = value.parse() {
+                syn.frequency = frequency
+            }
         });
         with_first_ext_value(&map, "updateBase", |value| syn.base = value.to_owned());
 


### PR DESCRIPTION
this feed (https://decrypt.co/rss) has invalid `updatePeriod`. because of this, parsing fails:

```rust
thread 'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an `Err` value: ()', /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/rss-2.0.0/src/extension/syndication.rs:170:40
stack backtrace:
   0: rust_begin_unwind
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/core/src/panicking.rs:143:14
   2: core::result::unwrap_failed
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/core/src/result.rs:1749:5
   3: rss::extension::syndication::SyndicationExtension::from_map
   4: rss::channel::Channel::from_xml
   5: rss::channel::Channel::read_from
   6: <el_monitorro::sync::reader::rss::RssReader as el_monitorro::sync::reader::ReadFeed>::read_from_bytes
   7: el_monitorro::sync::reader::validate_rss_url
   8: <el_monitorro::bot::commands::subscribe::Subscribe as el_monitorro::bot::commands::Command>::response
   9: el_monitorro::bot::commands::subscribe::Subscribe::execute
  10: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
  ```