### PR TITLE
ci: fail on clippy warnings

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo clippy --all --all-features
+      - run: cargo clippy --all --all-features -- -D warnings
   fmt:
     runs-on: ubuntu-latest
     steps:

--- a/src/util.rs
+++ b/src/util.rs
@@ -13,6 +13,7 @@ use quick_xml::events::attributes::Attribute;
 use quick_xml::events::Event;
 use quick_xml::name::QName;
 use quick_xml::Reader;
+use quick_xml::XmlVersion;
 
 use crate::error::Error;
 
@@ -28,7 +29,7 @@ pub(crate) fn attr_value<'s, B: BufRead>(
     attr: &'s Attribute<'s>,
     reader: &Reader<B>,
 ) -> Result<Cow<'s, str>, Error> {
-    let value = attr.decode_and_unescape_value(reader.decoder())?;
+    let value = attr.decoded_and_normalized_value(XmlVersion::Implicit1_0, reader.decoder())?;
     Ok(value)
 }
 


### PR DESCRIPTION
## Why

Dependency updates can surface warnings that are easy to miss during review.

## What

- Make the clippy job fail on warnings.
- Replace the deprecated quick-xml attribute value API with the normalized API.

## Evidence

The commits keep the CI gate and warning fix separate.

- 04896bb0959670774aace588f86c740c45fbe262: only updates the clippy command; the existing quick-xml deprecation warning fails the job: [failure](https://github.com/rust-syndication/rss/actions/runs/28605327405/job/84823940239).
- fb7f4a90afd6d51368c7f560c64d67a4b0689127: updates the attribute API; the same clippy job passes: [success](https://github.com/rust-syndication/rss/actions/runs/28605484204/job/84824482832).
