### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 2.0.14 - 2026-07-03
+## 2.1.0 - 2026-07-03
 
 - Update `quick-xml` to 0.41. [`#190`](https://github.com/rust-syndication/rss/pull/190)
 - Fail clippy on warnings and migrate to the normalized quick-xml attribute API. [`#191`](https://github.com/rust-syndication/rss/pull/191)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Update `quick-xml` to 0.41. [`#190`](https://github.com/rust-syndication/rss/pull/190)
 - Fail clippy on warnings and migrate to the normalized quick-xml attribute API. [`#191`](https://github.com/rust-syndication/rss/pull/191)
+- Note: `quick-xml` 0.41 raises the effective minimum Rust version to 1.79.
 
 ## 2.0.13 - 2026-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 2.0.14 - 2026-07-03
+
+- Update `quick-xml` to 0.41. [`#190`](https://github.com/rust-syndication/rss/pull/190)
+- Fail clippy on warnings and migrate to the normalized quick-xml attribute API. [`#191`](https://github.com/rust-syndication/rss/pull/191)
+
 ## 2.0.13 - 2026-05-10
 
 - Update `quick-xml` to 0.39. [`#186`](https://github.com/rust-syndication/rss/pull/186)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rss"
-version = "2.0.14"
+version = "2.1.0"
 authors = ["James Hurst <jh.jameshurst@gmail.com>", "Corey Farwell <coreyf@rwell.org>", "Chris Palmer <pennstate5013@gmail.com>"]
 description = "Library for serializing the RSS web content syndication format"
 repository = "https://github.com/rust-syndication/rss"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ with-serde = ["serde", "atom_syndication/with-serde"]
 
 [dependencies]
 quick-xml = { version = "0.41", features = ["encoding"] }
-atom_syndication = { version = "0.12.8", optional = true }
+atom_syndication = { version = "0.12.9", optional = true }
 chrono = { version = "0.4.31", optional = true, default-features = false, features = ["alloc"] }
 derive_builder = { version = "0.20", optional = true }
 mime = { version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rss"
-version = "2.0.13"
+version = "2.0.14"
 authors = ["James Hurst <jh.jameshurst@gmail.com>", "Corey Farwell <coreyf@rwell.org>", "Chris Palmer <pennstate5013@gmail.com>"]
 description = "Library for serializing the RSS web content syndication format"
 repository = "https://github.com/rust-syndication/rss"


### PR DESCRIPTION
## Why

Prepare the next rss crate release after the quick-xml 0.41 update and clippy warning gate changes.

## What

- Bump the crate version to 2.1.0.
- Add the 2.1.0 changelog entry, including the effective MSRV impact from quick-xml 0.41.

## Release readiness

- `cargo semver-checks check-release --baseline-version 2.0.13` reports no required semver update.
- `cargo publish --dry-run` packages and verifies rss 2.1.0 successfully.
