### PR TITLE
Improve parse item with multi links

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -634,7 +634,15 @@ impl Item {
                         item.source = Some(source);
                     }
                     b"title" => item.title = element_text(reader)?,
-                    b"link" => item.link = element_text(reader)?,
+                    b"link" => {
+                        // keep the first valid link
+                        if item.link.is_some() {
+                            // let the parse continue
+                            let _ = element_text(reader);
+                            continue;
+                        }
+                        item.link = element_text(reader)?
+                    }
                     b"description" => item.description = element_text(reader)?,
                     b"author" => item.author = element_text(reader)?,
                     b"comments" => item.comments = element_text(reader)?,

--- a/tests/data/multi_links.xml
+++ b/tests/data/multi_links.xml
@@ -1,0 +1,684 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:wfw="http://wellformedweb.org/CommentAPI/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:sy="http://purl.org/rss/1.0/modules/syndication/" xmlns:slash="http://purl.org/rss/1.0/modules/slash/" xmlns:media="http://search.yahoo.com/mrss/">
+    <channel>
+        <title>CoinDesk</title>
+        <link>https://www.coindesk.com</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/rss+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><atom:link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/rss+xml"/><description>Latest headlines from Coindesk.</description>
+        <lastBuildDate>Tue, 28 Jun 2022 05:55:47 +0000</lastBuildDate>
+        <language>en-US</language>
+        <category domain="https://www.coindesk.com">News</category>
+        <copyright>© 2022 CoinDesk, Inc.</copyright>
+        <generator>Arc Publishing</generator>
+        <ttl>5</ttl>
+        <sy:updatePeriod>hourly</sy:updatePeriod>
+        <sy:updateFrequency>12</sy:updateFrequency>
+        <image>
+            <url>https://www.coindesk.com/resizer/fTK3gATlyciJ-BZG2_OP12niDe0=/144x32/downloads.coindesk.com/arc/failsafe/feeds/coindesk-feed-logo.png</url>
+            <title>CoinDesk: Bitcoin, Ethereum, Crypto News and Price Data</title>
+            <link>https://www.coindesk.com</link>
+        </image>
+        <item>
+            <title>
+                <![CDATA[First Mover Asia: Chip Maker Nvidia Isn’t an Ether Proxy, Bitcoin Holds Near $21K]]>
+            </title>
+            <link>https://www.coindesk.com/markets/2022/06/28/first-mover-asia-chip-maker-nvidia-isnt-an-ether-proxy-bitcoin-holds-near-21k/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">PIYU6EZHMBCAHCUPYN6NRT5LPY</guid>
+            <dc:creator>
+                <![CDATA[Sam Reynolds, James Rubin]]>
+            </dc:creator>
+            <description>
+                <![CDATA[Crypto aided Nvidia's bottom line, but it has not been a major cause of the stock's steep decline; bitcoin hovers near $21K.]]>
+            </description>
+            <pubDate>Tue, 28 Jun 2022 00:29:27 +0000</pubDate>
+            <atom:updated>2022-06-28T00:29:28.640+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/markets/">
+                <![CDATA[Markets]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/vV64uwVghF9VlYkqoI8pr3d4ZLQ=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/FBHOAMNV4BFEDCMFEII7SF3L7M.jpg" type="image/jpeg" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[An Asus graphics card (Joseph Greve/Unsplash)]]>
+                </media:description>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[CoinFLEX to Launch a $47M Recovery Token to Solve Withdrawal Issues]]>
+            </title>
+            <link>https://www.coindesk.com/business/2022/06/27/coinflex-to-launch-a-47m-recovery-token-to-solve-withdrawal-issues/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">WNUCOHBJCFBPZNYDI6TTE3D7ZY</guid>
+            <dc:creator>
+                <![CDATA[Michael Bellusci]]>
+            </dc:creator>
+            <description>
+                <![CDATA[CoinFLEX said last week it was halting withdrawals amid the recent market downturn and counterparty uncertainty.]]>
+            </description>
+            <pubDate>Mon, 27 Jun 2022 23:27:48 +0000</pubDate>
+            <atom:updated>2022-06-27T23:27:49.463+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/business/">
+                <![CDATA[Business]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/C0BxmlRABJazBMTxitv3v77VFEk=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/BKO3HK4TKNBJLJSMFF5L4GQKS4.jpg" type="image/jpeg" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[CoinFLEX halted withdrawals. (FLY:D/Unsplash, modified by CoinDesk)]]>
+                </media:description>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[Solana’s Macalinao Brothers Double Down on Crypto Venture Fund]]>
+            </title>
+            <link>https://www.coindesk.com/business/2022/06/27/solanas-macalinao-brothers-double-down-on-crypto-venture-fund/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">IKCCIA55VRCNRKWAGPEUB5J4KM</guid>
+            <dc:creator>
+                <![CDATA[Danny Nelson]]>
+            </dc:creator>
+            <description>
+                <![CDATA[Crypto VCs told CoinDesk that building projects and investing in them is a tricky mix.]]>
+            </description>
+            <pubDate>Mon, 27 Jun 2022 22:03:57 +0000</pubDate>
+            <atom:updated>2022-06-27T22:41:22.287+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/business/">
+                <![CDATA[Business]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/Jo9FWR5FBop0zEq-8dxnfxBRckY=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/WNWQ4SW3BFFNJBYLLBDEOL3T3U.jpg" type="image/jpeg" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[Ian Macalinao is one half of the Saber brothers. (Danny Nelson/CoinDesk)]]>
+                </media:description>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[Ms. Crypto Goes to Washington]]>
+            </title>
+            <link>https://www.coindesk.com/layer2/2022/06/27/ms-crypto-goes-to-washington/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">LYYWUBTS6JA5BHTCKDB4XUH7EQ</guid>
+            <dc:creator>
+                <![CDATA[Adelle Nazarian, Todd  White]]>
+            </dc:creator>
+            <description>
+                <![CDATA[The Lummis-Gillibrand crypto bill represents a mainstreaming of crypto, even if it's unlikely to pass.]]></description><pubDate>Mon, 27 Jun 2022 20:44:51 +0000</pubDate><atom:updated>2022-06-27T20:44:52.163+00:00</atom:updated><category domain="https://www.coindesk.com/layer2/"><![CDATA[Layer 2]]></category><media:content url="https://www.coindesk.com/resizer/v85O8VPEALssolYyoVzCtPlTS-U=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/MUBJ6EMIXZB5VLGDPKTNACLLEQ.jpg" type="image/jpeg" height="600" width="800"><media:description type="plain"><![CDATA[U.S. Capitol (uschools/Getty Images)]]></media:description><media:credit role="author" scheme="urn:ebu">uschools</media:credit></media:content></item><item><title><![CDATA[Market Wrap: Recession Fears Halt Crypto Bounce]]></title><link>https://www.coindesk.com/markets/2022/06/27/market-wrap-recession-fears-halt-crypto-bounce/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">PCQN7R56XBHOLCQWHQCJLIWJHY</guid><dc:creator><![CDATA[Krisztian  Sandor, Jimmy He]]></dc:creator><description><![CDATA[Analysts see too few positive signs to sustain a crypto rally as investors position for further pain in traditional markets.]]></description><pubDate>Mon, 27 Jun 2022 20:35:46 +0000</pubDate><atom:updated>2022-06-27T21:14:02.095+00:00</atom:updated><category domain="https://www.coindesk.com/markets/"><![CDATA[Markets]]></category><media:content url="https://www.coindesk.com/resizer/chpqlWX1iAHMfLQ7IGYye7CTxuE=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/BCEZIJXAJFHOVJUUOVVQMTU62A.jpg" type="image/jpeg" height="600" width="800"><media:description type="plain"><![CDATA[Bitcoin is "balancing" at about $21,000. (Unsplash)]]></media:description><media:credit role="author" scheme="urn:ebu"></media:credit></media:content></item><item><title><![CDATA[Solana’s Biggest DeFi Lender Almost Got Rekt. Then Binance Stepped In]]></title><link>https://www.coindesk.com/business/2022/06/27/solanas-biggest-defi-lender-almost-got-rekt-then-binance-stepped-in/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">FGWJ42X55ZEHVMSHGY22NGGJQE</guid><dc:creator><![CDATA[Danny Nelson]]></dc:creator><description><![CDATA[Solend’s whale crisis rattled depositors and threatened to crash Solana. Can the lending protocol recover?]]></description><pubDate>Mon, 27 Jun 2022 20:29:22 +0000</pubDate><atom:updated>2022-06-27T21:30:19.768+00:00</atom:updated><category domain="https://www.coindesk.com/business/"><![CDATA[Business]]></category><media:content url="https://www.coindesk.com/resizer/2-zV3Bj0wJns2su1QvJJVei7V0o=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/FUKFHHJEAVHB5OIBXBWW4RXUC4.jpg" type="image/jpeg" height="600" width="800"><media:description type="plain"><![CDATA[(State Library of New South Wales/Wikimedia Commons)]]></media:description></media:content></item><item><title><![CDATA[Bitcoin mantiene nivel de $20K en medio de signos de impulso alcista ]]></title><link>https://www.coindesk.com/markets/2022/06/27/bitcoin-mantiene-nivel-de-20000-en-medio-de-signos-de-impulso-alcista/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">4XKOEE32QVE5ZAJ3WOHSUPRT3Y</guid><dc:creator><![CDATA[Jimmy He]]></dc:creator><description><![CDATA[Los analistas dicen que se necesitan signos de mejora en la economía general para lograr un crecimiento sostenido.]]></description><pubDate>Mon, 27 Jun 2022 20:06:48 +0000</pubDate><atom:updated>2022-06-27T20:07:18.592+00:00</atom:updated><category domain="https://www.coindesk.com/markets/"><![CDATA[Markets]]></category><media:content url="https://www.coindesk.com/resizer/2KqG0V-tBdGakZ6deIfLpgFwtfU=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/PDKTZBUSBZG73IU7UPRHLPI45M.png" type="image/png" height="600" width="800"><media:description type="plain"><![CDATA[El gráfico del precio de bitcoin durante la última semana ilustra el retroceso del mercado del lunes. (CoinDesk)]]></media:description></media:content></item><item><title><![CDATA[Robinhood Shares Spike on Report FTX May Be Seeking to Acquire It]]></title><link>https://www.coindesk.com/business/2022/06/27/robinhood-shares-spike-on-report-ftx-may-be-seeking-to-acquire-it/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">SR4E6BSA7BGULOA5QZRVTFWBU4</guid><dc:creator><![CDATA[Nelson Wang]]></dc:creator><description><![CDATA[Plans are still in the preliminary stages, according to a report from Bloomberg.]]></description><pubDate>Mon, 27 Jun 2022 19:55:25 +0000</pubDate><atom:updated>2022-06-27T20:31:25.001+00:00</atom:updated><category domain="https://www.coindesk.com/business/"><![CDATA[Business]]></category><media:content url="https://www.coindesk.com/resizer/eE3AJ-RznItKZbzzY2pndtIzMqY=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/2QAY2GTCOVC4PB2VYRVWXLAGTE.jpg" type="image/jpeg" height="600" width="800"><media:description type="plain"><![CDATA[Robinhood app on smartphone (Andrew Harrer/Bloomberg via Getty Images)]]></media:description><media:credit role="author" scheme="urn:ebu">Andrew Harrer/Bloomberg via Getty Images</media:credit></media:content></item><item><title><![CDATA[Few Signs of Upward Momentum as Bitcoin Holds $20K]]></title><link>https://www.coindesk.com/markets/2022/06/27/few-signs-of-upward-momentum-as-bitcoin-holds-20k/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">ZDLDZ46R45COZH42SBCKAWHL3U</guid><dc:creator><![CDATA[Jimmy He]]></dc:creator><description><![CDATA[BTC maintains $20K price level but analysts say wider economic improvements are needed for sustained growth.]]></description><pubDate>Mon, 27 Jun 2022 17:17:05 +0000</pubDate><atom:updated>2022-06-27T17:48:27.211+00:00</atom:updated><category domain="https://www.coindesk.com/markets/"><![CDATA[Markets]]></category><media:content url="https://www.coindesk.com/resizer/2KqG0V-tBdGakZ6deIfLpgFwtfU=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/PDKTZBUSBZG73IU7UPRHLPI45M.png" type="image/png" height="600" width="800"><media:description type="plain"><![CDATA[Chart of bitcoin’s price over the past week illustrates Monday’s market retracement. (CoinDesk)]]></media:description></media:content></item><item><title><![CDATA[Grayscale Lines Up Jane Street and Virtu as 'Authorized Participants' if GBTC Converts to ETF]]></title><link>https://www.coindesk.com/business/2022/06/27/grayscale-lines-up-jane-street-and-virtu-as-authorized-participants-if-gbtc-converts-to-etf/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">HR2YKLHFJZBOJAENQZYF5F3UWU</guid><dc:creator><![CDATA[Michael Bellusci]]></dc:creator><description><![CDATA[Grayscale is awaiting a decision from the SEC on its GBTC product in hopes of converting to a spot Bitcoin ETF.]]></description><pubDate>Mon, 27 Jun 2022 17:16:33 +0000</pubDate><atom:updated>2022-06-27T18:45:55.196+00:00</atom:updated><category domain="https://www.coindesk.com/business/"><![CDATA[Business]]></category><media:content url="https://www.coindesk.com/resizer/i9BmwDGKovVWmYQrWWp1HWvjtSY=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/6QBRKHIIOJHNDK3NY6EXCE7JNQ.jpeg" type="image/jpeg" height="600" width="800"><media:description type="plain"><![CDATA[Grayscale's new ad campaign can be seen in New York's Penn Station. (Nikhilesh De/CoinDesk)]]></media:description><media:credit role="author" scheme="urn:ebu"></media:credit></media:content></item><item><title><![CDATA[Plataforma de pagos B2B Tribal se une a grupo de lobby Blockchain Association]]></title><link>https://www.coindesk.com/business/2022/06/27/plataforma-de-pagos-b2b-tribal-se-une-a-grupo-de-lobby-blockchain-association/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">E4P2GSYEK5EFVHM4WCOBB2L6BE</guid><dc:creator><![CDATA[Andrés Engler]]></dc:creator><description><![CDATA[La compañía, enfocada en mercados emergentes, se convierte en miembro del grupo de lobby cripto y planea comprometerse con los reguladores y otros actores.]]></description><pubDate>Mon, 27 Jun 2022 16:55:37 +0000</pubDate><atom:updated>2022-06-27T17:45:41.467+00:00</atom:updated><category domain="https://www.coindesk.com/business/"><![CDATA[Business]]></category><media:content url="https://www.coindesk.com/resizer/zKFtQmeLBbbEwJR9l5uKEVyAmt4=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/6IU5B5O6Z5D2ZH4COA37BGGJZM.jpg" type="image/jpeg" height="600" width="800"><media:description type="plain"><![CDATA[Tribal ofrece una plataforma de pago business-to-business. (Tribal)]]></media:description></media:content></item><item><title><![CDATA[Web3 Adoption Is 'Inevitable,' Blockchain Creative Labs CEO Says ]]></title><link>https://www.coindesk.com/layer2/2022/06/27/web3-adoption-is-inevitable-blockchain-creative-labs-ceo-says/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">45S22WGNI5CPBJ2SIO6S7OOIGI</guid><dc:creator><![CDATA[Fran Velasquez]]></dc:creator><description><![CDATA[“We believe we can leverage the Fox platform to teach people what it means [for] them to value a digital good [and] the value of an NFT,” Blockchain Creative Labs CEO Scott Greenberg said during an interview with CoinDesk at NFT.NYC.]]></description><pubDate>Mon, 27 Jun 2022 16:52:44 +0000</pubDate><atom:updated>2022-06-27T16:52:45.690+00:00</atom:updated><category domain="https://www.coindesk.com/layer2/"><![CDATA[Layer 2]]></category><media:content url="https://www.coindesk.com/resizer/5AxKNTXRGkWQS0cLRXNo6lGqUsA=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/CF44OBYXORCCFGNTVA5YCTEB6U.jpg" type="image/jpeg" height="600" width="800"><media:description type="plain"><![CDATA[Blockchain Creative Labs CEO Scott Greenberg during an interview with CoinDesk at NFT.NYC (CoinDesk, modified)]]></media:description></media:content></item><item><title><![CDATA[Recent Crypto 'Bloodbath' Is Not Necessarily Bad, Regulators Say]]></title><link>https://www.coindesk.com/policy/2022/06/27/recent-crypto-bloodbath-is-not-necessarily-bad-regulators-say/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">PR537VBZJZH2ROF3UPR4GE2QZU</guid><dc:creator><![CDATA[Camomile Shumba]]></dc:creator><description><![CDATA[The recent crypto market downturn can help weed out bad actors and unsustainable projects, a number of regulators and entrepreneurs said at a forum in Zurich last week.]]></description><pubDate>Mon, 27 Jun 2022 16:19:31 +0000</pubDate><atom:updated>2022-06-27T18:40:24.567+00:00</atom:updated><category domain="https://www.coindesk.com/policy/"><![CDATA[Policy]]></category><media:content url="https://www.coindesk.com/resizer/egWh6unWdgUa9NZwXvGUFoOAYrs=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/RLTH7RXO5BFJHJE3CMWSC4TPIA.jpg" type="image/jpeg" height="600" width="800"><media:description type="plain"><![CDATA[The recent crypto crash might have a silver lining: Some industry sources contend that it could ultimately bring about more stability. (Jonny Clow/Unsplash)]]></media:description><media:credit role="author" scheme="urn:ebu">Jonny Clow/Unsplash</media:credit></media:content></item><item><title><![CDATA[B2B Payments Platform Tribal Joins the Blockchain Association]]></title><link>https://www.coindesk.com/business/2022/06/27/b2b-payments-platform-tribal-joins-the-blockchain-association/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">3SCHOLAEYZAZ7HY57TXXTT2ZDI</guid><dc:creator><![CDATA[Andrés Engler]]></dc:creator><description><![CDATA[The emerging markets-focused company is becoming a member of the crypto lobbying group and plans to engage with regulators and other stakeholders.]]></description><pubDate>Mon, 27 Jun 2022 16:14:14 +0000</pubDate><atom:updated>2022-06-27T16:53:00.397+00:00</atom:updated><category domain="https://www.coindesk.com/business/"><![CDATA[Business]]></category><media:content url="https://www.coindesk.com/resizer/zKFtQmeLBbbEwJR9l5uKEVyAmt4=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/6IU5B5O6Z5D2ZH4COA37BGGJZM.jpg" type="image/jpeg" height="600" width="800"><media:description type="plain"><![CDATA[Tribal offers a business-to-business payment platform. (Tribal)]]></media:description></media:content></item><item><title><![CDATA[The One Word That Defines Ethereum’s Goals]]></title><link>https://www.coindesk.com/layer2/2022/06/27/the-one-word-that-defines-ethereums-goals/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">4JS7B7JMK5FLPEUOT6LHEDSVOA</guid><dc:creator><![CDATA[Dr. Paul J. Dylan-Ennis]]></dc:creator><description></description><pubDate>Mon, 27 Jun 2022 16:12:24 +0000</pubDate><atom:updated>2022-06-27T16:12:25.044+00:00</atom:updated><category domain="https://www.coindesk.com/layer2/"><![CDATA[Layer 2]]></category><media:content url="https://www.coindesk.com/resizer/Z8ESj3cPbfKdIlR4lADe-qVGdVE=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/5NVQ2YOYVJGI7FXPXBX2Z3ZYDM.png" type="image/png" height="600" width="800"><media:description type="plain"><![CDATA[(Romain Vignes/Unsplash, modified by CoinDesk)]]></media:description></media:content></item><item><title><![CDATA[Introducing Future of Work Week]]></title><link>https://www.coindesk.com/layer2/futureofworkweek/2022/06/27/introducing-future-of-work-week/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">3ST4ZGIC65HBNNJ4Q23YF6VTGI</guid><dc:creator><![CDATA[Ben Schiller]]></dc:creator><description><![CDATA[Decentralized autonomous organizations (DAOs) are the new way of work, attracting people who  don't want to work for companies anymore.]]>
+    </description>
+        <pubDate>Mon, 27 Jun 2022 15:24:47 +0000</pubDate>
+        <atom:updated>2022-06-27T16:11:12.312+00:00</atom:updated>
+        <category domain="https://www.coindesk.com/layer2/futureofworkweek/">
+            <![CDATA[Future of Work Week]]>
+        </category><media:content url="https://www.coindesk.com/resizer/sDjkaPOpO_9x2pQ0m3NjfRum3sw=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/OLZTGM5ICZCVXAGRWVIQSJGZYA.png" type="image/png" height="600" width="800"/></item>
+        <item>
+            <title>
+                <![CDATA[NFT, Private Wallet Fates Hang on EU Crypto Talks This Week]]>
+            </title>
+            <link>https://www.coindesk.com/policy/2022/06/27/nft-private-wallet-fates-hang-on-eu-crypto-talks-this-week/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">KKDGFZSVY5FSFKAEGA5G7LDNUM</guid>
+            <dc:creator>
+                <![CDATA[Jack Schickler]]>
+            </dc:creator>
+            <description>
+                <![CDATA[Officials could this week finalize controversial privacy and licensing rules for the sector – once they decide how to treat NFTs and unhosted wallets.]]>
+            </description>
+            <pubDate>Mon, 27 Jun 2022 15:17:52 +0000</pubDate>
+            <atom:updated>2022-06-27T18:50:47.963+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/policy/">
+                <![CDATA[Policy]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/WG0aOtiI2W-tHBFphFGXSxhCJyg=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/RNFF63UV2JF6FOXA3JDCSBCQPY.jpg" type="image/jpeg" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[The European Parliament is set to make key decisions on crypto privacy and NFTs this week. (Laura Zulian Photography/Getty Images)]]>
+                </media:description>
+                <media:credit role="author" scheme="urn:ebu">Laura Zulian Photography</media:credit>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[Grayscale Remains ‘Unequivocally Committed’ to Converting GBTC to an ETF]]>
+            </title>
+            <link>https://www.coindesk.com/business/2022/06/27/grayscale-remains-unequivocally-committed-to-converting-gbtc-to-an-etf/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">VR3G7RJDPJEUZFCAHZ2XPGGGIE</guid>
+            <dc:creator>
+                <![CDATA[Michael Bellusci]]>
+            </dc:creator>
+            <description>
+                <![CDATA[A July 6 deadline for an SEC ruling on Grayscale’s GBTC product looms]]>
+            </description>
+            <pubDate>Mon, 27 Jun 2022 15:10:35 +0000</pubDate>
+            <atom:updated>2022-06-27T16:25:14.765+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/business/">
+                <![CDATA[Business]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/NUg31JUbncwCDE81H4_eTFDXDIc=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/K67YCGVST5EXND4NY6ACA6JSEY.jpg" type="image/jpeg" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[Grayscale CEO Michael Sonnenshein (CoinDesk archives)]]>
+                </media:description>
+                <media:credit role="author" scheme="urn:ebu">CoinDesk Staff</media:credit>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[Crypto Exchange Unizen Receives $200M 'Capital Commitment' From Investment Group GEM]]>
+            </title>
+            <link>https://www.coindesk.com/business/2022/06/27/cypto-exchange-unizen-receives-200m-capital-commitment-from-investment-group-gem/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">YMP66CBEB5CJZMSMNPC6CS4VQY</guid>
+            <dc:creator>
+                <![CDATA[Jamie Crawley]]>
+            </dc:creator>
+            <description>
+                <![CDATA[Cryptocurrency exchange Unizen has received $200 million from alternative investment group Global Emerging Markets (GEM) to accelerate development of its trade aggregation system.]]>
+            </description>
+            <pubDate>Mon, 27 Jun 2022 15:00:00 +0000</pubDate>
+            <atom:updated>2022-06-27T18:26:49.676+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/business/">
+                <![CDATA[Business]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/eGeWOgkS48YXvUpGMNsVjqtH4ps=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/AXR2HPSGAZCZLBVPTT2YGI5URE.jpg" type="image/jpeg" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[Unizen has received $200 million from alternative investment group Global Emerging Markets. (Shutterstock)]]>
+                </media:description>
+                <media:credit role="author" scheme="urn:ebu">Shutterstock</media:credit>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[Azuro Raises $4M for ‘Decentralized Sportsbook Protocol’]]>
+            </title>
+            <link>https://www.coindesk.com/business/2022/06/27/azuro-raises-4m-for-decentralized-sportsbook-protocol/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">EP4F3LKWAJFLJGK2FJJ4QCD6KI</guid>
+            <dc:creator>
+                <![CDATA[Eli Tan]]>
+            </dc:creator>
+            <description>
+                <![CDATA[The funding marks the latest injection of capital into the nascent blockchain betting industry.]]>
+            </description>
+            <pubDate>Mon, 27 Jun 2022 15:00:00 +0000</pubDate>
+            <atom:updated>2022-06-27T18:38:33.885+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/business/">
+                <![CDATA[Business]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/YykmK3-lrTcR4vyP2uOTKJHpTtg=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/XPNLVULVJNHABHOBN5O67CRDQI.jpg" type="image/jpeg" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[(Sarah Stierch/flickr)]]>
+                </media:description>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[Chase Chapman on DAOs and Professional Polyamory]]>
+            </title>
+            <link>https://www.coindesk.com/layer2/futureofworkweek/2022/06/27/chase-chapman-on-daos-and-professional-polyamory/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">XZOGMEE2UZBFRCJVPBMBSLMXRY</guid>
+            <dc:creator>
+                <![CDATA[Jessica  Klein]]>
+            </dc:creator>
+            <description>
+                <![CDATA[“There's a lot of value in talent that doesn't want to be held down by one organization.” This interview is part of CoinDesk's "Future of Work" Week.]]></description><pubDate>Mon, 27 Jun 2022 14:56:31 +0000</pubDate><atom:updated>2022-06-27T15:47:45.604+00:00</atom:updated><category domain="https://www.coindesk.com/layer2/futureofworkweek/"><![CDATA[Future of Work Week]]></category><media:content url="https://www.coindesk.com/resizer/dIJqH-PZ_LKzdSldOQjf5L7x-gY=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/FRJUJNPT45BRRHGLCEUCXRPKV4.png" type="image/png" height="600" width="800"><media:description type="plain"><![CDATA[Chase Chapman, a member of the core team and DAO of Orca Protocol, modified by Melody Wang/CoinDesk.]]></media:description></media:content></item><item><title><![CDATA[Fondos de inversión y traders cripto recortan Tether tras la implosión de UST, según informe]]></title><link>https://www.coindesk.com/markets/2022/06/27/fondos-de-inversion-y-traders-cripto-recortan-tether-tras-la-implosion-de-ust-segun-informe/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">C27GOPXMUZCL3FFENAMV7ABDYA</guid><dc:creator><![CDATA[Shaurya Malwa]]></dc:creator><description><![CDATA[Las posiciones tienen un valor de al menos “cientos de millones” de dólares, dijo un trader.]]></description><pubDate>Mon, 27 Jun 2022 14:49:37 +0000</pubDate><atom:updated>2022-06-27T14:49:37.998+00:00</atom:updated><category domain="https://www.coindesk.com/markets/"><![CDATA[Markets]]></category><media:content url="https://www.coindesk.com/resizer/90PMXzwVKI0NGfJuTWtqTm6TNdY=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/RMLPLGA7J5CEZOBVEN5FJS6AZY.jpg" type="image/jpeg" height="600" width="800"><media:description type="plain"><![CDATA[Dólar estadounidense. (Chris Rogers/Getty Images)]]></media:description><media:credit role="author" scheme="urn:ebu">Chris Rogers</media:credit></media:content></item><item><title><![CDATA[FTX Token DAO Raises $7M From Community of Sam Bankman-Fried Fans]]></title><link>https://www.coindesk.com/business/2022/06/27/ftx-token-dao-raises-7m-from-community-of-sam-bankman-fried-fans/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">JTAJUS5KJZFQ5K5SG3FLWULUUQ</guid><dc:creator><![CDATA[Oliver Knight]]></dc:creator><description><![CDATA[The dedicated FTX token (FTT) DAO has raised $7 million from its community members as plans to invest in crypto education and DeFi.]]></description><pubDate>Mon, 27 Jun 2022 13:45:46 +0000</pubDate><atom:updated>2022-06-27T19:48:23.096+00:00</atom:updated><category domain="https://www.coindesk.com/business/"><![CDATA[Business]]></category><media:content url="https://www.coindesk.com/resizer/2pTibcpkawSfJYJb0itwicIcaGw=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/TKS7FQAZMNHRHOLZB7NVH4WCLQ.jpg" type="image/jpeg" height="600" width="800"><media:description type="plain"><![CDATA[Sam Bankman-Fried speaks at Crypto Bahamas 2022. (Danny Nelson/CoinDesk)]]></media:description></media:content></item><item><title><![CDATA[Según Morgan Stanley, la demanda de GPUs podría ralentizarse si Ethereum pasa a proof-of-stake]]></title><link>https://www.coindesk.com/business/2022/06/27/segun-morgan-stanley-la-demanda-de-gpus-podria-ralentizarse-si-ethereum-pasa-a-proof-of-stake/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">3BVCT57K5JGA3KX7U7OUWW7CSU</guid><dc:creator><![CDATA[Will Canny]]></dc:creator><description><![CDATA[El cambio tampoco resolverá los problemas de escala de Ethereum, agregó el informe del banco.]]></description><pubDate>Mon, 27 Jun 2022 13:41:38 +0000</pubDate><atom:updated>2022-06-27T16:12:36.329+00:00</atom:updated><category domain="https://www.coindesk.com/business/"><![CDATA[Business]]></category><media:content url="https://www.coindesk.com/resizer/obOOTz9pG5D9ObG7N3hVlTEJfOE=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/QCTJI2LUTBATDH75EPCMP7VCO4.jpg" type="image/jpeg" height="600" width="800"><media:description type="plain"><![CDATA[La fusión de Ethereum frenará la demanda de GPUs. (Bradley D. Saum/Shutterstock)]]></media:description><media:credit role="author" scheme="urn:ebu">Bradley D. Saum/Shutterstock</media:credit></media:content></item><item><title><![CDATA[First Mover Americas: Bitcoin Holds $21K as BTC Outflows Hit Record High]]></title><link>https://www.coindesk.com/markets/2022/06/27/first-mover-americas-bitcoin-holds-21k-as-btc-outflows-hit-record-high/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">S6MIHZXFEZAHZL7EHNXYG3VEZI</guid><dc:creator><![CDATA[Lyllah Ledesma]]></dc:creator><description><![CDATA[The latest price moves in bitcoin ($BTC) and crypto markets in context, for June 24, 2022.]]></description><pubDate>Mon, 27 Jun 2022 13:26:35 +0000</pubDate><atom:updated>2022-06-27T19:05:30.837+00:00</atom:updated><category domain="https://www.coindesk.com/markets/"><![CDATA[Markets]]></category><media:content url="https://www.coindesk.com/resizer/L_C87P9HqNQHSr9c3rNCfKoEL_U=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/JFSNYYC3GRCLTPLBIP45LNZ7XQ.jpg" type="image/jpeg" height="600" width="800"><media:description type="plain"><![CDATA[Bitcoin's net outflows hit a record last week. (photo-lime/Getty images)]]>
+    </media:description>
+        <media:credit role="author" scheme="urn:ebu">photo-lime</media:credit>
+    </media:content>
+    </item>
+        <item>
+            <title>
+                <![CDATA[Goldman Cuts Coinbase to ‘Sell’ Due to Fall in Crypto Prices and Industry Activity; Shares Drop ]]>
+            </title>
+            <link>https://www.coindesk.com/business/2022/06/27/goldman-cuts-coinbase-to-sell-due-to-fall-in-crypto-prices-and-industry-activity-shares-drop/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">DHPV4ZQMMZGL5LY6KS2GFWCE3Y</guid>
+            <dc:creator>
+                <![CDATA[Will Canny]]>
+            </dc:creator>
+            <description>
+                <![CDATA[The company faces a difficult choice between shareholder dilution and effective employee compensation, the report said.]]>
+            </description>
+            <pubDate>Mon, 27 Jun 2022 12:48:45 +0000</pubDate>
+            <atom:updated>2022-06-27T19:27:48.805+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/business/">
+                <![CDATA[Business]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/OQHGUg8ihKLzUj8QfRftZpcac_Y=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/NXCHBGV3XJG6NCWVF52QG7PEXI.jpeg" type="image/jpeg" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[Coinbase CEO Brian Armstrong (Coinbase)]]>
+                </media:description>
+                <media:credit role="author" scheme="urn:ebu"></media:credit>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[Payroll, Web3 and the $62B Opportunity]]>
+            </title>
+            <link>https://www.coindesk.com/layer2/futureofworkweek/2022/06/27/payroll-web3-and-the-62b-opportunity/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">75HSGQWPLZHETNTGTMCG6CC7OY</guid>
+            <dc:creator>
+                <![CDATA[Megan  Knab]]>
+            </dc:creator>
+            <description>
+                <![CDATA[Crypto can make it faster and cheaper to pay workers. This article is part of the “Future of Work” series.]]>
+            </description>
+            <pubDate>Mon, 27 Jun 2022 12:41:52 +0000</pubDate>
+            <atom:updated>2022-06-27T13:12:37.205+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/layer2/futureofworkweek/">
+                <![CDATA[Future of Work Week]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/mn0cSXj_xz1Tij9YQ5MWl71b5nw=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/YGZYVGUHL5AQZJELPUTU3DQC4Y.jpg" type="image/jpeg" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[(Viktor Forgacs/Unsplash)]]>
+                </media:description>
+                <media:credit role="author" scheme="urn:ebu"></media:credit>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[You’re Hiring Wrong: Do It More Like Web3]]>
+            </title>
+            <link>https://www.coindesk.com/layer2/futureofworkweek/2022/06/27/youre-hiring-wrong-do-it-more-like-web3/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">SYSAUJKYBVHQ3O5C6ZBSBAYGVI</guid>
+            <dc:creator>
+                <![CDATA[Avi Meyers]]>
+            </dc:creator>
+            <description>
+                <![CDATA[By adopting a more open, fluid model, traditional firms would find it easier to attract talent and end up with a more passionate, engaged workforce.]]>
+            </description>
+            <pubDate>Mon, 27 Jun 2022 12:40:24 +0000</pubDate>
+            <atom:updated>2022-06-27T12:40:25.033+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/layer2/futureofworkweek/">
+                <![CDATA[Future of Work Week]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/SrOTFaWRq6-yIcSG5WWrALJEd-k=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/6NVODBOXDFAVJL3G37U26ZCHFY.jpg" type="image/jpeg" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[Instead of a gated community, think of your entry-level talent pool as a community garden where anyone can come and contribute. (Tim Mossholder/Unsplash, modified by CoinDesk)]]>
+                </media:description>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[The Crypto Jobs Boom]]>
+            </title>
+            <link>https://www.coindesk.com/layer2/futureofworkweek/2022/06/27/the-crypto-jobs-boom/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">AIB3OLKKURHSFM4GFFEQPIVYVE</guid>
+            <dc:creator>
+                <![CDATA[Jeff  Wilser]]>
+            </dc:creator>
+            <description>
+                <![CDATA[It may be a bear market, but there are still plenty of jobs to be had at crypto companies. This article is part of CoinDesk's "Future of Work" Week.]]></description><pubDate>Mon, 27 Jun 2022 12:38:40 +0000</pubDate><atom:updated>2022-06-27T18:08:22.900+00:00</atom:updated><category domain="https://www.coindesk.com/layer2/futureofworkweek/"><![CDATA[Future of Work Week]]></category><media:content url="https://www.coindesk.com/resizer/JOyRiv010UXJQP-xsPDEixO4RFM=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/NMEGEO34T5BKNGZEMXKEYQFD4Q.png" type="image/png" height="600" width="800"><media:description type="plain"><![CDATA[(Yunha Lee/CoinDesk)]]></media:description><media:credit role="author" scheme="urn:ebu">(Yunha Lee/CoinDesk)</media:credit></media:content></item><item><title><![CDATA[Voyager Digital Issues Default Notice to Three Arrows Capital]]></title><link>https://www.coindesk.com/business/2022/06/27/voyager-digital-issues-default-notice-to-3ac-draws-down-75m-of-alameda-revolver/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">CYQDE2XMRZBPNN5LQBIAOHYGWE</guid><dc:creator><![CDATA[Jamie Crawley]]></dc:creator><description><![CDATA[Crypto broker has issued a notice of default to Three Arrows Capital (3AC) after the beleaguered hedge fund failed to make the required payments on its loans of 15,250 bitcoin and $350 million in USDC.]]></description><pubDate>Mon, 27 Jun 2022 12:24:53 +0000</pubDate><atom:updated>2022-06-27T19:47:17.902+00:00</atom:updated><category domain="https://www.coindesk.com/business/"><![CDATA[Business]]></category><media:content url="https://www.coindesk.com/resizer/2RipYBgNq5cWnqIW9s8LkQUpR8g=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/XMZRDEGMBJERZEHTMXDMQNLYBI.png" type="image/png" height="600" width="800"><media:description type="plain"><![CDATA[Steve Ehrlich, co-founder and CEO of Voyager Digital (YouTube)]]></media:description></media:content></item><item><title><![CDATA[Crypto Hedge Funds, Traders Short Tether After UST’s Implosion: Report]]></title><link>https://www.coindesk.com/markets/2022/06/27/crypto-hedge-funds-traders-short-tether-after-usts-implosion-report/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">FTCNDOATXZGFXFUEETXJWCW4QI</guid><dc:creator><![CDATA[Shaurya Malwa]]></dc:creator><description><![CDATA[The positions are worth at least “hundreds of millions” of dollars in notional value, one trader said.]]></description><pubDate>Mon, 27 Jun 2022 11:40:40 +0000</pubDate><atom:updated>2022-06-27T17:50:15.919+00:00</atom:updated><category domain="https://www.coindesk.com/markets/"><![CDATA[Markets]]></category><media:content url="https://www.coindesk.com/resizer/90PMXzwVKI0NGfJuTWtqTm6TNdY=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/RMLPLGA7J5CEZOBVEN5FJS6AZY.jpg" type="image/jpeg" height="600" width="800"><media:description type="plain"><![CDATA[(Chris Rogers/Getty Images)]]></media:description><media:credit role="author" scheme="urn:ebu">Chris Rogers</media:credit></media:content></item><item><title><![CDATA[Morgan Stanley: GPU Demand Likely to Slow if Ethereum Moves to Proof-of-Stake]]></title><link>https://www.coindesk.com/business/2022/06/27/morgan-stanley-gpu-demand-likely-to-slow-if-ethereum-moves-to-proof-of-stake/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">QOVEU4MAVFC2BFTMICXP4O2XJU</guid><dc:creator><![CDATA[Will Canny]]></dc:creator><description><![CDATA[A mov to PoS will also not solve Ethereum’s scaling problems, the report said.]]></description><pubDate>Mon, 27 Jun 2022 11:04:16 +0000</pubDate><atom:updated>2022-06-27T17:51:40.473+00:00</atom:updated><category domain="https://www.coindesk.com/business/"><![CDATA[Business]]></category><media:content url="https://www.coindesk.com/resizer/obOOTz9pG5D9ObG7N3hVlTEJfOE=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/QCTJI2LUTBATDH75EPCMP7VCO4.jpg" type="image/jpeg" height="600" width="800"><media:description type="plain"><![CDATA[Ethereum's Merge will slow demand for GPUs. (Bradley D. Saum/Shutterstock)]]>
+    </media:description>
+        <media:credit role="author" scheme="urn:ebu">Bradley D. Saum/Shutterstock</media:credit>
+    </media:content>
+    </item>
+        <item>
+            <title>
+                <![CDATA[Ethereum Lending Protocol XCarnival Hit With $3.8M Exploit, Recovers 50%]]>
+            </title>
+            <link>https://www.coindesk.com/business/2022/06/27/ethereum-lending-protocol-xcarnival-hit-with-38m-exploit-recovers-50/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">7CCO33XN6VGO7CXTBIMWN2HKYQ</guid>
+            <dc:creator>
+                <![CDATA[Oliver Knight]]>
+            </dc:creator>
+            <description>
+                <![CDATA[Singapore-based metaverse lending protocol XCarnival recovered 1,467 ether following an exploit that saw a hacker siphon 3,087 ETH out of the platform.]]>
+            </description>
+            <pubDate>Mon, 27 Jun 2022 10:31:12 +0000</pubDate>
+            <atom:updated>2022-06-27T17:10:56.624+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/business/">
+                <![CDATA[Business]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/NsMuAEDk0NK6nUD3QDPcNbi7T3o=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/XJTG7PYRNRDVVD2G3NV54BW2YM.jpg" type="image/jpeg" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[Some $3.8 million was siphoned from NFT lending platform XCarnival (Kevin Ku/Unsplash)]]>
+                </media:description>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[Australian Crypto Exchange Banxa Lays Off 70]]>
+            </title>
+            <link>https://www.coindesk.com/business/2022/06/27/australian-crypto-exchange-banxa-cuts-70-staff/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">QO62LUAXHJC4DC4VJLUZN77OVM</guid>
+            <dc:creator>
+                <![CDATA[Shaurya Malwa]]>
+            </dc:creator>
+            <description>
+                <![CDATA[The publicly traded crypto exchange said the "crypto winter" drove the decision to reduce headcount by about 30%.]]>
+            </description>
+            <pubDate>Mon, 27 Jun 2022 09:35:13 +0000</pubDate>
+            <atom:updated>2022-06-27T17:22:58.627+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/business/">
+                <![CDATA[Business]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/S0lUTwwpxXDn4MlacB5fx_o4bW0=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/4UXH2RI56ND23MZDGB7ETST6II.jpg" type="image/jpeg" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[Staff leaving (Joao Viegas/Unsplash)]]>
+                </media:description>
+                <media:credit role="author" scheme="urn:ebu">Staff leaving. (Photo by Joao Viegas/Unsplash)</media:credit>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[Nexo Sends Cease-and-Desist Letter to Anonymous Twitter Account Accusing It of Embezzlement]]>
+            </title>
+            <link>https://www.coindesk.com/business/2022/06/27/nexo-sends-cease-and-desist-letter-to-anonymous-twitter-account-accusing-it-of-embezzlement/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">34U5IUG7QBFHFHKYSFZR2W2WIQ</guid>
+            <dc:creator>
+                <![CDATA[Sam Reynolds]]>
+            </dc:creator>
+            <description>
+                <![CDATA[The Twitter account “@otteroooo” has claimed that crypto lender Nexo embezzled funds from a charity. Nexo says the the account user is intentionally using the name of someone unrelated to Nexo.]]>
+            </description>
+            <pubDate>Mon, 27 Jun 2022 06:37:10 +0000</pubDate>
+            <atom:updated>2022-06-27T16:01:47.991+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/business/">
+                <![CDATA[Business]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/IS32WpmPEGeK-dGslwYbJumSf3M=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/GVGYE3XFABBIZETNRWFHDTWUVA.jpg" type="image/jpeg" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[(Rich Miller/Flickr)]]>
+                </media:description>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[First Mover Asia: Bitcoin Holds Above $21K in Weekend Trading, Solana Web3 Phone Faces Long Odds ]]>
+            </title>
+            <link>https://www.coindesk.com/markets/2022/06/26/first-mover-asia-bitcoin-holds-above-21k-in-weekend-trading-solana-web3-phone-faces-long-odds/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">UZ36O2IVGNDBXKEOV5JKWLZGXI</guid>
+            <dc:creator>
+                <![CDATA[Sam Reynolds, James Rubin]]>
+            </dc:creator>
+            <description>
+                <![CDATA[Prior blockchain phones have failed because the market have realized their functionalities are available already via apps that can be loaded onto any old phone; ether stays above $1,200.]]>
+            </description>
+            <pubDate>Sun, 26 Jun 2022 23:26:15 +0000</pubDate>
+            <atom:updated>2022-06-27T15:44:27.124+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/markets/">
+                <![CDATA[Markets]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/cdcTbEC9XNQ3UX7XFZQ5WTuuVZc=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/X26EXWKTWVHFRHQR3MHDX563UY.jpg" type="image/jpeg" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[Bitcoin was down slightly on Sunday, but still trading at over $21,000. (Jay Radhakrishnan)]]>
+                </media:description>
+                <media:credit role="author" scheme="urn:ebu">jayk7</media:credit>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[Opaque Platforms and Intertwined Protocols Pose Big Risk to Crypto]]>
+            </title>
+            <link>https://www.coindesk.com/markets/2022/06/26/opaque-platforms-and-intertwined-protocols-pose-big-risk-to-crypto/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">TJUUBYR3ORAJ3F7FQKLPHC7ECY</guid>
+            <dc:creator>
+                <![CDATA[George Kaloudis]]>
+            </dc:creator>
+            <description>
+                <![CDATA[Second article in a series about risks we’re thinking about during these crypto down days.]]>
+            </description>
+            <pubDate>Sun, 26 Jun 2022 14:50:00 +0000</pubDate>
+            <atom:updated>2022-06-26T14:57:07.556+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/markets/">
+                <![CDATA[Markets]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/BynF5ITgkGKFBBP2Ae-65ckuv3o=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/VVISK5DXABFN7IWQWBT7QNKYN4.jpg" type="image/jpeg" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[Interdependent protocols and black-box platforms make for a dicey pairing. (Edge2Edge Media/Unsplash)]]>
+                </media:description>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[Morgan Creek Is Trying to Counter FTX’s BlockFi Bailout, Leaked Call Shows]]>
+            </title>
+            <link>https://www.coindesk.com/business/2022/06/25/morgan-creek-is-trying-to-counter-ftxs-blockfi-bailout-leaked-call-shows/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">3JEJSX7ACND6JGOE2ENFRNA32I</guid>
+            <dc:creator>
+                <![CDATA[Tracy Wang]]>
+            </dc:creator>
+            <description>
+                <![CDATA[FTX’s $250 million credit facility offer – if inked as initially proposed – stood to effectively wipe out all BlockFi shareholders, including Morgan Creek Digital, the firm told its investors.]]>
+            </description>
+            <pubDate>Sat, 25 Jun 2022 21:16:24 +0000</pubDate>
+            <atom:updated>2022-06-27T18:52:24.868+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/business/">
+                <![CDATA[Business]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/NJoymts7f93b3KUg8ttbTAI836A=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/NXAR5S4FVBBTHM5FF5YZFETENE.jpg" type="image/jpeg" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[Mark Yusko, founder of Morgan Creek Capital Management, speaks at Consensus 2018. (CoinDesk archives)]]>
+                </media:description>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[Bitcoin se estabiliza cerca de $21K; inversores esperan evitar otra caída el fin de semana]]>
+            </title>
+            <link>https://www.coindesk.com/markets/2022/06/24/bitcoin-se-estabiliza-cerca-de-21k-inversores-esperan-evitar-otra-caida-el-fin-de-semana/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">Q3G7CK5NZNC2ZEEQJUNCMMREOU</guid>
+            <dc:creator>
+                <![CDATA[Jimmy He]]>
+            </dc:creator>
+            <description>
+                <![CDATA[Los analistas se cuestionan si BTC podrá mantenerse por encima del umbral de $20.000 en un clima de desconfianza entre los inversores.]]>
+            </description>
+            <pubDate>Fri, 24 Jun 2022 21:07:39 +0000</pubDate>
+            <atom:updated>2022-06-24T21:07:40.319+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/markets/">
+                <![CDATA[Markets]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/6P7kBlHCHbqbVQEf2WVCcOUBCrQ=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/ZLXKQJBMMNBPHCSDJY6VJ4QXXQ.jpeg" type="image/jpeg" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[Bitcoin subió en el trading del día viernes. (Jay Radhakrishnan)]]>
+                </media:description>
+                <media:credit role="author" scheme="urn:ebu"></media:credit>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[Market Wrap: From GBTC Discount to Short Bitcoin ETF, Traders See Reasons for Optimism  ]]>
+            </title>
+            <link>https://www.coindesk.com/markets/2022/06/24/market-wrap-from-gbtc-discount-to-short-bitcoin-etf-traders-see-reasons-for-optimism/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">ISXI2M2AB5BYLP2CGEI4YX4E3A</guid>
+            <dc:creator>
+                <![CDATA[Bradley Keoun, Jimmy He]]>
+            </dc:creator>
+            <description>
+                <![CDATA[It's hard to imagine that data showing traders piling into a trade designed to profit from further bitcoin price declines might be bullish, but that's how some analysts are interpreting the signal.]]>
+            </description>
+            <pubDate>Fri, 24 Jun 2022 20:29:56 +0000</pubDate>
+            <atom:updated>2022-06-27T13:58:27.603+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/markets/">
+                <![CDATA[Markets]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/7r8HtLMUgoQyzPoDDiI1E3_ZRwk=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/GPBZ4XTHOZCT7NICTHRDEID7VE.png" type="image/png" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[Seemingly bearish market indicators are seen by analysts as reasons for optimism. (Creative Commons)]]>
+                </media:description>
+                <media:credit role="author" scheme="urn:ebu"></media:credit>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[Goldman Sachs Leading Investor Group to Buy Celsius Assets: Sources]]>
+            </title>
+            <link>https://www.coindesk.com/business/2022/06/24/goldman-sachs-raising-funds-to-buy-celsius-assets-sources/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">4XYL5SSYWVGQFLULQPDEEEURU4</guid>
+            <dc:creator>
+                <![CDATA[Tracy Wang]]>
+            </dc:creator>
+            <description>
+                <![CDATA[The Wall Street firm is seeking $2 billion in commitments from investors to buy distressed assets at steep discounts if the crypto lender goes bankrupt.]]>
+            </description>
+            <pubDate>Fri, 24 Jun 2022 20:12:48 +0000</pubDate>
+            <atom:updated>2022-06-24T21:10:34.236+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/business/">
+                <![CDATA[Business]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/WWHAGql4mQU1-M7iTR0shhHlQ7Y=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/3DFH774MUVD7FOLU43FC4YJJQ4.jpeg" type="image/jpeg" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[Goldman Sachs is said to have an eye on Celsius. (Chris Hondros/Getty Images)]]>
+                </media:description>
+                <media:credit role="author" scheme="urn:ebu">Chris Hondros</media:credit>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[Why the Crypto Crash Will Accelerate Regulatory Action]]>
+            </title>
+            <link>https://www.coindesk.com/layer2/2022/06/24/why-the-crypto-crash-will-accelerate-regulatory-action/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">B3EK5KEITJDZRMN7CI6RK3ZAMY</guid>
+            <dc:creator>
+                <![CDATA[Tracy Basinger, Jonah Crane]]>
+            </dc:creator>
+            <description>
+                <![CDATA[Recent events, including the collapse of the TerraUSD stablecoin, are likely to hasten regulators consideration of crypto regulation.]]>
+            </description>
+            <pubDate>Fri, 24 Jun 2022 19:59:29 +0000</pubDate>
+            <atom:updated>2022-06-24T20:09:52.567+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/layer2/">
+                <![CDATA[Layer 2]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/v85O8VPEALssolYyoVzCtPlTS-U=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/MUBJ6EMIXZB5VLGDPKTNACLLEQ.jpg" type="image/jpeg" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[U.S. Capitol Building (uschools/Getty Images)]]>
+                </media:description>
+                <media:credit role="author" scheme="urn:ebu">uschools</media:credit>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[Es argentino, ofrece tours en Airbnb para explicar bitcoin y a los turistas les encanta]]>
+            </title>
+            <link>https://www.coindesk.com/business/2022/06/24/es-argentino-ofrece-tours-en-airbnb-para-explicar-bitcoin-y-a-los-turistas-les-encanta/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">36XEN6CD5RGXHF4B2GYJDYFVIM</guid>
+            <dc:creator>
+                <![CDATA[Marina Lammertyn]]>
+            </dc:creator>
+            <description>
+                <![CDATA[Después de que Argentina confiscara sus ahorros dos veces, Jerónimo Ferrer descubrió bitcoin y convirtió su historia en un recorrido con cientos de visitantes y una calificación de 4,9 (sobre 5) estrellas en Airbnb.]]>
+            </description>
+            <pubDate>Fri, 24 Jun 2022 19:07:04 +0000</pubDate>
+            <atom:updated>2022-06-24T19:48:04.393+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/business/">
+                <![CDATA[Business]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/NSjEcvpM9dRqsIM-rMiU-uZnNsE=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/7JRY7GLZHJCPRNYE27PNPRGI4U.jpeg" type="image/jpeg" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[Jerónimo Ferrer en Buenos Aires, explicando bitcoin a turistas. (Jerónimo Ferrer/Airbnb)]]>
+                </media:description>
+                <media:credit role="author" scheme="urn:ebu"></media:credit>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[With Bitwise and Grayscale Decisions Looming, Spot Bitcoin ETF Approval Hopes Are Running Low]]>
+            </title>
+            <link>https://www.coindesk.com/business/2022/06/24/with-bitwise-and-grayscale-decisions-looming-spot-bitcoin-etf-approval-hopes-are-running-low/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">TXW5CSEKSRGFJIU4DB4ONB355U</guid>
+            <dc:creator>
+                <![CDATA[Michael Bellusci]]>
+            </dc:creator>
+            <description>
+                <![CDATA[Final deadlines for approval by the SEC for the two applications are fast approaching.]]>
+            </description>
+            <pubDate>Fri, 24 Jun 2022 19:06:13 +0000</pubDate>
+            <atom:updated>2022-06-24T20:07:57.433+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/business/">
+                <![CDATA[Business]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/pc6hZpFxcmxNMkTsziFUAN6yYbY=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/54Y2WYFEW5BN3P3MBE2W7WBY3Q" type="image/jpeg" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[Grayscale CEO Michael Sonnenshein, second from right, attending a Consensus event in 2016 (CoinDesk archives)]]>
+                </media:description>
+                <media:credit role="author" scheme="urn:ebu"></media:credit>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[This Buenos Aires Evangelist Offers Tours to Expound Bitcoin, Tourists Love It]]>
+            </title>
+            <link>https://www.coindesk.com/business/2022/06/24/this-buenos-aires-evangelist-offers-tours-to-expound-bitcoin-tourists-love-it/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">OQJ2WS7J4RBYZODO7P7P533FXM</guid>
+            <dc:creator>
+                <![CDATA[Marina Lammertyn]]>
+            </dc:creator>
+            <description>
+                <![CDATA[After having his savings confiscated by Argentina twice, Jerónimo Ferrer discovered bitcoin. And he made his story into a tour with hundreds of visitors and high ratings.]]>
+            </description>
+            <pubDate>Fri, 24 Jun 2022 18:58:00 +0000</pubDate>
+            <atom:updated>2022-06-24T19:46:59.855+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/business/">
+                <![CDATA[Business]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/NSjEcvpM9dRqsIM-rMiU-uZnNsE=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/7JRY7GLZHJCPRNYE27PNPRGI4U.jpeg" type="image/jpeg" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[Jerónimo Ferrer with a Bitcoin t-shirt, explaining the crypto boom in Argentina to tourists. (Jerónimo Ferrer/Airbnb)]]>
+                </media:description>
+                <media:credit role="author" scheme="urn:ebu"></media:credit>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[Grayscale Bitcoin Trust's 'GBTC Discount' Narrows With ETF Decision on Horizon]]></title><link>https://www.coindesk.com/markets/2022/06/24/grayscale-bitcoin-trusts-gbtc-discount-narrows-with-etf-decision-on-horizon/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">IBSDEIQ7Y5F2ZBQVFH37MBAKTQ</guid><dc:creator><![CDATA[Lyllah Ledesma]]></dc:creator><description><![CDATA[Shares of the GBTC are trading at a discount of 29% to bitcoin’s price, down from 34% last week – and there's all sorts of speculation on what it means.]]>
+        </description>
+            <pubDate>Fri, 24 Jun 2022 18:45:26 +0000</pubDate>
+            <atom:updated>2022-06-24T18:45:27.305+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/markets/">
+                <![CDATA[Markets]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/77QwdNEOhVbieyed-k1GmMBhTW0=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/TULMMR67MZB4ZIXCEUKUE7PSN4.png" type="image/png" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[The "Grayscale discount" has narrowed after widening out to 34% last week. (Skew)]]>
+                </media:description>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[Bitcoin Hovers Near $21K as Investors Look to Avoid Another Weekend Slump]]>
+            </title>
+            <link>https://www.coindesk.com/markets/2022/06/24/bitcoin-hovers-near-21k-as-investors-look-to-avoid-another-weekend-slump/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">XQEFJZFDVZHUJDZBZYGJOC2KKA</guid>
+            <dc:creator>
+                <![CDATA[Jimmy He]]>
+            </dc:creator>
+            <description>
+                <![CDATA[Bitcoin held steady at about $21K, but analysts say its hold above 20K is precarious.]]>
+            </description>
+            <pubDate>Fri, 24 Jun 2022 18:45:12 +0000</pubDate>
+            <atom:updated>2022-06-24T19:35:58.598+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/markets/">
+                <![CDATA[Markets]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/X4qvloIA5whHS-e5wGMJRihoyQs=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/SANMXWNEURHJDIFCCTTPN5C6A4.jpg" type="image/jpeg" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[Bitcoin rose in Friday trading. (Jay Radhakrishnan)]]>
+                </media:description>
+                <media:credit role="author" scheme="urn:ebu">jayk7</media:credit>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[BlockFi Raises Deposit Rates, Eliminates Free Withdrawals]]>
+            </title>
+            <link>https://www.coindesk.com/business/2022/06/24/blockfi-raises-deposit-rates-eliminates-free-withdrawals/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">ZSE5CCVGMBGJZB66O2VXG7QZDA</guid>
+            <dc:creator>
+                <![CDATA[Sam  Kessler]]>
+            </dc:creator>
+            <description>
+                <![CDATA[The rate increases across BTC, ETH, USDT and other crypto deposits come after layoffs at the company and a $250 million emergency line of credit from FTX.]]>
+            </description>
+            <pubDate>Fri, 24 Jun 2022 17:43:53 +0000</pubDate>
+            <atom:updated>2022-06-24T19:53:59.378+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/business/">
+                <![CDATA[Business]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/E7XgEUcOJna3EobCu31r1bJaOxQ=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/HDMU37Z3QRHO7JQN3K27RUISLQ.jpg" type="image/jpeg" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[BlockFi is set to offer higher yields on deposits. (Torsten Asmus/Getty images)]]>
+                </media:description>
+                <media:credit role="author" scheme="urn:ebu">Torsten Asmus</media:credit>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[European Crypto Exchange Bitpanda Cuts Staff by Hundreds]]>
+            </title>
+            <link>https://www.coindesk.com/business/2022/06/24/european-crypto-exchange-bitpanda-cuts-staff-by-hundreds/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">VHWDT3DGVNERRKKAU277KNWVS4</guid>
+            <dc:creator>
+                <![CDATA[Michael Bellusci]]>
+            </dc:creator>
+            <description>
+                <![CDATA[Bitpanda announced it is reducing its employee count to 730, down from about 1,000.]]>
+            </description>
+            <pubDate>Fri, 24 Jun 2022 17:22:10 +0000</pubDate>
+            <atom:updated>2022-06-24T18:16:14.569+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/business/">
+                <![CDATA[Business]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/MiLvhRcpfq47XqvtMNsfpkyuhQg=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/KOSNFBHQAZEB3NRHPSSV2ZLRXA.jpg" type="image/jpeg" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[Bitpanda co-founders (left to right) Christian Trummer, Paul Klanschek and Eric Demuth.]]>
+                </media:description>
+            </media:content>
+        </item>
+        <item>
+            <title>
+                <![CDATA[Investors Pile Into Short Bitcoin ETF Betting on Prices to Fall]]>
+            </title>
+            <link>https://www.coindesk.com/markets/2022/06/24/investors-pile-into-short-bitcoin-etf-betting-on-prices-to-fall/?utm_medium=referral&amp;utm_source=rss&amp;utm_campaign=headlines</link><link href="https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml" rel="self" type="application/atom+xml"/><link href="https://pubsubhubbub.appspot.com/" rel="hub"/><guid isPermaLink="false">ZXSKN2GONNGPDAIMIOC4JFKFDA</guid>
+            <dc:creator>
+                <![CDATA[Krisztian  Sandor]]>
+            </dc:creator>
+            <description>
+                <![CDATA[ProShares Inverse Bitcoin ETF (BITI) saw large inflows after a lackluster opening day.]]>
+            </description>
+            <pubDate>Fri, 24 Jun 2022 17:21:18 +0000</pubDate>
+            <atom:updated>2022-06-24T17:32:52.794+00:00</atom:updated>
+            <category domain="https://www.coindesk.com/markets/">
+                <![CDATA[Markets]]>
+            </category>
+            <media:content url="https://www.coindesk.com/resizer/b1HnLW9hjnedwzNmuulJetW_4QI=/800x600/cloudfront-us-east-1.images.arcpublishing.com/coindesk/IAQLIQH2PNBL3N3BUWHS6RV3F4.png" type="image/png" height="600" width="800">
+                <media:description type="plain">
+                    <![CDATA[ProShares' short bitcoin ETF toppled Valkyrie's and VanEck's future-based ETFs in assets under management. (Arcane Research)]]></media:description><media:credit role="author" scheme="urn:ebu"></media:credit></media:content></item></channel></rss>

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -158,7 +158,7 @@ fn read_rss1() {
         channel.description().lines().collect::<Vec<_>>(),
         vec![
             "XML.com features a rich mix of information and services ",
-            "      for the XML community."
+            "      for the XML community.",
         ]
     );
 
@@ -186,7 +186,7 @@ fn read_rss1() {
         Some(vec![
             "Processing document inclusions with general XML tools can be ",
             "     problematic. This article proposes a way of preserving inclusion ",
-            "     information through SAX-based processing."
+            "     information through SAX-based processing.",
         ])
     );
 }
@@ -944,4 +944,16 @@ fn read_escaped() {
     let output = channel.to_string();
     let parsed_channel = output.parse::<Channel>().unwrap();
     assert_eq!(channel, parsed_channel);
+}
+
+#[test]
+fn read_multi_links() {
+    let input = include_str!("data/multi_links.xml");
+    let channel = input.parse::<Channel>().expect("failed to parse xml");
+
+    assert_eq!(channel.items.len(), 50);
+    assert_eq!(
+        channel.items[0].link,
+        Some("https://www.coindesk.com/markets/2022/06/28/first-mover-asia-chip-maker-nvidia-isnt-an-ether-proxy-bitcoin-holds-near-21k/?utm_medium=referral&utm_source=rss&utm_campaign=headlines".to_string()),
+    );
 }


### PR DESCRIPTION
Some rss like `https://www.coindesk.com/arc/outboundfeeds/rss/?outputType=xml` will have multi links in single item.

So we could improve parse it by just keep the first valid link.

Let me know if you guys have better way to handle this.