### PR TITLE
Fix `]]>` escaping in `CDATA` sections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ validation = ["chrono", "chrono/std", "url", "mime"]
 with-serde = ["serde", "atom_syndication/with-serde"]
 
 [dependencies]
-quick-xml = { version = "0.37", features = ["encoding"] }
+quick-xml = { version = "0.37.1", features = ["encoding"] }
 atom_syndication = { version = "0.12", optional = true }
 chrono = { version = "0.4.31", optional = true, default-features = false, features = ["alloc"] }
 derive_builder = { version = "0.20", optional = true }

--- a/src/toxml.rs
+++ b/src/toxml.rs
@@ -86,7 +86,8 @@ impl<W: Write> WriterExt for Writer<W> {
     {
         let name = name.as_ref();
         self.write_event(Event::Start(BytesStart::new(name)))?;
-        self.write_event(Event::CData(BytesCData::new(text.as_ref())))?;
+        BytesCData::escaped(text.as_ref())
+            .try_for_each(|event| self.write_event(Event::CData(event)))?;
         self.write_event(Event::End(BytesEnd::new(name)))?;
         Ok(())
     }

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -240,6 +240,7 @@ fn test_escape() {
                     .value("51ed8fb6-e7db-4b1d-a75a-0d1621e895b4")
                     .build(),
             )
+            .description("let's try & break this <item> ]]>, shall we?".to_owned())
             .content("Lorem ipsum dolor sit amet".to_owned())
             .enclosure(
                 EnclosureBuilder::default()
@@ -290,6 +291,7 @@ fn test_escape() {
     assert!(xml.contains("http://example.com?test=1&amp;another=true"));
     assert!(xml.contains("http://example.com?test=2&amp;another=false"));
     assert!(xml.contains("&lt;title&gt;"));
+    assert!(xml.contains("<![CDATA[let's try & break this <item> ]]]]><![CDATA[>, shall we?]]>"));
 
     let channel = rss::Channel::read_from(xml.as_bytes()).unwrap();
 
@@ -322,6 +324,10 @@ fn test_escape() {
             .as_ref()
             .unwrap(),
         "<title>"
+    );
+    assert_eq!(
+        channel.items[0].description.as_ref().unwrap(),
+        "let's try & break this <item> ]]>, shall we?"
     );
 }
 


### PR DESCRIPTION
This PR resolves https://github.com/rust-syndication/rss/issues/173 by splitting `CDATA` sections by the `]]>` search string and adding multiple `BytesCData` events, if necessary.

As [mentioned in the linked issue](https://github.com/rust-syndication/rss/issues/173#issuecomment-2481048385), I've also [reported](https://github.com/tafia/quick-xml/issues/831) this bug at `quick-xml` to clarify who's responsibility the escaping is. If the responsibility is on the caller then this PR should fix the issue.

I ran `cargo bench` a couple of times on `master` and this branch and it seems like the performance impact is negligible.

Related:

- https://github.com/rust-syndication/rss/issues/173
- https://github.com/tafia/quick-xml/issues/831