### PR TITLE
feat: add atom support

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1354,6 +1354,67 @@ impl Channel {
         Ok(channel)
     }
 
+    /// Parse an Atom person construct (author/contributor)
+    /// Returns a tuple of (name, email, uri)
+    #[cfg(feature = "atom")]
+    pub(crate) fn parse_atom_person<R: BufRead>(
+        reader: &mut Reader<R>,
+    ) -> Result<(Option<String>, Option<String>, Option<String>), Error> {
+        let mut name = None;
+        let mut email = None;
+        let mut uri = None;
+        let mut buf = Vec::new();
+
+        loop {
+            match reader.read_event_into(&mut buf)? {
+                Event::Start(element) => match decode(element.name().as_ref(), reader)?.as_ref() {
+                    "name" => name = element_text(reader)?,
+                    "email" => email = element_text(reader)?,
+                    "uri" => uri = element_text(reader)?,
+                    _ => skip(element.name(), reader)?,
+                },
+                Event::End(_) => break,
+                Event::Eof => return Err(Error::Eof),
+                _ => {}
+            }
+            buf.clear();
+        }
+
+        Ok((name, email, uri))
+    }
+
+    /// Parse an Atom category element
+    /// Returns a Category with term mapped to name and scheme mapped to domain
+    #[cfg(feature = "atom")]
+    pub(crate) fn parse_atom_category<R: BufRead>(
+        reader: &mut Reader<R>,
+        element: &BytesStart,
+    ) -> Result<Category, Error> {
+        let mut term = None;
+        let mut scheme = None;
+        let mut label = None;
+
+        for attr in element.attributes().with_checks(false).flatten() {
+            let key = decode(attr.key.as_ref(), reader)?;
+            let value = crate::util::attr_value(&attr, reader)?;
+
+            match key.as_ref() {
+                "term" => term = Some(value.to_string()),
+                "scheme" => scheme = Some(value.to_string()),
+                "label" => label = Some(value.to_string()),
+                _ => {}
+            }
+        }
+
+        // Use label if present, otherwise use term
+        let name = label.or(term).unwrap_or_default();
+
+        Ok(Category {
+            name,
+            domain: scheme,
+        })
+    }
+
     /// Builds a Channel from an Atom feed
     #[cfg(feature = "atom")]
     fn from_atom_feed<R: BufRead>(
@@ -1426,12 +1487,37 @@ impl Channel {
                         let item = Item::from_atom_entry(namespaces.as_ref(), reader, element.attributes())?;
                         channel.items.push(item);
                     }
+                    "author" => {
+                        // RFC 4287: Parse author person construct
+                        let (name, email, _uri) = Self::parse_atom_person(reader)?;
+
+                        // Format as RSS managing_editor: "email (name)" or just email or name
+                        if channel.managing_editor.is_none() {
+                            channel.managing_editor = match (email, name) {
+                                (Some(e), Some(n)) => Some(format!("{} ({})", e, n)),
+                                (Some(e), None) => Some(e),
+                                (None, Some(n)) => Some(n),
+                                (None, None) => None,
+                            };
+                        }
+                    }
+                    "contributor" => {
+                        // RFC 4287: Skip contributors for channel (no RSS equivalent)
+                        // Could be added to extensions in the future
+                        skip(element.name(), reader)?;
+                    }
+                    "category" => {
+                        // RFC 4287: Parse category element
+                        let category = Self::parse_atom_category(reader, &element)?;
+                        channel.categories.push(category);
+                        skip(element.name(), reader)?;
+                    }
                     "id" => {
                         // RFC 4287: id is required for atom:feed
                         // We skip it since RSS Channel doesn't have a direct equivalent
                         skip(element.name(), reader)?;
                     }
-                    "icon" | "logo" | "rights" | "author" | "contributor" | "category" => {
+                    "icon" | "logo" | "rights" => {
                         // Skip optional elements we don't currently map
                         skip(element.name(), reader)?;
                     }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1058,6 +1058,17 @@ impl Channel {
                         .into_owned();
                         break;
                     }
+                    #[cfg(feature = "atom")]
+                    "feed" => {
+                        namespaces = read_namespace_declarations(
+                            &mut reader,
+                            element.attributes(),
+                            &BTreeMap::new(),
+                        )?
+                        .into_owned();
+                        // Parse Atom feed
+                        return Channel::from_atom_feed(&namespaces, &mut reader, element.attributes());
+                    }
                     _ => {
                         return Err(Error::InvalidStartTag);
                     }
@@ -1339,6 +1350,109 @@ impl Channel {
         if let Some(v) = extensions.remove(syndication::NAMESPACE) {
             channel.syndication_ext = Some(syndication::SyndicationExtension::from_map(v));
         }
+
+        Ok(channel)
+    }
+
+    /// Builds a Channel from an Atom feed
+    #[cfg(feature = "atom")]
+    fn from_atom_feed<R: BufRead>(
+        namespaces: &BTreeMap<String, String>,
+        reader: &mut Reader<R>,
+        atts: Attributes,
+    ) -> Result<Self, Error> {
+        let mut channel = Channel::default();
+        let mut buf = Vec::new();
+        let mut atom_links = Vec::new();
+
+        let namespaces = read_namespace_declarations(reader, atts, namespaces)?;
+
+        loop {
+            match reader.read_event_into(&mut buf)? {
+                Event::Start(element) => match decode(element.name().as_ref(), reader)?.as_ref() {
+                    "title" => {
+                        if let Some(content) = element_text(reader)? {
+                            channel.title = content;
+                        }
+                    }
+                    "subtitle" => {
+                        if let Some(content) = element_text(reader)? {
+                            channel.description = content;
+                        }
+                    }
+                    "link" => {
+                        // Parse Atom link element
+                        let mut link = atom::Link::default();
+                        let mut has_rel = false;
+
+                        for attr in element.attributes().with_checks(false).flatten() {
+                            let key = decode(attr.key.as_ref(), reader)?;
+                            let value = crate::util::attr_value(&attr, reader)?;
+
+                            match key.as_ref() {
+                                "href" => link.href = value.to_string(),
+                                "rel" => {
+                                    link.rel = value.to_string();
+                                    has_rel = true;
+                                }
+                                "type" => link.mime_type = Some(value.to_string()),
+                                "hreflang" => link.hreflang = Some(value.to_string()),
+                                "title" => link.title = Some(value.to_string()),
+                                "length" => link.length = Some(value.to_string()),
+                                _ => {}
+                            }
+                        }
+
+                        // RFC 4287: If rel is not present, default to "alternate"
+                        if !has_rel {
+                            link.rel = "alternate".to_string();
+                        }
+
+                        // Set channel.link to the first alternate link
+                        if channel.link.is_empty() && link.rel == "alternate" {
+                            channel.link = link.href.clone();
+                        }
+
+                        atom_links.push(link);
+                        skip(element.name(), reader)?;
+                    }
+                    "updated" => {
+                        channel.last_build_date = element_text(reader)?;
+                    }
+                    "generator" => {
+                        channel.generator = element_text(reader)?;
+                    }
+                    "entry" => {
+                        let item = Item::from_atom_entry(namespaces.as_ref(), reader, element.attributes())?;
+                        channel.items.push(item);
+                    }
+                    "id" => {
+                        // RFC 4287: id is required for atom:feed
+                        // We skip it since RSS Channel doesn't have a direct equivalent
+                        skip(element.name(), reader)?;
+                    }
+                    "icon" | "logo" | "rights" | "author" | "contributor" | "category" => {
+                        // Skip optional elements we don't currently map
+                        skip(element.name(), reader)?;
+                    }
+                    _ => {
+                        skip(element.name(), reader)?;
+                    }
+                },
+                Event::End(_) => break,
+                Event::Eof => return Err(Error::Eof),
+                _ => {}
+            }
+
+            buf.clear();
+        }
+
+        // Set the Atom extension with the links
+        if !atom_links.is_empty() {
+            channel.atom_ext = Some(atom::AtomExtension { links: atom_links });
+        }
+
+        channel.namespaces = namespaces.into_owned();
 
         Ok(channel)
     }

--- a/src/item.rs
+++ b/src/item.rs
@@ -695,6 +695,174 @@ impl Item {
 
         Ok(item)
     }
+
+    /// Builds an Item from an Atom entry
+    #[cfg(feature = "atom")]
+    pub fn from_atom_entry<R: BufRead>(
+        namespaces: &BTreeMap<String, String>,
+        reader: &mut Reader<R>,
+        atts: Attributes,
+    ) -> Result<Self, Error> {
+        let mut item = Item::default();
+        let mut buf = Vec::new();
+        let mut atom_links = Vec::new();
+
+        let _namespaces = read_namespace_declarations(reader, atts, namespaces)?;
+
+        loop {
+            match reader.read_event_into(&mut buf)? {
+                Event::Start(element) => match decode(element.name().as_ref(), reader)?.as_ref() {
+                    "title" => {
+                        item.title = element_text(reader)?;
+                    }
+                    "link" => {
+                        // Parse Atom link element
+                        let mut link = atom::Link::default();
+                        let mut has_rel = false;
+
+                        for attr in element.attributes().with_checks(false).flatten() {
+                            let key = decode(attr.key.as_ref(), reader)?;
+                            let value = crate::util::attr_value(&attr, reader)?;
+
+                            match key.as_ref() {
+                                "href" => link.href = value.to_string(),
+                                "rel" => {
+                                    link.rel = value.to_string();
+                                    has_rel = true;
+                                }
+                                "type" => link.mime_type = Some(value.to_string()),
+                                "hreflang" => link.hreflang = Some(value.to_string()),
+                                "title" => link.title = Some(value.to_string()),
+                                "length" => link.length = Some(value.to_string()),
+                                _ => {}
+                            }
+                        }
+
+                        // RFC 4287: If rel is not present, default to "alternate"
+                        if !has_rel {
+                            link.rel = "alternate".to_string();
+                        }
+
+                        // Set item.link to the first alternate link
+                        if item.link.is_none() && link.rel == "alternate" {
+                            item.link = Some(link.href.clone());
+                        }
+
+                        atom_links.push(link);
+                        skip(element.name(), reader)?;
+                    }
+                    "published" => {
+                        // RFC 4287: published is when the entry was first made available
+                        item.pub_date = element_text(reader)?;
+                    }
+                    "updated" => {
+                        // RFC 4287: updated is required for atom:entry
+                        // Use it as pub_date if published is not present
+                        if item.pub_date.is_none() {
+                            item.pub_date = element_text(reader)?;
+                        } else {
+                            skip(element.name(), reader)?;
+                        }
+                    }
+                    "content" => {
+                        // Read content including any HTML tags inside
+                        let mut content = String::new();
+                        let mut buf_inner = Vec::new();
+                        let mut depth = 0i32;
+
+                        loop {
+                            match reader.read_event_into(&mut buf_inner)? {
+                                Event::Start(e) => {
+                                    depth += 1;
+                                    content.push('<');
+                                    content.push_str(&decode(e.name().as_ref(), reader)?);
+                                    for attr in e.attributes().with_checks(false).flatten() {
+                                        content.push(' ');
+                                        content.push_str(&decode(attr.key.as_ref(), reader)?);
+                                        content.push_str("=\"");
+                                        content.push_str(&crate::util::attr_value(&attr, reader)?);
+                                        content.push('"');
+                                    }
+                                    content.push('>');
+                                }
+                                Event::End(e) => {
+                                    if depth == 0 {
+                                        break;
+                                    }
+                                    depth -= 1;
+                                    content.push_str("</");
+                                    content.push_str(&decode(e.name().as_ref(), reader)?);
+                                    content.push('>');
+                                }
+                                Event::Empty(e) => {
+                                    content.push('<');
+                                    content.push_str(&decode(e.name().as_ref(), reader)?);
+                                    for attr in e.attributes().with_checks(false).flatten() {
+                                        content.push(' ');
+                                        content.push_str(&decode(attr.key.as_ref(), reader)?);
+                                        content.push_str("=\"");
+                                        content.push_str(&crate::util::attr_value(&attr, reader)?);
+                                        content.push('"');
+                                    }
+                                    content.push_str("/>");
+                                }
+                                Event::Text(e) => {
+                                    content.push_str(&e.unescape()?);
+                                }
+                                Event::CData(e) => {
+                                    content.push_str(decode(&e, reader)?.as_ref());
+                                }
+                                Event::Eof => return Err(Error::Eof),
+                                _ => {}
+                            }
+                            buf_inner.clear();
+                        }
+
+                        if !content.is_empty() {
+                            item.content = Some(content);
+                        }
+                    }
+                    "summary" => {
+                        // Use summary as description if we don't have content
+                        if item.content.is_none() {
+                            item.description = element_text(reader)?;
+                        } else {
+                            skip(element.name(), reader)?;
+                        }
+                    }
+                    "id" => {
+                        // RFC 4287: id is required for atom:entry
+                        // Map Atom id to RSS guid
+                        if let Some(id_text) = element_text(reader)? {
+                            item.guid = Some(Guid {
+                                value: id_text,
+                                permalink: false,
+                            });
+                        }
+                    }
+                    "author" | "contributor" | "category" | "rights" | "source" => {
+                        // Skip optional elements we don't currently map
+                        skip(element.name(), reader)?;
+                    }
+                    _ => {
+                        skip(element.name(), reader)?;
+                    }
+                },
+                Event::End(_) => break,
+                Event::Eof => return Err(Error::Eof),
+                _ => {}
+            }
+
+            buf.clear();
+        }
+
+        // Set the Atom extension with the links
+        if !atom_links.is_empty() {
+            item.atom_ext = Some(atom::AtomExtension { links: atom_links });
+        }
+
+        Ok(item)
+    }
 }
 
 impl ToXml for Item {

--- a/src/item.rs
+++ b/src/item.rs
@@ -840,7 +840,32 @@ impl Item {
                             });
                         }
                     }
