### PR TITLE
Bump quick-xml to 0.41

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ validation = ["chrono", "chrono/std", "url", "mime"]
 with-serde = ["serde", "atom_syndication/with-serde"]
 
 [dependencies]
-quick-xml = { version = "0.39", features = ["encoding"] }
+quick-xml = { version = "0.41", features = ["encoding"] }
 atom_syndication = { version = "0.12.8", optional = true }
 chrono = { version = "0.4.31", optional = true, default-features = false, features = ["alloc"] }
 derive_builder = { version = "0.20", optional = true }


### PR DESCRIPTION
## Bump quick-xml to 0.41

quick-xml `< 0.41` is affected by two RustSec advisories (both DoS on crafted XML,
reachable through RSS/atom parsing):

- **RUSTSEC-2026-0194** — `O(N²)` duplicate-attribute check in `BytesStart::attributes()`
- **RUSTSEC-2026-0195** — unbounded namespace-declaration allocation in `NsReader`

Both are fixed in quick-xml `>= 0.41.0`.

### Change

Raise the `quick-xml` dependency from `0.39` to `0.41` (keeping `features = ["encoding"]`).

The public quick-xml API used by this crate is unchanged across `0.39 → 0.41`
(`Reader`, `Writer`, `events::*`, `Attributes`, `escape::resolve_predefined_entity`) —
the crate uses the plain `Reader`, not `NsReader`, and wraps quick-xml errors rather than
matching the enum exhaustively. The full `--all-features` test suite passes unmodified.

`Attribute::decode_and_unescape_value` is deprecated in 0.40 in favour of
`decoded_and_normalized_value` but retains identical behaviour, so it's left as-is here
to keep this change minimal.

### Note on `atom_syndication`

With the `atom` feature enabled, this crate depends on `atom_syndication`, which still
pins quick-xml `^0.39`. A companion PR raising `atom_syndication` to quick-xml 0.41 is
open at rust-syndication/atom#96; merging/releasing that first avoids a transient
quick-xml version split for `rss` builds using the `atom` feature.
