### PR TITLE
Add `From<String>` constructor for `Category`

### DIFF
--- a/src/category.rs
+++ b/src/category.rs
@@ -136,6 +136,21 @@ impl ToXml for Category {
     }
 }
 
+impl From<String> for Category {
+    fn from(name: String) -> Self {
+        Self { name, domain: None }
+    }
+}
+
+impl From<&str> for Category {
+    fn from(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            domain: None,
+        }
+    }
+}
+
 #[cfg(feature = "builders")]
 impl CategoryBuilder {
     /// Builds a new `Category`.


### PR DESCRIPTION
This is an alternative to the `Default::default()` constructor. The `Default::default()` constructor produces an empty string for the `name`, which is probably not what the user wants in most cases.

This PR also adds a similar `From<&str>` constructor.