### PR TITLE
chore(ci): update GitHub Actions versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           - stable
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -6,12 +6,12 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo clippy --all --all-features
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo fmt --all -- --check

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
       image: xd009642/tarpaulin:develop-nightly
       options: --security-opt seccomp=unconfined
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Measure coverage
       run: |
         cargo +nightly tarpaulin \
@@ -26,4 +26,6 @@ jobs:
           -- \
           --test-threads=1
     - name: Upload coverage report to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v6
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,5 +27,3 @@ jobs:
           --test-threads=1
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v6
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,19 +8,21 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Generate docs
         run: cargo doc --features "validation serde"
 
       - name: Deploy documentation 🚀
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
-          BRANCH: gh-pages
-          FOLDER: target/doc
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          folder: target/doc

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build status](https://github.com/rust-syndication/rss/workflows/Build/badge.svg)](https://github.com/rust-syndication/rss/actions?query=branch%3Amaster)
 [![Codecov](https://codecov.io/gh/rust-syndication/rss/branch/master/graph/badge.svg)](https://codecov.io/gh/rust-syndication/rss)
 [![crates.io Status](https://img.shields.io/crates/v/rss.svg)](https://crates.io/crates/rss)
+[![dependency status](https://deps.rs/crate/rss/latest/status.svg)](https://deps.rs/crate/rss/latest)
 [![Docs](https://docs.rs/rss/badge.svg)](https://docs.rs/rss)
 
 Library for deserializing and serializing the RSS web content syndication format.


### PR DESCRIPTION
## Why

- Recent workflow runs warn that several actions are still running on Node.js 20, which GitHub will force-upgrade to Node.js 24 on June 2, 2026 and remove from runners on September 16, 2026.
- The README can also expose the crate dependency status next to the existing status badges.

## What

- Update `actions/checkout` from v3 to v6 across workflows.
- Update the docs deployment action from `JamesIves/github-pages-deploy-action@releases/v3` to v4 and switch to the current input names.
- Update `codecov/codecov-action` from v3 to v6.
- Add the deps.rs dependency status badge to the README.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/workflows/*.yml`
- `actionlint`
