### PR TITLE
Correctly use atom:link instead of link for atom links

### DIFF
--- a/src/extension/atom.rs
+++ b/src/extension/atom.rs
@@ -81,7 +81,7 @@ impl AtomExtension {
 impl ToXml for AtomExtension {
     fn to_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         for link in &self.links {
-            let name = b"link";
+            let name = b"atom:link";
             let mut element = BytesStart::borrowed(name, name.len());
             element.push_attribute(("href", &*link.href));
             element.push_attribute(("rel", &*link.rel));


### PR DESCRIPTION
`<link rel="self>` does not validate in https://validator.w3.org/feed, while this (`<atom:link rel="self">`) does.