### PR TITLE
chore: release rss 2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2.1.2 - 2026-09-10
+
+- Escape XML special characters in namespace URIs when writing channels. [`#196`](https://github.com/rust-syndication/rss/pull/196)
+
 ## 2.1.1 - 2026-09-06
 
 - Fix image height validation to accept values up to the RSS 2.0 limit of 400 pixels. [`#194`](https://github.com/rust-syndication/rss/pull/194)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rss"
-version = "2.1.1"
+version = "2.1.2"
 authors = ["James Hurst <jh.jameshurst@gmail.com>", "Corey Farwell <coreyf@rwell.org>", "Chris Palmer <pennstate5013@gmail.com>"]
 description = "Library for serializing the RSS web content syndication format"
 repository = "https://github.com/rust-syndication/rss"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,41 @@
+# Releasing
+
+This project follows [Semantic Versioning](https://semver.org/):
+
+- Use a patch release for backward-compatible bug fixes.
+- Use a minor release for backward-compatible public API additions. Treat an
+  increased minimum supported Rust version as a minor release.
+- Use a major release for incompatible public API changes.
+
+## Prepare the release
+
+1. Start a `release/X.Y.Z` branch from the latest `master`.
+2. Update the package version in `Cargo.toml`.
+3. Add a dated `X.Y.Z` section below `Unreleased` in `CHANGELOG.md`. Include all
+   user-visible changes since the previous release and link their pull requests.
+4. Commit only the version and release documentation changes with the subject
+   `chore: release rss X.Y.Z`.
+5. Run the release checks from a clean worktree:
+
+   ```console
+   cargo test --all-features --no-fail-fast --all
+   cargo publish --dry-run
+   ```
+
+6. Open a pull request and wait for its CI checks to pass. Keep it as a draft
+   until the intended release contents and version are settled.
+
+## Publish the release
+
+1. Merge the release pull request.
+2. Check out the updated `master` and confirm that `Cargo.toml` and
+   `CHANGELOG.md` contain the intended version.
+3. Run `cargo publish --dry-run` once more from the clean release commit, then
+   publish it with `cargo publish`.
+4. Create a GitHub release and tag named `X.Y.Z` for the same commit. Use the
+   changelog entry as the release notes, or generate equivalent notes on GitHub.
+5. Confirm that the version is available on crates.io and that the GitHub tag
+   points to the published commit.
+
+Published crate versions cannot be overwritten, so resolve any version,
+packaging, or CI problem before running `cargo publish`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -32,10 +32,23 @@ This project follows [Semantic Versioning](https://semver.org/):
    `CHANGELOG.md` contain the intended version.
 3. Run `cargo publish --dry-run` once more from the clean release commit, then
    publish it with `cargo publish`.
-4. Create a GitHub release and tag named `X.Y.Z` for the same commit. Use the
-   changelog entry as the release notes, or generate equivalent notes on GitHub.
-5. Confirm that the version is available on crates.io and that the GitHub tag
-   points to the published commit.
+4. Create the GitHub release with automatically generated notes. Pass the full
+   release commit SHA so the new tag cannot accidentally point to a later
+   `master` commit:
+
+   ```console
+   gh release create X.Y.Z \
+     --repo rust-syndication/rss \
+     --target RELEASE_COMMIT_SHA \
+     --title X.Y.Z \
+     --generate-notes \
+     --fail-on-no-commits
+   ```
+
+   If the tag does not exist, this command creates it at `RELEASE_COMMIT_SHA`.
+5. Confirm that the version is available on crates.io. Run
+   `gh release view X.Y.Z --repo rust-syndication/rss` and confirm that the
+   GitHub release and tag point to the published commit.
 
 Published crate versions cannot be overwritten, so resolve any version,
 packaging, or CI problem before running `cargo publish`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,7 +10,7 @@ This project follows [Semantic Versioning](https://semver.org/):
 ## Prepare the release
 
 1. Start a `release/X.Y.Z` branch from the latest `master`.
-2. Update the package version in `Cargo.toml`.
+2. Update the package version with `cargo set-version X.Y.Z`.
 3. Add a dated `X.Y.Z` section below `Unreleased` in `CHANGELOG.md`. Include all
    user-visible changes since the previous release and link their pull requests.
 4. Commit only the version and release documentation changes with the subject


### PR DESCRIPTION
## Why

Prepare a patch release for the namespace URI escaping fix and document a lightweight release process that prevents common publishing mistakes.

## What

- Bump the crate version to 2.1.2 with `cargo set-version` and add the changelog entry for #196.
- Add a concise release guide covering version selection, release checks, publishing, tagging, and post-release verification.

## Release readiness

- `cargo publish --dry-run` packages and verifies rss 2.1.2 successfully.