-                    "author" | "contributor" | "category" | "rights" | "source" => {
+                    "author" => {
+                        // RFC 4287: Parse author person construct
+                        let (name, email, _uri) = crate::channel::Channel::parse_atom_person(reader)?;
+
+                        // Format as RSS author: "email (name)" or just email or name
+                        if item.author.is_none() {
+                            item.author = match (email, name) {
+                                (Some(e), Some(n)) => Some(format!("{} ({})", e, n)),
+                                (Some(e), None) => Some(e),
+                                (None, Some(n)) => Some(n),
+                                (None, None) => None,
+                            };
+                        }
+                    }
+                    "contributor" => {
+                        // RFC 4287: Skip contributors for entry (no RSS equivalent)
+                        // Could be added to extensions in the future
+                        skip(element.name(), reader)?;
+                    }
+                    "category" => {
+                        // RFC 4287: Parse category element
+                        let category = crate::channel::Channel::parse_atom_category(reader, &element)?;
+                        item.categories.push(category);
+                        skip(element.name(), reader)?;
+                    }
+                    "rights" | "source" => {
                         // Skip optional elements we don't currently map
                         skip(element.name(), reader)?;
                     }

--- a/tests/data/atom_feed.xml
+++ b/tests/data/atom_feed.xml
@@ -1,0 +1,17 @@
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en">
+<title>XXXX XXXXXXXX</title>
+<subtitle>Subtitle</subtitle>
+<link href="https://blog.example.com/atom.xml" rel="self" type="application/atom+xml"/>
+<link href="https://blog.example.com"/>
+<generator uri="https://www.getzola.org/">Zola</generator>
+<updated>2022-04-01T00:00:00+00:00</updated>
+<id>https://blog.example.com/atom.xml</id>
+<entry xml:lang="en">
+<title>2024 reflections</title>
+<published>2025-04-01T00:00:00+00:00</published>
+<updated>2025-04-01T00:00:00+00:00</updated>
+<link href="https://blog.example.com/2024-reflections/" type="text/html"/>
+<id>https://blog.example.com/2024-reflections/</id>
+<content type="html"><p>Yes its html</p> </content>
+</entry>
+</feed>

--- a/tests/data/atom_spec_compliance.xml
+++ b/tests/data/atom_spec_compliance.xml
@@ -11,7 +11,18 @@
   <link href="http://example.org/feed" rel="self" type="application/atom+xml"/>
   <generator>Test Generator</generator>
 
-  <!-- Entry with published date -->
+  <!-- Author element -->
+  <author>
+    <name>Jane Doe</name>
+    <email>jane@example.org</email>
+    <uri>http://example.org/jane</uri>
+  </author>
+
+  <!-- Category elements -->
+  <category term="technology" scheme="http://example.org/categories" label="Technology"/>
+  <category term="software" label="Software Development"/>
+
+  <!-- Entry with published date, author, and categories -->
   <entry>
     <id>http://example.org/entry1</id>
     <title>Entry with published</title>
@@ -19,6 +30,19 @@
     <published>2025-01-01T12:00:00Z</published>
     <link href="http://example.org/entry1" /><!-- No rel, should default to "alternate" -->
     <summary>Entry with both published and updated</summary>
+
+    <author>
+      <name>John Smith</name>
+      <email>john@example.org</email>
+    </author>
+
+    <category term="news" scheme="http://example.org/categories"/>
+    <category term="announcement"/>
+
+    <contributor>
+      <name>Bob Jones</name>
+      <email>bob@example.org</email>
+    </contributor>
   </entry>
 
   <!-- Entry without published, only updated (required) -->
@@ -28,6 +52,10 @@
     <updated>2025-01-03T00:00:00Z</updated>
     <link href="http://example.org/entry2" rel="alternate"/>
     <content type="html">&lt;p&gt;Content only, no summary&lt;/p&gt;</content>
+
+    <author>
+      <name>Alice Brown</name>
+    </author>
   </entry>
 
   <!-- Entry with explicit alternate links -->
@@ -38,5 +66,8 @@
     <link href="http://example.org/entry3" rel="alternate" type="text/html"/>
     <link href="http://example.org/entry3.pdf" rel="related" type="application/pdf"/>
     <summary>Entry with multiple link relations</summary>
+
+    <category term="tech" label="Technology"/>
+    <category term="tutorial" scheme="http://example.org/types"/>
   </entry>
 </feed>

--- a/tests/data/atom_spec_compliance.xml
+++ b/tests/data/atom_spec_compliance.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <!-- RFC 4287 Required elements -->
+  <id>http://example.org/feed</id>
+  <title>Spec Compliance Test Feed</title>
+  <updated>2025-01-01T00:00:00Z</updated>
+
+  <!-- Optional elements -->
+  <subtitle>Testing RFC 4287 compliance</subtitle>
+  <link href="http://example.org/" /><!-- No rel, should default to "alternate" -->
+  <link href="http://example.org/feed" rel="self" type="application/atom+xml"/>
+  <generator>Test Generator</generator>
+
+  <!-- Entry with published date -->
+  <entry>
+    <id>http://example.org/entry1</id>
+    <title>Entry with published</title>
+    <updated>2025-01-02T00:00:00Z</updated>
+    <published>2025-01-01T12:00:00Z</published>
+    <link href="http://example.org/entry1" /><!-- No rel, should default to "alternate" -->
+    <summary>Entry with both published and updated</summary>
+  </entry>
+
+  <!-- Entry without published, only updated (required) -->
+  <entry>
+    <id>http://example.org/entry2</id>
+    <title>Entry without published</title>
+    <updated>2025-01-03T00:00:00Z</updated>
+    <link href="http://example.org/entry2" rel="alternate"/>
+    <content type="html">&lt;p&gt;Content only, no summary&lt;/p&gt;</content>
+  </entry>
+
+  <!-- Entry with explicit alternate links -->
+  <entry>
+    <id>http://example.org/entry3</id>
+    <title>Entry with multiple links</title>
+    <updated>2025-01-04T00:00:00Z</updated>
+    <link href="http://example.org/entry3" rel="alternate" type="text/html"/>
+    <link href="http://example.org/entry3.pdf" rel="related" type="application/pdf"/>
+    <summary>Entry with multiple link relations</summary>
+  </entry>
+</feed>

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -1068,6 +1068,16 @@ fn read_atom_spec_compliance() {
     assert_eq!(channel.last_build_date(), Some("2025-01-01T00:00:00Z"));
     assert_eq!(channel.generator(), Some("Test Generator"));
 
+    // RFC 4287: Author element parsed as managing_editor
+    assert_eq!(channel.managing_editor(), Some("jane@example.org (Jane Doe)"));
+
+    // RFC 4287: Category elements parsed
+    assert_eq!(channel.categories().len(), 2);
+    assert_eq!(channel.categories()[0].name(), "Technology");
+    assert_eq!(channel.categories()[0].domain(), Some("http://example.org/categories"));
+    assert_eq!(channel.categories()[1].name(), "Software Development");
+    assert_eq!(channel.categories()[1].domain(), None);
+
     // RFC 4287: Link without rel attribute should default to "alternate"
     assert_eq!(channel.link(), "http://example.org/");
     let links = channel.atom_ext().unwrap().links();
@@ -1078,18 +1088,28 @@ fn read_atom_spec_compliance() {
 
     assert_eq!(channel.items().len(), 3);
 
-    // Entry 1: Has both published and updated
+    // Entry 1: Has both published and updated, author, and categories
     let item1 = &channel.items[0];
     assert_eq!(item1.title(), Some("Entry with published"));
     assert_eq!(item1.pub_date(), Some("2025-01-01T12:00:00Z")); // Should use published
     assert_eq!(item1.description(), Some("Entry with both published and updated"));
     assert_eq!(item1.guid().as_ref().map(|g| g.value()), Some("http://example.org/entry1"));
 
+    // RFC 4287: Author element parsed
+    assert_eq!(item1.author(), Some("john@example.org (John Smith)"));
+
+    // RFC 4287: Category elements parsed
+    assert_eq!(item1.categories().len(), 2);
+    assert_eq!(item1.categories()[0].name(), "news");
+    assert_eq!(item1.categories()[0].domain(), Some("http://example.org/categories"));
+    assert_eq!(item1.categories()[1].name(), "announcement");
+    assert_eq!(item1.categories()[1].domain(), None);
+
     // RFC 4287: Link without rel should default to "alternate"
     assert_eq!(item1.link(), Some("http://example.org/entry1"));
     assert_eq!(item1.atom_ext().unwrap().links()[0].rel, "alternate");
 
-    // Entry 2: Only has updated (no published)
+    // Entry 2: Only has updated (no published), author with name only
     let item2 = &channel.items[1];
     assert_eq!(item2.title(), Some("Entry without published"));
     assert_eq!(item2.pub_date(), Some("2025-01-03T00:00:00Z")); // Should use updated
@@ -1098,10 +1118,20 @@ fn read_atom_spec_compliance() {
     assert_eq!(item2.guid().as_ref().map(|g| g.value()), Some("http://example.org/entry2"));
     assert_eq!(item2.link(), Some("http://example.org/entry2"));
 
-    // Entry 3: Multiple links with different rel values
+    // RFC 4287: Author with only name (no email)
+    assert_eq!(item2.author(), Some("Alice Brown"));
+
+    // Entry 3: Multiple links with different rel values and categories
     let item3 = &channel.items[2];
     assert_eq!(item3.title(), Some("Entry with multiple links"));
     assert_eq!(item3.description(), Some("Entry with multiple link relations"));
+
+    // RFC 4287: Category elements with labels and schemes
+    assert_eq!(item3.categories().len(), 2);
+    assert_eq!(item3.categories()[0].name(), "Technology"); // label takes precedence
+    assert_eq!(item3.categories()[0].domain(), None);
+    assert_eq!(item3.categories()[1].name(), "tutorial");
+    assert_eq!(item3.categories()[1].domain(), Some("http://example.org/types"));
 
     let item3_links = item3.atom_ext().unwrap().links();
     assert_eq!(item3_links.len(), 2);

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -999,3 +999,119 @@ fn read_local_namespace_hijack() {
     assert!(channel.dublin_core_ext().is_some());
     assert_eq!(channel.dublin_core_ext().unwrap().creators, vec!["Creator"]);
 }
+
+#[cfg(feature = "atom")]
+#[test]
+fn read_atom_feed() {
+    let input = include_str!("data/atom_feed.xml");
+    let channel = input.parse::<Channel>().expect("failed to parse xml");
+
+    // Verify channel metadata from Atom feed
+    assert_eq!(channel.title(), "XXXX XXXXXXXX");
+    assert_eq!(channel.description(), "Subtitle");
+    assert_eq!(channel.link(), "https://blog.example.com");
+    assert_eq!(channel.generator(), Some("Zola"));
+    assert_eq!(channel.last_build_date(), Some("2022-04-01T00:00:00+00:00"));
+
+    // Verify Atom links were parsed
+    assert_eq!(
+        channel.atom_ext().unwrap().links(),
+        &[
+            rss::extension::atom::Link {
+                href: "https://blog.example.com/atom.xml".into(),
+                rel: "self".into(),
+                mime_type: Some("application/atom+xml".into()),
+                ..Default::default()
+            },
+            rss::extension::atom::Link {
+                href: "https://blog.example.com".into(),
+                rel: "alternate".into(),
+                ..Default::default()
+            },
+        ]
+    );
+
+    // Verify one entry was parsed
+    assert_eq!(channel.items().len(), 1);
+
+    let item = &channel.items[0];
+    assert_eq!(item.title(), Some("2024 reflections"));
+    assert_eq!(item.pub_date(), Some("2025-04-01T00:00:00+00:00"));
+    assert_eq!(item.link(), Some("https://blog.example.com/2024-reflections/"));
+    assert_eq!(item.content(), Some("<p>Yes its html</p> "));
+
+    // Verify item GUID was set from Atom ID
+    assert_eq!(item.guid().as_ref().map(|g| g.value()), Some("https://blog.example.com/2024-reflections/"));
+    assert_eq!(item.guid().as_ref().map(|g| g.is_permalink()), Some(false));
+
+    // Verify item Atom links
+    assert_eq!(
+        item.atom_ext().unwrap().links(),
+        &[rss::extension::atom::Link {
+            href: "https://blog.example.com/2024-reflections/".into(),
+            rel: "alternate".into(),
+            mime_type: Some("text/html".into()),
+            ..Default::default()
+        }]
+    );
+}
+
+#[cfg(feature = "atom")]
+#[test]
+fn read_atom_spec_compliance() {
+    let input = include_str!("data/atom_spec_compliance.xml");
+    let channel = input.parse::<Channel>().expect("failed to parse xml");
+
+    // Verify required feed elements are parsed
+    assert_eq!(channel.title(), "Spec Compliance Test Feed");
+    assert_eq!(channel.description(), "Testing RFC 4287 compliance");
+    assert_eq!(channel.last_build_date(), Some("2025-01-01T00:00:00Z"));
+    assert_eq!(channel.generator(), Some("Test Generator"));
+
+    // RFC 4287: Link without rel attribute should default to "alternate"
+    assert_eq!(channel.link(), "http://example.org/");
+    let links = channel.atom_ext().unwrap().links();
+    assert_eq!(links[0].rel, "alternate"); // No rel in XML, should default
+    assert_eq!(links[0].href, "http://example.org/");
+    assert_eq!(links[1].rel, "self");
+    assert_eq!(links[1].href, "http://example.org/feed");
+
+    assert_eq!(channel.items().len(), 3);
+
+    // Entry 1: Has both published and updated
+    let item1 = &channel.items[0];
+    assert_eq!(item1.title(), Some("Entry with published"));
+    assert_eq!(item1.pub_date(), Some("2025-01-01T12:00:00Z")); // Should use published
+    assert_eq!(item1.description(), Some("Entry with both published and updated"));
+    assert_eq!(item1.guid().as_ref().map(|g| g.value()), Some("http://example.org/entry1"));
+
+    // RFC 4287: Link without rel should default to "alternate"
+    assert_eq!(item1.link(), Some("http://example.org/entry1"));
+    assert_eq!(item1.atom_ext().unwrap().links()[0].rel, "alternate");
+
+    // Entry 2: Only has updated (no published)
+    let item2 = &channel.items[1];
+    assert_eq!(item2.title(), Some("Entry without published"));
+    assert_eq!(item2.pub_date(), Some("2025-01-03T00:00:00Z")); // Should use updated
+    assert_eq!(item2.content(), Some("<p>Content only, no summary</p>"));
+    assert_eq!(item2.description(), None); // No summary, content only
+    assert_eq!(item2.guid().as_ref().map(|g| g.value()), Some("http://example.org/entry2"));
+    assert_eq!(item2.link(), Some("http://example.org/entry2"));
+
+    // Entry 3: Multiple links with different rel values
+    let item3 = &channel.items[2];
+    assert_eq!(item3.title(), Some("Entry with multiple links"));
+    assert_eq!(item3.description(), Some("Entry with multiple link relations"));
+
+    let item3_links = item3.atom_ext().unwrap().links();
+    assert_eq!(item3_links.len(), 2);
+    assert_eq!(item3_links[0].rel, "alternate");
+    assert_eq!(item3_links[0].href, "http://example.org/entry3");
+    assert_eq!(item3_links[0].mime_type, Some("text/html".to_string()));
+    assert_eq!(item3_links[1].rel, "related");
+    assert_eq!(item3_links[1].href, "http://example.org/entry3.pdf");
+    assert_eq!(item3_links[1].mime_type, Some("application/pdf".to_string()));
+
+    // The first alternate link should be used for item.link
+    assert_eq!(item3.link(), Some("http://example.org/entry3"));
+}


### PR DESCRIPTION
Adding atom parsing

# Atom Feed Parser RFC 4287 Compliance

This document describes how the RSS crate's Atom feed parser complies with RFC 4287 (The Atom Syndication Format).

## Overview

The crate now supports parsing standalone Atom feeds (with `<feed>` as the root element) when the `atom` feature is enabled. The parser converts Atom elements to RSS Channel and Item structures with appropriate mappings.

## RFC 4287 Required Elements

### atom:feed (Channel)

**Required elements:**
- ✅ `<id>` - Acknowledged and skipped (RSS has no direct equivalent)
- ✅ `<title>` - Mapped to `channel.title`
- ✅ `<updated>` - Mapped to `channel.last_build_date`

**Recommended/Optional elements:**
- ✅ `<subtitle>` - Mapped to `channel.description`
- ✅ `<link>` - Parsed with all attributes, stored in `channel.atom_ext`
- ✅ `<generator>` - Mapped to `channel.generator`
- ✅ `<author>` - Mapped to `channel.managing_editor` as "email (name)"
- ✅ `<category>` - Mapped to `channel.categories[]` (term/label → name, scheme → domain)
- ✅ `<contributor>` - Acknowledged and skipped (no RSS equivalent)
- ⚠️  `<icon>` - Skipped (no RSS equivalent)
- ⚠️  `<logo>` - Skipped (no RSS equivalent)
- ⚠️  `<rights>` - Skipped (future enhancement)

### atom:entry (Item)

**Required elements:**
- ✅ `<id>` - Mapped to `item.guid` with `permalink=false`
- ✅ `<title>` - Mapped to `item.title`
- ✅ `<updated>` - Used as `item.pub_date` if `<published>` is not present

**Recommended/Optional elements:**
- ✅ `<link>` - Parsed with all attributes, stored in `item.atom_ext`
- ✅ `<published>` - Mapped to `item.pub_date` (takes precedence over `<updated>`)
- ✅ `<content>` - Mapped to `item.content` with full HTML preservation
- ✅ `<summary>` - Mapped to `item.description` (if `<content>` is not present)
- ✅ `<author>` - Mapped to `item.author` as "email (name)"
- ✅ `<category>` - Mapped to `item.categories[]` (term/label → name, scheme → domain)
- ✅ `<contributor>` - Acknowledged and skipped (no RSS equivalent)
- ⚠️  `<rights>` - Skipped (future enhancement)
- ⚠️  `<source>` - Skipped (future enhancement)

## RFC 4287 Person Construct (Author/Contributor)

### Author Mapping

Atom `<author>` elements are parsed from their person construct format:
```xml
<author>
  <name>John Doe</name>
  <email>john@example.com</email>
  <uri>http://example.com</uri>
</author>
```

And formatted for RSS as:
- **Feed level**: First `<author>` → `channel.managing_editor` as "email (name)"
- **Entry level**: First `<author>` → `item.author` as "email (name)"

Formatting logic:
- If both email and name: `"email (name)"`
- If only email: `"email"`
- If only name: `"name"`

### Contributor Handling

`<contributor>` elements are acknowledged and properly skipped during parsing, as RSS has no direct equivalent. These could be added to a future extension.

## RFC 4287 Category Element

Atom categories are mapped to RSS categories:

```xml
<category term="technology" scheme="http://example.org/cats" label="Technology"/>
```

Mapping:
- `label` (or `term` if no label) → RSS `category.name`
- `scheme` → RSS `category.domain`

The `label` attribute takes precedence over `term` for the category name, as it's intended to be human-readable.

## RFC 4287 Link Element Compliance

### Link Relation Default (Section 4.2.7.2)

✅ **Compliant**: Per RFC 4287, "if the rel attribute is not present, the link element MUST be interpreted as if the link relation type is 'alternate'."

Implementation:
```rust
// If rel is not present, default to "alternate"
if !has_rel {
    link.rel = "alternate".to_string();
}
```

### Link Attributes

All Atom link attributes are properly parsed and preserved:
- ✅ `href` (required) - The link URI
- ✅ `rel` (defaults to "alternate") - The link relationship type
- ✅ `type` - The media type hint
- ✅ `hreflang` - The language of the resource
- ✅ `title` - Human-readable link title
- ✅ `length` - Advisory length of the content

## Element Mapping Strategy

### Channel Link Selection

The first link with `rel="alternate"` (or with no `rel` attribute) is used as the primary `channel.link`. All links are preserved in `channel.atom_ext.links`.

### Item Link Selection

The first link with `rel="alternate"` (or with no `rel` attribute) is used as the primary `item.link`. All links are preserved in `item.atom_ext.links`.

### Date Mapping

- **Feed level**: `<updated>` → `channel.last_build_date`
- **Entry level**:
  - If `<published>` exists: `<published>` → `item.pub_date`
  - If only `<updated>` exists: `<updated>` → `item.pub_date`

This follows the semantic difference where `<published>` is the initial publication date and `<updated>` is the last modification date.

### Content Handling

Atom `<content>` elements are parsed with full HTML preservation, including nested tags and attributes. This ensures that HTML content in Atom feeds is correctly converted to RSS `<content:encoded>` format.

## Testing

Comprehensive test coverage is provided in `tests/read.rs`:

1. **read_atom_feed**: Basic Atom feed parsing
2. **read_atom_spec_compliance**: RFC 4287 compliance verification including:
   - Link `rel` attribute defaulting to "alternate"
   - Required elements handling
   - Author person constructs (with and without email)
   - Category elements (with term, label, and scheme attributes)
   - Contributor elements (properly skipped)
   - Multiple links with different relations
   - Entry with only `<updated>` (no `<published>`)
   - HTML content preservation

Test data files:
- `tests/data/atom_feed.xml` - Real-world Atom feed example
- `tests/data/atom_spec_compliance.xml` - RFC 4287 compliance test cases

## Limitations and Future Enhancements

The following optional elements are not currently mapped but could be added in future versions:

1. **Rights**: Could be mapped to RSS `<copyright>`
2. **Source**: Could be mapped to RSS `<source>` element
3. **Icon/Logo**: No RSS equivalent, could be added to extensions
4. **Multiple Authors**: Currently only the first author is used; additional authors could be stored in extensions

These limitations do not affect RFC 4287 compliance since these are optional elements, and the parser correctly handles (skips) them without errors.

## References

- RFC 4287: The Atom Syndication Format
  https://www.rfc-editor.org/rfc/rfc4287
