### PR TITLE
Escape namespace URIs when writing a channel

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1131,7 +1131,9 @@ impl Channel {
         namespaces.extend(&used_namespaces);
         namespaces.extend(&self.namespaces);
         for (name, url) in namespaces {
-            element.push_attribute((format!("xmlns:{}", name).as_bytes(), url.as_bytes()));
+            // The byte-slice form of `push_attribute` writes the value verbatim, so use the
+            // string form, which escapes the namespace URI.
+            element.push_attribute((format!("xmlns:{}", name).as_str(), url.as_str()));
         }
 
         writer.write_event(Event::Start(element))?;

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -214,6 +214,33 @@ fn test_namespaces() {
 }
 
 #[test]
+fn test_escape_namespace() {
+    let input = r#"<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:ex="http://example.com/ns?a=1&amp;b=2">
+    <channel>
+        <title>Title</title>
+        <link>http://example.com/</link>
+        <description>Description</description>
+    </channel>
+</rss>"#;
+
+    let channel = input.parse::<Channel>().expect("failed to parse xml");
+    assert_eq!(
+        channel.namespaces().get("ex").map(String::as_str),
+        Some("http://example.com/ns?a=1&b=2")
+    );
+
+    let xml = channel.to_string();
+    assert!(
+        xml.contains(r#"xmlns:ex="http://example.com/ns?a=1&amp;b=2""#),
+        "namespace URI was not escaped exactly once: {}",
+        xml
+    );
+
+    test_write!(channel);
+}
+
+#[test]
 fn test_escape() {
     let mut channel = ChannelBuilder::default()
         .image(


### PR DESCRIPTION
## Problem

`Channel::to_string` / `Channel::write_to` emit a malformed `xmlns:` attribute whenever a namespace URI contains an XML special character, producing output that `Channel::read_from` can no longer parse. Query strings in namespace URIs are the common way to hit this:

```
parsed namespaces: {"ex": "http://example.com/ns?a=1&b=2"}
written: <?xml version="1.0" encoding="utf-8"?><rss version="2.0" xmlns:ex="http://example.com/ns?a=1&b=2" ...
re-read failed: Error while escaping character at range 25..29: Cannot find ';' after '&'
```

So a feed that round-trips through this crate comes out unparseable, including by this crate itself.

## Cause

`src/channel.rs:1134` is the only `push_attribute` call site in the crate that uses the byte-slice form:

```rust
element.push_attribute((format!("xmlns:{}", name).as_bytes(), url.as_bytes()));
```

quick-xml documents the two forms differently: the `(&[u8], &[u8])` overload "does not apply any transformation to both key and value", while the `(&str, &str)` overload escapes the value. Of the 19 `push_attribute` call sites here, 18 use the escaping string form -- including `element.push_attribute(("version", "2.0"))` two lines above at `src/channel.rs:1127`, and every attribute in `src/category.rs:130`, `src/cloud.rs:238`, `src/enclosure.rs:164`, `src/source.rs:129`, `src/guid.rs:140` and `src/extension/atom.rs`.

This one looks like an oversight rather than a decision: commit 68be4a6 "Escape text in enclosure, source, categories, and extensions" (#121) swept `src/category.rs`, `src/extension/mod.rs`, `src/source.rs` and `tests/write.rs`, but never touched `src/channel.rs`. The existing `test_escape` (`tests/write.rs:217`) covers image, category, cloud and guid, but no namespace.

## Verification

- `cargo test --all-features --no-fail-fast --all`: all green (7 / 25 / 1 / 24 / 193 passed, 5 ignored).
- Reverting only the source change makes the new `test_escape_namespace` fail: `namespace URI was not escaped exactly once: ...xmlns:ex="http://example.com/ns?a=1&b=2"...`
- Over-correcting the other way (pre-escaping `&` before handing the value to the escaping form) also fails it, this time on `...a=1&amp;amp;b=2`. The single assertion pins both under- and double-escaping because it compares against the exact expected string. Measured with two separate temporary probes, the under- and over-escaping failure sets are disjoint.
- Gates from `.github/workflows/`: `cargo clippy --all --all-features -- -D warnings` clean, `cargo fmt --all -- --check` clean.

(`cargo clippy --all-targets` reports 47 pre-existing `get(0)` lints in `tests/read.rs`. They are present at baseline and CI does not pass `--all-targets`, so this PR leaves them alone.)

## Prior art

Searched open and closed issues and PRs for namespace and `xmlns` escaping; nothing covers this. The neighbouring escaping fixes are all closed and all about other fields: #32, #98, #119, #120, #121, #167, #170, #173, #174.

---

Disclosure: this change was prepared with AI assistance. I reproduced the failure through the public API, verified the history and every gate locally, and will handle review feedback myself.
