### PR TITLE
chore: release rss 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2.1.1 - 2026-09-06
+
+- Fix image height validation to accept values up to the RSS 2.0 limit of 400 pixels. [`#194`](https://github.com/rust-syndication/rss/pull/194)
+
 ## 2.1.0 - 2026-07-03
 
 - Update `quick-xml` to 0.41. [`#190`](https://github.com/rust-syndication/rss/pull/190)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rss"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["James Hurst <jh.jameshurst@gmail.com>", "Corey Farwell <coreyf@rwell.org>", "Chris Palmer <pennstate5013@gmail.com>"]
 description = "Library for serializing the RSS web content syndication format"
 repository = "https://github.com/rust-syndication/rss"


### PR DESCRIPTION
## Why

Prepare a patch release for the image height validation fix.

## What

- Bump the crate version to 2.1.1.
- Add the changelog entry for accepting image heights up to the RSS 2.0 limit of 400 pixels.
